### PR TITLE
Add "x: int" syntax

### DIFF
--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -703,6 +703,10 @@ static void build_statement(struct State *st, const struct AstStatement *stmt)
         st->current_block = add_block(st);  // an unreachable block
         break;
 
+    case AST_STMT_DECLARE_LOCAL_VAR:
+        add_variable(st, &stmt->data.vardecl.type, stmt->data.vardecl.name);
+        break;
+
     case AST_STMT_EXPRESSION_STATEMENT:
         build_expression(st, &stmt->data.expression, NULL, NULL, false);
         break;

--- a/src/free.c
+++ b/src/free.c
@@ -107,6 +107,9 @@ static void free_statement(const struct AstStatement *stmt)
     case AST_STMT_RETURN_VALUE:
         free_expression(&stmt->data.expression);
         break;
+    case AST_STMT_DECLARE_LOCAL_VAR:
+        free_type(&stmt->data.vardecl.type);
+        break;
     case AST_STMT_RETURN_WITHOUT_VALUE:
     case AST_STMT_BREAK:
     case AST_STMT_CONTINUE:

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -169,6 +169,7 @@ struct AstStatement {
         AST_STMT_FOR,
         AST_STMT_BREAK,
         AST_STMT_CONTINUE,
+        AST_STMT_DECLARE_LOCAL_VAR,
         AST_STMT_EXPRESSION_STATEMENT,  // Evaluate an expression and discard the result.
     } kind;
     union {
@@ -180,6 +181,7 @@ struct AstStatement {
         } ifstatement;
         struct AstConditionAndBody whileloop;
         struct AstForLoop forloop;
+        struct { char name[100]; struct Type type; } vardecl;
     } data;
 };
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -506,6 +506,13 @@ static struct AstStatement parse_statement(const struct Token **tokens)
         ++*tokens;
         result.kind = AST_STMT_CONTINUE;
         eat_newline(tokens);
+    } else if ((*tokens)->type == TOKEN_NAME && is_operator(&(*tokens)[1], ":")) {
+        // "foo: int" creates a variable "foo" of type "int"
+        result.kind = AST_STMT_DECLARE_LOCAL_VAR;
+        safe_strcpy(result.data.vardecl.name, (*tokens)->data.name);
+        *tokens += 2;
+        result.data.vardecl.type = parse_type(tokens);
+        eat_newline(tokens);
     } else {
         result.kind = AST_STMT_EXPRESSION_STATEMENT;
         result.data.expression = parse_expression(tokens);

--- a/src/print.c
+++ b/src/print.c
@@ -250,6 +250,10 @@ static void print_ast_statement(const struct AstStatement *stmt, int indent)
         case AST_STMT_CONTINUE:
             printf("Continue loop\n");
             break;
+        case AST_STMT_DECLARE_LOCAL_VAR:
+            printf(
+                "Declare local variable \"%s\" of type %s.\n",
+                stmt->data.vardecl.name, stmt->data.vardecl.type.name);
     }
 }
 

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -105,9 +105,19 @@ static void update_statuses_with_instruction(const struct CfGraph *cfg, enum Var
             statuses[destidx] = VS_DEFINED;
         }
         break;
-    case CF_TRUE: statuses[destidx] = VS_TRUE; break;
-    case CF_FALSE: statuses[destidx] = VS_FALSE; break;
-    default: statuses[destidx] = VS_DEFINED; break;
+    case CF_ADDRESS_OF_VARIABLE:
+        statuses[find_var_index(cfg, ins->operands[0])] = VS_UNPREDICTABLE;
+        statuses[destidx] = VS_DEFINED;
+        break;
+    case CF_TRUE:
+        statuses[destidx] = VS_TRUE;
+        break;
+    case CF_FALSE:
+        statuses[destidx] = VS_FALSE;
+        break;
+    default:
+        statuses[destidx] = VS_DEFINED;
+        break;
     }
 }
 

--- a/tests/should_succeed/scanf.jou
+++ b/tests/should_succeed/scanf.jou
@@ -1,0 +1,12 @@
+declare printf(format: byte*, ...) -> int
+declare sscanf(string: byte*, format: byte*, ...) -> int
+
+def calculate_sum(string: byte*) -> int:
+    x: int
+    y: int
+    sscanf(string, "%d + %d", &x, &y)
+    return x + y
+
+def main() -> int:
+    printf("%d\n", calculate_sum("12 + 3"))  # Output: 15
+    return 0

--- a/tests/should_succeed/undefined_value_warning.jou
+++ b/tests/should_succeed/undefined_value_warning.jou
@@ -1,14 +1,18 @@
 declare puts(s: byte*) -> int
 
-def maybe_uninitialized(n: int) -> void:
+def maybe_undefined(n: int) -> void:
     for i = 0; i < n; i++:
         message = "Hi"
     puts(message)  # Warning: the value of 'message' may be undefined
 
-def surely_uninitialized() -> void:
+def surely_undefined_loop() -> void:
     while False:
         message = "Hi"  # Warning: this code will never run
     puts(message)  # Warning: the value of 'message' is undefined
+
+def surely_undefined_annotation() -> void:
+    x: byte*
+    puts(x)  # Warning: the value of 'x' is undefined
 
 def main() -> int:
     return 0


### PR DESCRIPTION
fixes #29

Also fixes a bug that generated a bunch of false-positive warnings when trying to use `sscanf()`