### PR TITLE
Better analyzing for values of booleans in simplify_cfg

### DIFF
--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -50,10 +50,12 @@ Figure out whether boolean variables are true or false.
 return_value[block_index][variable_index] = status of variable at END of block
 variable_index must be so that the variable has type bool.
 
-Idea: Initially mark everything as impossible, so no variable can be true or false
-anywhere, except arguments which can be anything. Loop through instructions of
-start block, marking other possibilities. Repeat for blocks where execution jumps,
-unless we got same result as last time, then jumped blocks are unaffected.
+Idea: Initially mark everything as possible, so all variables can be true or false.
+Loop through instructions of start block, filtering out impossible options: for
+example, if a variable is set to True, then it can be True and cannot be False.
+Repeat for blocks where execution jumps from the current block, unless we got same
+result as last time, then we know that we don't have to reanalyze blocks where
+execution jumps from the current block.
 */
 static struct BoolStatus **determine_known_bool_values(const struct CfGraph *cfg)
 {

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -91,8 +91,8 @@ static struct BoolStatus **determine_known_bool_values(const struct CfGraph *cfg
             }
         }
         for (int i = 0; i < nblocks; i++) {
-            if (cfg->all_blocks.ptr[i]->iftrue == cfg->all_blocks.ptr[visiting]
-                || cfg->all_blocks.ptr[i]->iffalse == cfg->all_blocks.ptr[visiting])
+            if (cfg->all_blocks.ptr[i]->iftrue == visitingblock
+                || cfg->all_blocks.ptr[i]->iffalse == visitingblock)
             {
                 // TODO: If we only get here from the true jump, or only from false
                 // jump, we could assume that the variable used in the jump was true/false.

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -124,7 +124,7 @@ static struct BoolStatus **determine_known_bool_values(const struct CfGraph *cfg
 
         // Figure out how each instruction affects booleans.
         for (const struct CfInstruction *ins = visitingblock->instructions.ptr; ins < End(visitingblock->instructions); ins++) {
-            if (ins->destvar->type.kind != TYPE_BOOL || !ins->destvar->analyzable)
+            if (!ins->destvar || !ins->destvar->analyzable || ins->destvar->type.kind != TYPE_BOOL)
                 continue;
 
             int destidx = find_var_index(cfg, ins->destvar);

--- a/tests/should_succeed/unreachable_warning.jou
+++ b/tests/should_succeed/unreachable_warning.jou
@@ -10,6 +10,18 @@ def after_infinite_loop() -> void:
         puts("hi")
     puts("yooooo wat")  # Warning: this code will never run
 
+def after_infinite_loop_with_variable() -> void:
+    flag = True
+    while flag:
+        puts("hi")
+    puts("yooooo wat")  # Warning: this code will never run
+
+def after_infinite_loop_with_variable_set_after_loop() -> void:
+    flag = True
+    while flag:
+        puts("hi")
+    flag = False  # Warning: this code will never run
+
 def main() -> int:
     after_return()
     # Can't run infinite loops (test script redirects output to file)

--- a/tests/should_succeed/unreachable_warning.jou
+++ b/tests/should_succeed/unreachable_warning.jou
@@ -16,11 +16,12 @@ def after_infinite_loop_with_variable() -> void:
         puts("hi")
     puts("yooooo wat")  # Warning: this code will never run
 
+# TODO: this does not emit a warning, although it should
 def after_infinite_loop_with_variable_set_after_loop() -> void:
     flag = True
     while flag:
         puts("hi")
-    flag = False  # Warning: this code will never run
+    flag = False
 
 def main() -> int:
     after_return()


### PR DESCRIPTION
Fixes half of #15. The other half requires something to get rid of unnecessary address-ofs: if a variable named `flag` already exists, then `flag = False` becomes `*(&flag) = False` in the CFG, and `simplify_cfg` avoids touching variables whose address is used somewhere.