### PR TITLE
Add a warning for attempting to use undefined variables

### DIFF
--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -300,6 +300,7 @@ Most of these take the data for an entire program.
 void print_token(const struct Token *token);
 void print_tokens(const struct Token *tokenlist);
 void print_ast(const struct AstToplevelNode *topnodelist);
+void print_control_flow_graph(const struct CfGraph *cfg);
 void print_control_flow_graphs(const struct CfGraphFile *cfgfile);
 void print_llvm_ir(LLVMModuleRef module);
 

--- a/src/print.c
+++ b/src/print.c
@@ -356,7 +356,7 @@ static void print_cf_instruction(const struct CfInstruction *ins, int indent)
     printf("\n");
 }
 
-static void print_cf_graph(const struct CfGraph *cfg, int indent)
+static void print_control_flow_graph_with_indent(const struct CfGraph *cfg, int indent)
 {
     if (!cfg) {
         printf("%*sControl Flow Graph = NULL\n", indent, "");
@@ -403,6 +403,11 @@ static void print_cf_graph(const struct CfGraph *cfg, int indent)
     }
 }
 
+void print_control_flow_graph(const struct CfGraph *cfg)
+{
+    print_control_flow_graph_with_indent(cfg, 0);
+}
+
 void print_control_flow_graphs(const struct CfGraphFile *cfgfile)
 {
     printf("===== Control Flow Graphs for file \"%s\" =====\n", cfgfile->filename);
@@ -410,7 +415,7 @@ void print_control_flow_graphs(const struct CfGraphFile *cfgfile)
         char *sigstr = signature_to_string(&cfgfile->signatures[i], true);
         printf("Function on line %d: %s\n", cfgfile->signatures[i].location.lineno, sigstr);
         free(sigstr);
-        print_cf_graph(cfgfile->graphs[i], 2);
+        print_control_flow_graph_with_indent(cfgfile->graphs[i], 2);
         printf("\n");
     }
 }

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -26,7 +26,7 @@ enum VarStatus {
     VS_UNDEFINED,  // No value has been set to the variable. Holds a garbage value.
     VS_UNPREDICTABLE,  // Address of variable (&foo) has been used. Give up analzing it.
     /*
-    Longer explanation of VS_UNPREDICTABLE: The value of an unpredictable variable can
+    Longer description of VS_UNPREDICTABLE: The value of an unpredictable variable can
     change in lines of code that seem to have nothing to do with the variable. For
     example, a function that doesn't take &foo as an argument can change the value of foo,
     because the pointer &foo can be stored in some place that the function can access.

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -86,6 +86,9 @@ static bool merge_arrays_in_place(enum VarStatus *dest, const enum VarStatus *sr
 // Figure out how an instruction affects variables when it runs.
 static void update_statuses_with_instruction(const struct CfGraph *cfg, enum VarStatus *statuses, const struct CfInstruction *ins)
 {
+    for (int i = 0; i < cfg->variables.len; i++)
+        assert(statuses[i] != VS_UNVISITED);
+
     if (!ins->destvar)
         return;
 
@@ -96,10 +99,9 @@ static void update_statuses_with_instruction(const struct CfGraph *cfg, enum Var
     switch(ins->kind) {
     case CF_VARCPY:
         statuses[destidx] = statuses[find_var_index(cfg, ins->operands[0])];
-        assert(statuses[destidx] != VS_UNVISITED);
         if (statuses[destidx] == VS_UNPREDICTABLE) {
             // Assume that unpredictable variables always yield non-garbage values.
-            // Otherwise using functions like fscanf() would be annoying.
+            // Otherwise using functions like scanf() would be annoying.
             statuses[destidx] = VS_DEFINED;
         }
         break;

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -109,7 +109,7 @@ static void update_statuses_with_instruction(const struct CfGraph *cfg, enum Var
     }
 }
 
-#define DebugPrint 0  // change to 1 to see debug prints
+#define DebugPrint 0  // change to 1 to see VarStatuses
 
 #if DebugPrint
 static const char * vs_to_string(enum VarStatus vs)

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -103,15 +103,9 @@ static void update_statuses_with_instruction(const struct CfGraph *cfg, enum Var
             statuses[destidx] = VS_DEFINED;
         }
         break;
-    case CF_TRUE:
-        statuses[destidx] = VS_TRUE;
-        break;
-    case CF_FALSE:
-        statuses[destidx] = VS_FALSE;
-        break;
-    default:
-        statuses[destidx] = VS_DEFINED;
-        break;
+    case CF_TRUE: statuses[destidx] = VS_TRUE; break;
+    case CF_FALSE: statuses[destidx] = VS_FALSE; break;
+    default: statuses[destidx] = VS_DEFINED; break;
     }
 }
 

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -37,6 +37,7 @@ enum VarStatus {
 a and b are statuses from different branches that both jump to the same block.
 Should have these properties:
 
+    merge(a, VS_UNVISITED) == a
     merge(a, a) == a
     merge(a, b) == merge(b, a)
     merge(a, merge(b, c)) == merge(merge(a, b), c)

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -17,47 +17,64 @@ static int find_var_index(const struct CfGraph *cfg, const struct CfVariable *v)
     assert(0);
 }
 
-enum BoolStatus {
-    KNOWN_TO_BE_TRUE,
-    KNOWN_TO_BE_FALSE,
+enum VarStatus {
+    VS_UNVISITED = 0,  // Don't know anything about this variable yet.
+    VS_TRUE,  // This is a boolean variable that is set to True.
+    VS_FALSE,  // This is a boolean variable that is set to False.
+    VS_DEFINED,  // This variable (boolean or other) has been set to some non-garbage value.
+    VS_POSSIBLY_UNDEFINED,  // Could hold a garbage value or a non-garbage value.
+    VS_UNDEFINED,  // No value has been set to the variable. Holds a garbage value.
+    VS_UNPREDICTABLE,  // Address of variable (&foo) has been used. Give up analzing it.
     /*
-    The remaining statuses have different meanings:
-    - CAN_CHANGE_UNPREDICTABLY: The address of the variable (&foo) has been used, so
-      from now on, the variable's value can change in lines of code that don't seem
-      to have anything to do with the variable. For example, a function that doesn't
-      take the variable as an argument could still change the variable, if the
-      pointer &foo was stored elsewhere earlier.
-    - COULD_BE_TRUE_OR_FALSE: The value of the variable is not known.
-    - UNSET: The variable can be neither true nor false, according to current
-      knowledge. If the variable is set somewhere, and that code isn't unreachable,
-      we will later know which values the variable can have.
+    Longer explanation of VS_UNPREDICTABLE: The value of an unpredictable variable can
+    change in lines of code that seem to have nothing to do with the variable. For
+    example, a function that doesn't take &foo as an argument can change the value of foo,
+    because the pointer &foo can be stored in some place that the function can access.
     */
-    CAN_CHANGE_UNPREDICTABLY,
-    COULD_BE_TRUE_OR_FALSE,
-    UNSET,
 };
 
