### PR TITLE
Error for missing 'return' statement

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -218,6 +218,8 @@ static void codegen_function_def(struct State *st, const struct Signature *sig, 
             assert((*b)->instructions.len == 0);
             if (return_value)
                 LLVMBuildRet(st->builder, LLVMBuildLoad(st->builder, return_value, "return_value"));
+            else if (sig->returntype)  // "return" variable was deleted as unused
+                LLVMBuildUnreachable(st->builder);
             else
                 LLVMBuildRetVoid(st->builder);
         } else {

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -491,12 +491,11 @@ static void error_about_missing_return(struct CfGraph *cfg, const struct Signatu
 
     int blockidx = find_block_index(cfg, &cfg->end_block);
     switch(statuses[blockidx][varidx]) {
-    case VS_UNVISITED:
-        assert(0);
     case VS_TRUE:
     case VS_FALSE:
     case VS_DEFINED:
     case VS_UNPREDICTABLE:
+    case VS_UNVISITED:  // This happens when there is an infinite loop.
         break;
     case VS_POSSIBLY_UNDEFINED:
         show_warning(

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -254,6 +254,13 @@ static enum VarStatus **determine_var_statuses(const struct CfGraph *cfg)
     return result;
 }
 
+static void free_var_statuses(const struct CfGraph *cfg, enum VarStatus** statuses)
+{
+    for (int i = 0; i < cfg->all_blocks.len; i++)
+        free(statuses[i]);
+    free(statuses);
+}
+
 static void clean_jumps_where_condition_always_true_or_always_false(struct CfGraph *cfg)
 {
     enum VarStatus **statuses = determine_var_statuses(cfg);
@@ -276,10 +283,7 @@ static void clean_jumps_where_condition_always_true_or_always_false(struct CfGra
             break;
         }
     }
-
-    for (int i = 0; i < cfg->all_blocks.len; i++)
-        free(statuses[i]);
-    free(statuses);
+    free_var_statuses(cfg, statuses);
 }
 
 /*
@@ -467,9 +471,7 @@ static void warn_about_undefined_variables(struct CfGraph *cfg)
         }
     }
 
-    for (int i = 0; i < cfg->all_blocks.len; i++)
-        free(statuses[i]);
-    free(statuses);
+    free_var_statuses(cfg, statuses);
 }
 
 static void error_about_missing_return(struct CfGraph *cfg, const struct Signature *sig)
@@ -502,9 +504,7 @@ static void error_about_missing_return(struct CfGraph *cfg, const struct Signatu
             sig->funcname, sig->returntype->name);
     }
 
-    for (int i = 0; i < cfg->all_blocks.len; i++)
-        free(statuses[i]);
-    free(statuses);
+    free_var_statuses(cfg, statuses);
 }
 
 static void simplify_cfg(struct CfGraph *cfg, const struct Signature *sig)

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -489,25 +489,17 @@ static void error_about_missing_return(struct CfGraph *cfg, const struct Signatu
     }
     assert(varidx != -1);
 
-    int blockidx = find_block_index(cfg, &cfg->end_block);
-    switch(statuses[blockidx][varidx]) {
-    case VS_TRUE:
-    case VS_FALSE:
-    case VS_DEFINED:
-    case VS_UNPREDICTABLE:
-    case VS_UNVISITED:  // This happens when there is an infinite loop.
-        break;
-    case VS_POSSIBLY_UNDEFINED:
+    enum VarStatus s = statuses[find_block_index(cfg, &cfg->end_block)][varidx];
+    if (s == VS_POSSIBLY_UNDEFINED) {
         show_warning(
             sig->location,
             "function '%s' doesn't seem to return a value in all cases", sig->funcname);
-        break;
-    case VS_UNDEFINED:
+    }
+    if (s == VS_UNDEFINED) {
         fail_with_error(
             sig->location,
             "function '%s' must return a value, because it is defined with '-> %s'",
             sig->funcname, sig->returntype->name);
-        break;
     }
 
     for (int i = 0; i < cfg->all_blocks.len; i++)

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -472,10 +472,55 @@ static void warn_about_undefined_variables(struct CfGraph *cfg)
     free(statuses);
 }
 
-static void simplify_cfg(struct CfGraph *cfg)
+static void error_about_missing_return(struct CfGraph *cfg, const struct Signature *sig)
+{
+    if (!sig->returntype)
+        return;
+
+    enum VarStatus **statuses = determine_var_statuses(cfg);
+
+    // When a function returns a value, it is stored in a variable named "return".
+    int varidx = -1;
+    for (int i = 0; i < cfg->variables.len; i++) {
+        if (!strcmp(cfg->variables.ptr[i]->name, "return")) {
+            varidx = i;
+            break;
+        }
+    }
+    assert(varidx != -1);
+
+    int blockidx = find_block_index(cfg, &cfg->end_block);
+    switch(statuses[blockidx][varidx]) {
+    case VS_UNVISITED:
+        assert(0);
+    case VS_TRUE:
+    case VS_FALSE:
+    case VS_DEFINED:
+    case VS_UNPREDICTABLE:
+        break;
+    case VS_POSSIBLY_UNDEFINED:
+        show_warning(
+            sig->location,
+            "function '%s' doesn't seem to return a value in all cases", sig->funcname);
+        break;
+    case VS_UNDEFINED:
+        fail_with_error(
+            sig->location,
+            "function '%s' must return a value, because it is defined with '-> %s'",
+            sig->funcname, sig->returntype->name);
+        break;
+    }
+
+    for (int i = 0; i < cfg->all_blocks.len; i++)
+        free(statuses[i]);
+    free(statuses);
+}
+
+static void simplify_cfg(struct CfGraph *cfg, const struct Signature *sig)
 {
     clean_jumps_where_condition_always_true_or_always_false(cfg);
     remove_unreachable_blocks(cfg);
+    error_about_missing_return(cfg, sig);
     remove_unused_variables(cfg);
     warn_about_undefined_variables(cfg);
 }
@@ -484,5 +529,5 @@ void simplify_control_flow_graphs(const struct CfGraphFile *cfgfile)
 {
     for (int i = 0; i < cfgfile->nfuncs; i++)
         if (cfgfile->graphs[i])
-            simplify_cfg(cfgfile->graphs[i]);
+            simplify_cfg(cfgfile->graphs[i], &cfgfile->signatures[i]);
 }

--- a/tests/other_errors/missing_return.jou
+++ b/tests/other_errors/missing_return.jou
@@ -1,0 +1,18 @@
+declare putchar(ch: int) -> int
+
+def foo(n: int) -> int:  # Warning: function 'foo' doesn't seem to return a value in all cases
+    if n > 10:
+        return 123
+
+# Ideally we could detect this too, but currently the compiler is not smart enough.
+# That's why the warning says "doesn't seem to" instead of "doesn't".
+# That's also why it is a warning, not an error.
+def bar(n: int) -> int:  # Warning: function 'bar' doesn't seem to return a value in all cases
+    if n > 10:
+        return 123
+    if n <= 10:
+        return 456
+
+# This one is an error because the compiler knows that the function will not return anything.
+def baz() -> int:  # Error: function 'baz' must return a value, because it is defined with '-> int'
+    putchar('x')

--- a/tests/should_succeed/infinite_loop_but_doesnt_return_void.jou
+++ b/tests/should_succeed/infinite_loop_but_doesnt_return_void.jou
@@ -1,0 +1,10 @@
+declare puts(s: byte*) -> int
+
+# No warning or error for missing return statement.
+# But we can't call this function as it loops infinitely.
+def foo() -> int:
+    while True:
+        puts("Hi")
+
+def main() -> int:
+    return 0


### PR DESCRIPTION
Fixes #3

In cases where the compiler doesn't know for sure that the return statement is missing, it only emits a warning, not an error.