-static bool add_possibilities(enum BoolStatus *dest, const enum BoolStatus *src, int n)
+/*
+a and b are statuses from different branches that both jump to the same block.
+Should have these properties:
+
+    merge(a, a) == a
+    merge(a, b) == merge(b, a)
+    merge(a, merge(b, c)) == merge(merge(a, b), c)
+
+In other words:
+- It makes sense to merge an unordered collection of statuses.
+- VS_UNVISITED corresponds with merging an empty set of statuses.
+- Having the same status several times doesn't affect anything.
+*/
+static enum VarStatus merge(enum VarStatus a, enum VarStatus b)
+{
+    // Unvisited --> use the other status
+    if (a == VS_UNVISITED) return b;
+    if (b == VS_UNVISITED) return a;
+
+    // If any value in a merge is unpredictable or undefined, then the result is also
+    // unpredictable/undefined.
+    // If there are unpredictable and undefined values, the merge is unpredictable.
+    if (a == VS_UNPREDICTABLE || b == VS_UNPREDICTABLE) return VS_UNPREDICTABLE;
+    if (a == VS_UNDEFINED && b == VS_UNDEFINED) return VS_UNDEFINED;
+    if (a == VS_UNDEFINED || b == VS_UNDEFINED || a == VS_POSSIBLY_UNDEFINED || b == VS_POSSIBLY_UNDEFINED) return VS_POSSIBLY_UNDEFINED;
+
+    // At this point we know that the value is set to something. We may or may not know
+    // what it is set to.
+    assert(a == VS_TRUE || a == VS_FALSE || a == VS_DEFINED);
+    assert(b == VS_TRUE || b == VS_FALSE || b == VS_DEFINED);
+    if (a == VS_TRUE && b == VS_TRUE) return VS_TRUE;
+    if (a == VS_FALSE && b == VS_FALSE) return VS_FALSE;
+    return VS_DEFINED;
+}
+
+static bool merge_arrays_in_place(enum VarStatus *dest, const enum VarStatus *src, int n)
 {
     bool did_something = false;
     for (int i = 0; i < n; i++) {
-        enum BoolStatus combined;
-
-        if (src[i] == CAN_CHANGE_UNPREDICTABLY || dest[i] == CAN_CHANGE_UNPREDICTABLY)
-            combined = CAN_CHANGE_UNPREDICTABLY;
-        else if (src[i] == KNOWN_TO_BE_FALSE && dest[i] == KNOWN_TO_BE_FALSE)
-            combined = KNOWN_TO_BE_FALSE;
-        else if (src[i] == KNOWN_TO_BE_TRUE && dest[i] == KNOWN_TO_BE_TRUE)
-            combined = KNOWN_TO_BE_TRUE;
-        else if (dest[i] == UNSET)
-            combined = src[i];
-        else if (src[i] == UNSET)
-            combined = dest[i];
-        else
-            combined = COULD_BE_TRUE_OR_FALSE;
-
-        if (dest[i] != combined) {
-            dest[i] = combined;
+        enum VarStatus m = merge(src[i], dest[i]);
+        if (dest[i] != m) {
+            dest[i] = m;
             did_something = true;
         }
     }
@@ -65,40 +82,43 @@ static bool add_possibilities(enum BoolStatus *dest, const enum BoolStatus *src,
     return did_something;
 }
 
-static void print_bool_statuses(const struct CfGraph *cfg, enum BoolStatus **statuses, const enum BoolStatus *temp, const char *description)
+#if 0  // change to 1 to see debug prints
+static const char * vs_to_string(enum VarStatus vs)
 {
-    (void)cfg, (void)statuses, (void)temp, (void)description;  // silence unused var warnings
-
-#if 0   // change to 1 to debug
+    switch(vs){
+        case VS_UNVISITED: return "unvisited";
+        case VS_TRUE: return "true";
+        case VS_FALSE: return "false";
+        case VS_DEFINED: return "defined";
+        case VS_POSSIBLY_UNDEFINED: return "possibly undefined";
+        case VS_UNDEFINED: return "undefined";
+        case VS_UNPREDICTABLE: return "unpredictable";
+    }
+    assert(0);
+}
+static void print_var_statuses(const struct CfGraph *cfg, enum VarStatus **statuses, const enum VarStatus *temp, const char *description)
+{
     int nblocks = cfg->all_blocks.len;
     int nvars = cfg->variables.len;
 
-    const char *strs[] = {
-        [KNOWN_TO_BE_TRUE] = "true",
-        [KNOWN_TO_BE_FALSE] = "false",
-        [CAN_CHANGE_UNPREDICTABLY] = "unpredictable",
-        [COULD_BE_TRUE_OR_FALSE] = "true/false",
-        [UNSET] = "unset",
-    };
-
     puts(description);
     for (int blockidx = 0; blockidx < nblocks; blockidx++) {
-        printf("  block %d:", blockidx);
+        printf("  block %d:\n", blockidx);
         for (int i = 0; i < nvars; i++)
-            if (cfg->variables.ptr[i]->type.kind == TYPE_BOOL)
-                printf(" %10s %-14s", cfg->variables.ptr[i]->name, strs[statuses[blockidx][i]]);
+            printf("    %-10s  %s\n", cfg->variables.ptr[i]->name, vs_to_string(statuses[blockidx][i]));
         printf("\n");
     }
     if(temp) {
-        printf("  temp:   ");
+        printf("  temp:\n");
         for (int i = 0; i < nvars; i++)
-            if (cfg->variables.ptr[i]->type.kind == TYPE_BOOL)
-                printf(" %10s %-14s", cfg->variables.ptr[i]->name, strs[temp[i]]);
+            printf("    %-10s  %s\n", cfg->variables.ptr[i]->name, vs_to_string(temp[i]));
         printf("\n");
     }
     printf("\n");
-#endif
 }
+#else
+    #define print_var_statuses(...)
+#endif
 
 static bool all_zero(const char *ptr, int n)
 {
@@ -120,22 +140,19 @@ Repeat for blocks where execution jumps from the current block, unless we got sa
 result as last time, then we know that we don't have to reanalyze blocks where
 execution jumps from the current block.
 */
-static enum BoolStatus **determine_known_bool_values(const struct CfGraph *cfg)
+static enum VarStatus **determine_var_statuses(const struct CfGraph *cfg)
 {
     int nblocks = cfg->all_blocks.len;
     int nvars = cfg->variables.len;
 
-    enum BoolStatus **result = malloc(sizeof(result[0]) * nblocks);  // NOLINT
-    for (int i = 0; i < nblocks; i++) {
-        result[i] = malloc(sizeof(result[i][0]) * nvars);
-        for (int k = 0; k < nvars; k++)
-            result[i][k] = UNSET;
-    }
+    enum VarStatus **result = malloc(sizeof(result[0]) * nblocks);  // NOLINT
+    for (int i = 0; i < nblocks; i++)
+        result[i] = calloc(sizeof(result[i][0]), nvars);
 
     char *blocks_to_visit = calloc(1, nblocks);
     blocks_to_visit[0] = true;  // visit initial block
 
-    enum BoolStatus *tempstatus = malloc(nvars*sizeof(tempstatus[0]));
+    enum VarStatus *tempstatus = malloc(nvars*sizeof(tempstatus[0]));
 
     while(!all_zero(blocks_to_visit, nblocks)){
         // Find a block to visit.
@@ -147,65 +164,62 @@ static enum BoolStatus **determine_known_bool_values(const struct CfGraph *cfg)
 
         // Determine initial values based on other blocks that jump here.
         for (int i = 0; i < nvars; i++) {
-            if (visiting == 0) {
-                // Start block: don't assume the value of any variable.
-                tempstatus[i] = COULD_BE_TRUE_OR_FALSE;
+            if (visiting != 0) {
+                // start block
+                tempstatus[i] = cfg->variables.ptr[i]->is_argument ? VS_DEFINED : VS_UNDEFINED;
             } else {
                 // What is possible in other blocks is determined based on only how
                 // they are jumped into.
-                tempstatus[i] = UNSET;
+                tempstatus[i] = VS_UNVISITED;
             }
         }
-        print_bool_statuses(cfg, result, tempstatus, "Initial");
+        print_var_statuses(cfg, result, tempstatus, "Initial");
+
         for (int i = 0; i < nblocks; i++) {
             if (cfg->all_blocks.ptr[i]->iftrue == visitingblock
                 || cfg->all_blocks.ptr[i]->iffalse == visitingblock)
             {
                 // TODO: If we only get here from the true jump, or only from false
                 // jump, we could assume that the variable used in the jump was true/false.
-                add_possibilities(tempstatus, result[i], nvars);
+                merge_arrays_in_place(tempstatus, result[i], nvars);
             }
         }
-        print_bool_statuses(cfg, result, tempstatus, "After adding from other blocks to temp");
+        print_var_statuses(cfg, result, tempstatus, "After adding from other blocks to temp");
 
-        // Figure out how each instruction affects booleans.
+        // Figure out how each instruction affects variables.
         for (const struct CfInstruction *ins = visitingblock->instructions.ptr; ins < End(visitingblock->instructions); ins++) {
-            if (!ins->destvar || ins->destvar->type.kind != TYPE_BOOL)
+            if (!ins->destvar)
                 continue;
 
             int destidx = find_var_index(cfg, ins->destvar);
+            if (tempstatus[destidx] == VS_UNPREDICTABLE)
+                continue;
+
             switch(ins->kind) {
             case CF_VARCPY:
-                switch(tempstatus[find_var_index(cfg, ins->operands[0])]) {
-                case KNOWN_TO_BE_TRUE:
-                    tempstatus[destidx] = KNOWN_TO_BE_TRUE;
-                    break;
-                case KNOWN_TO_BE_FALSE:
-                    tempstatus[destidx] = KNOWN_TO_BE_FALSE;
-                    break;
-                case CAN_CHANGE_UNPREDICTABLY:  // Even an unpredictable variable yields true or false value.
-                case COULD_BE_TRUE_OR_FALSE:
-                    tempstatus[destidx] = COULD_BE_TRUE_OR_FALSE;
-                    break;
-                case UNSET:
-                    assert(0);
+                tempstatus[destidx] = tempstatus[find_var_index(cfg, ins->operands[0])];
+                assert(tempstatus[destidx] != VS_UNVISITED);
+                if (tempstatus[destidx] == VS_UNPREDICTABLE) {
+                    // Assume that unpredictable variables always yield non-garbage values.
+                    // Otherwise using functions like fscanf() would be annoying.
+                    tempstatus[destidx] = VS_DEFINED;
                 }
                 break;
             case CF_TRUE:
-                tempstatus[destidx] = KNOWN_TO_BE_TRUE;
+                tempstatus[destidx] = VS_TRUE;
                 break;
             case CF_FALSE:
-                tempstatus[destidx] = KNOWN_TO_BE_FALSE;
+                tempstatus[destidx] = VS_FALSE;
                 break;
             default:
-                tempstatus[destidx] = COULD_BE_TRUE_OR_FALSE;
+                tempstatus[destidx] = VS_DEFINED;
                 break;
             }
         }
 
-        // If some values of variables are possible, remember that from now on.
-        bool result_affected = add_possibilities(result[visiting], tempstatus, nvars);
-        print_bool_statuses(cfg, result, NULL, "At end");
+        // Update what we learned about variable status at end of this block.
+        bool result_affected = merge_arrays_in_place(result[visiting], tempstatus, nvars);
+        print_var_statuses(cfg, result, NULL, "At end");
 
         if (result_affected && visitingblock != &cfg->end_block) {
             // Also need to update blocks where we jump from here.
@@ -222,7 +236,7 @@ static enum BoolStatus **determine_known_bool_values(const struct CfGraph *cfg)
 
 static void clean_jumps_where_condition_always_true_or_always_false(struct CfGraph *cfg)
 {
-    enum BoolStatus **statuses = determine_known_bool_values(cfg);
+    enum VarStatus **statuses = determine_var_statuses(cfg);
 
     for (int blockidx = 0; blockidx < cfg->all_blocks.len; blockidx++) {
         struct CfBlock *block = cfg->all_blocks.ptr[blockidx];
@@ -230,11 +244,11 @@ static void clean_jumps_where_condition_always_true_or_always_false(struct CfGra
             continue;
 
         switch(statuses[blockidx][find_var_index(cfg, block->branchvar)]) {
-        case KNOWN_TO_BE_TRUE:
+        case VS_TRUE:
             // Always jump to true case.
             block->iffalse = block->iftrue;
             break;
-        case KNOWN_TO_BE_FALSE:
+        case VS_FALSE:
             // Always jump to false case.
             block->iftrue = block->iffalse;
             break;

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -450,6 +450,8 @@ static void warn_about_undefined_variables(struct CfGraph *cfg)
                 case VS_UNPREDICTABLE:
                     break;
                 case VS_POSSIBLY_UNDEFINED:
+                    // The compiler internally creates variables named $foo.
+                    // I think they are never used undefined if the compiler works correctly.
                     assert(ins->operands[i]->name[0] != '$');
                     show_warning(ins->location, "the value of '%s' may be undefined", ins->operands[i]->name);
                     break;

--- a/tests/should_succeed/undefined_value_warning.jou
+++ b/tests/should_succeed/undefined_value_warning.jou
@@ -1,0 +1,14 @@
+declare puts(s: byte*) -> int
+
+def maybe_uninitialized(n: int) -> void:
+    for i = 0; i < n; i = i+1:
+        message = "Hi"
+    puts(message)  # Warning: the value of 'message' may be undefined
+
+def surely_uninitialized() -> void:
+    while False:
+        message = "Hi"  # Warning: this code will never run
+    puts(message)  # Warning: the value of 'message' is undefined
+
+def main() -> int:
+    return 0

--- a/tests/should_succeed/undefined_value_warning.jou
+++ b/tests/should_succeed/undefined_value_warning.jou
@@ -1,7 +1,7 @@
 declare puts(s: byte*) -> int
 
 def maybe_uninitialized(n: int) -> void:
-    for i = 0; i < n; i = i+1:
+    for i = 0; i < n; i++:
         message = "Hi"
     puts(message)  # Warning: the value of 'message' may be undefined
 


### PR DESCRIPTION
~Fixes #26~ Adds warnings for code where you use or may use a variable before it is assigned.