### PR TITLE
Introduce AstType

### DIFF
--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -857,6 +857,7 @@ static void build_statement(struct State *st, const AstStatement *stmt)
                 true);
             add_unary_op(st, stmt->location, CF_VARCPY, cfvar, v);
         }
+        free_type(&type);
         break;
 
     case AST_STMT_EXPRESSION_STATEMENT:

--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -904,15 +904,6 @@ static Signature build_signature(const struct State *st, const AstSignature *ast
         if (!strcmp(st->cfgfile->signatures[i].funcname, astsig->funcname))
             fail_with_error(astsig->funcname_location, "a function named '%s' already exists", astsig->funcname);
 
-    Type *returntype = build_type_or_void(st, &astsig->returntype);
-
-    // TODO: validate main() parameters
-    if (!strcmp(astsig->funcname, "main") &&
-        (returntype == NULL || !same_type(returntype, &intType)))
-    {
-        fail_with_error(astsig->returntype.location, "the main() function must return int");
-    }
-
     Signature result = { .nargs = astsig->nargs, .takes_varargs = astsig->takes_varargs };
     safe_strcpy(result.funcname, astsig->funcname);
 
@@ -925,8 +916,15 @@ static Signature build_signature(const struct State *st, const AstSignature *ast
         result.argtypes[i] = build_type(st, &astsig->argtypes[i]);
 
     result.returntype = build_type_or_void(st, &astsig->returntype);
-    result.returntype_location = astsig->returntype.location;
+    // TODO: validate main() parameters
+    // TODO: test main() taking parameters
+    if (!strcmp(astsig->funcname, "main") &&
+        (result.returntype == NULL || !same_type(result.returntype, &intType)))
+    {
+        fail_with_error(astsig->returntype.location, "the main() function must return int");
+    }
 
+    result.returntype_location = astsig->returntype.location;
     return result;
 }
 

--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -899,11 +899,11 @@ static CfGraph *build_function(struct State *st, const Signature *sig, const Ast
     return st->cfg;
 }
 
-static Signature build_signature(const struct State *st, const AstSignature *astsig)
+static Signature build_signature(const struct State *st, const AstSignature *astsig, Location location)
 {
     for (int i = 0; i < st->cfgfile->nfuncs; i++)
         if (!strcmp(st->cfgfile->signatures[i].funcname, astsig->funcname))
-            fail_with_error(astsig->funcname_location, "a function named '%s' already exists", astsig->funcname);
+            fail_with_error(location, "a function named '%s' already exists", astsig->funcname);
 
     Signature result = { .nargs = astsig->nargs, .takes_varargs = astsig->takes_varargs };
     safe_strcpy(result.funcname, astsig->funcname);
@@ -946,13 +946,13 @@ CfGraphFile build_control_flow_graphs(AstToplevelNode *ast)
         case AST_TOPLEVEL_END_OF_FILE:
             assert(0);
         case AST_TOPLEVEL_DECLARE_FUNCTION:
-            sig = build_signature(&st, &ast->data.decl_signature);
+            sig = build_signature(&st, &ast->data.decl_signature, ast->location);
             result.signatures[result.nfuncs] = sig;
             result.graphs[result.nfuncs] = NULL;
             result.nfuncs++;
             break;
         case AST_TOPLEVEL_DEFINE_FUNCTION:
-            sig = build_signature(&st, &ast->data.funcdef.signature);
+            sig = build_signature(&st, &ast->data.funcdef.signature, ast->location);
             result.signatures[result.nfuncs] = sig;
             result.nfuncs++;  // Make signature of current function usable in function calls (recursion)
             result.graphs[result.nfuncs-1] = build_function(&st, &sig, &ast->data.funcdef.body);

--- a/src/free.c
+++ b/src/free.c
@@ -112,7 +112,6 @@ static void free_statement(const AstStatement *stmt)
         free_expression(&stmt->data.expression);
         break;
     case AST_STMT_DECLARE_LOCAL_VAR:
-        free_type(&stmt->data.vardecl.type);
         if (stmt->data.vardecl.initial_value) {
             free_expression(stmt->data.vardecl.initial_value);
             free(stmt->data.vardecl.initial_value);
@@ -136,12 +135,19 @@ static void free_signature(const Signature *sig)
 {
     for (int i = 0; i < sig->nargs; i++)
         free_type(&sig->argtypes[i]);
-    free(sig->argtypes);
-    if (sig->returntype){
+
+    if (sig->returntype)
         free_type(sig->returntype);
-        free(sig->returntype);
-    }
+    free(sig->returntype);
+
     free(sig->argnames);
+    free(sig->argtypes);
+}
+
+static void free_ast_signature(const AstSignature *sig)
+{
+    free(sig->argnames);
+    free(sig->argtypes);
 }
 
 void free_ast(AstToplevelNode *topnodelist)
@@ -149,10 +155,10 @@ void free_ast(AstToplevelNode *topnodelist)
     for (AstToplevelNode *t = topnodelist; t->kind != AST_TOPLEVEL_END_OF_FILE; t++) {
         switch(t->kind) {
         case AST_TOPLEVEL_DECLARE_FUNCTION:
-            free_signature(&t->data.decl_signature);
+            free_ast_signature(&t->data.decl_signature);
             break;
         case AST_TOPLEVEL_DEFINE_FUNCTION:
-            free_signature(&t->data.funcdef.signature);
+            free_ast_signature(&t->data.funcdef.signature);
             free_body(&t->data.funcdef.body);
             break;
         case AST_TOPLEVEL_END_OF_FILE:

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -146,7 +146,6 @@ struct AstType {
 };
 
 struct AstSignature {
-    Location funcname_location;
     char funcname[100];
     int nargs;
     AstType *argtypes;

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -13,6 +13,8 @@ typedef struct Type Type;
 typedef struct Signature Signature;
 typedef struct Constant Constant;
 
+typedef struct AstType AstType;
+typedef struct AstSignature AstSignature;
 typedef struct AstBody AstBody;
 typedef struct AstCall AstCall;
 typedef struct AstConditionAndBody AstConditionAndBody;
@@ -105,13 +107,13 @@ bool is_pointer_type(const Type *t);  // includes void pointers
 bool same_type(const Type *a, const Type *b);
 
 struct Signature {
-    Location location;
     char funcname[100];
     int nargs;
     Type *argtypes;
     char (*argnames)[100];
     bool takes_varargs;  // true for functions like printf()
     Type *returntype;  // NULL, if does not return a value
+    Location returntype_location;  // meaningful even if returntype is NULL
 };
 char *signature_to_string(const Signature *sig, bool include_return_type);
 Signature copy_signature(const Signature *sig);
@@ -135,6 +137,23 @@ struct Constant {
 };
 #define copy_constant(c) ( same_type(&(c)->type, &stringType) ? (Constant){ stringType, {.str=strdup((c)->value.str)} } : *(c) )
 
+
+// Can also represent "void" even though that is not a valid type
+struct AstType {
+    Location location;
+    char name[100];
+    int npointers;  // example: 2 means foo**
+};
+
+struct AstSignature {
+    Location funcname_location;
+    char funcname[100];
+    int nargs;
+    AstType *argtypes;
+    char (*argnames)[100];
+    bool takes_varargs;  // true for functions like printf()
+    AstType returntype;  // can represent void
+};
 
 struct AstCall {
     char funcname[100];
@@ -209,7 +228,7 @@ struct AstIfStatement {
 };
 struct AstVarDeclaration {
     char name[100];
-    Type type;
+    AstType type;
     AstExpression *initial_value; // can be NULL
 };
 
@@ -236,7 +255,7 @@ struct AstStatement {
 };
 
 struct AstFunctionDef {
-    Signature signature;
+    AstSignature signature;
     AstBody body;
 };
 
@@ -249,7 +268,7 @@ struct AstToplevelNode {
         AST_TOPLEVEL_DEFINE_FUNCTION,
     } kind;
     union {
-        Signature decl_signature;  // for AST_TOPLEVEL_DECLARE_FUNCTION
+        AstSignature decl_signature;  // for AST_TOPLEVEL_DECLARE_FUNCTION
         AstFunctionDef funcdef;  // for AST_TOPLEVEL_DEFINE_FUNCTION
     } data;
 };

--- a/src/parse.c
+++ b/src/parse.c
@@ -65,7 +65,6 @@ static AstSignature parse_function_signature(const Token **tokens)
     if ((*tokens)->type != TOKEN_NAME)
         fail_with_parse_error(*tokens, "a function name");
     safe_strcpy(result.funcname, (*tokens)->data.name);
-    result.funcname_location = (*tokens)->location;
     ++*tokens;
 
     if (!is_operator(*tokens, "("))
@@ -588,9 +587,7 @@ static AstToplevelNode parse_toplevel_node(const Token **tokens)
             result.data.funcdef.signature = parse_function_signature(tokens);
             if (result.data.funcdef.signature.takes_varargs) {
                 // TODO: support "def foo(x: str, ...)" in some way
-                fail_with_error(
-                    result.data.funcdef.signature.funcname_location,
-                    "functions with variadic arguments cannot be defined yet");
+                fail_with_error((*tokens)->location, "functions with variadic arguments cannot be defined yet");
             }
             result.data.funcdef.body = parse_body(tokens);
             break;

--- a/src/print.c
+++ b/src/print.c
@@ -94,11 +94,26 @@ void print_tokens(const Token *tokens)
     printf("\n");
 }
 
-static void print_ast_function_signature(const Signature *sig, int indent)
+static void print_ast_type(const struct AstType *t)
 {
-    char *s = signature_to_string(sig, true);
-    printf("%*sSignature on line %d: %s\n", indent, "", sig->location.lineno, s);
-    free(s);
+    printf("%s", t->name);
+    for (int i=0; i<t->npointers; i++)
+        printf("*");
+    printf(" [line %d]", t->location.lineno);
+}
+
+static void print_ast_function_signature(const AstSignature *sig, int indent)
+{
+    printf("%*sSignature:\n", indent, "");
+    printf("%*s  Function on line %d: %s(", indent, "", sig->funcname_location.lineno, sig->funcname);
+    for (int i = 0; i < sig->nargs; i++) {
+        if(i) printf(", ");
+        printf("%s: ", sig->argnames[i]);
+        print_ast_type(&sig->argtypes[i]);
+    }
+    printf(") -> ");
+    print_ast_type(&sig->returntype);
+    printf("\n");
 }
 
 static void print_ast_call(const AstCall *call, int arg_indent);
@@ -441,7 +456,7 @@ void print_control_flow_graphs(const CfGraphFile *cfgfile)
     printf("===== Control Flow Graphs for file \"%s\" =====\n", cfgfile->filename);
     for (int i = 0; i < cfgfile->nfuncs; i++) {
         char *sigstr = signature_to_string(&cfgfile->signatures[i], true);
-        printf("Function on line %d: %s\n", cfgfile->signatures[i].location.lineno, sigstr);
+        printf("Function %s\n", sigstr);
         free(sigstr);
         print_control_flow_graph_with_indent(cfgfile->graphs[i], 2);
         printf("\n");

--- a/src/print.c
+++ b/src/print.c
@@ -102,10 +102,9 @@ static void print_ast_type(const struct AstType *t)
     printf(" [line %d]", t->location.lineno);
 }
 
-static void print_ast_function_signature(const AstSignature *sig, int indent)
+static void print_ast_function_signature(const AstSignature *sig)
 {
-    printf("%*sSignature:\n", indent, "");
-    printf("%*s  Function on line %d: %s(", indent, "", sig->funcname_location.lineno, sig->funcname);
+    printf("%s(", sig->funcname);
     for (int i = 0; i < sig->nargs; i++) {
         if(i) printf(", ");
         printf("%s: ", sig->argnames[i]);
@@ -308,12 +307,12 @@ void print_ast(const AstToplevelNode *topnodelist)
 
         switch(topnodelist->kind) {
             case AST_TOPLEVEL_DECLARE_FUNCTION:
-                printf("Declare a C function.\n");
-                print_ast_function_signature(&topnodelist->data.decl_signature, 2);
+                printf("Declare a function: ");
+                print_ast_function_signature(&topnodelist->data.decl_signature);
                 break;
             case AST_TOPLEVEL_DEFINE_FUNCTION:
-                printf("Define a function.\n");
-                print_ast_function_signature(&topnodelist->data.funcdef.signature, 2);
+                printf("Define a function: ");
+                print_ast_function_signature(&topnodelist->data.funcdef.signature);
                 print_ast_body(&topnodelist->data.funcdef.body, 2);
                 break;
             case AST_TOPLEVEL_END_OF_FILE:

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -509,12 +509,12 @@ static void error_about_missing_return(CfGraph *cfg, const Signature *sig)
     enum VarStatus s = statuses[find_block_index(cfg, &cfg->end_block)][varidx];
     if (s == VS_POSSIBLY_UNDEFINED) {
         show_warning(
-            sig->location,
+            sig->returntype_location,
             "function '%s' doesn't seem to return a value in all cases", sig->funcname);
     }
     if (s == VS_UNDEFINED) {
         fail_with_error(
-            sig->location,
+            sig->returntype_location,
             "function '%s' must return a value, because it is defined with '-> %s'",
             sig->funcname, sig->returntype->name);
     }

--- a/tests/404/type.jou
+++ b/tests/404/type.jou
@@ -1,2 +1,2 @@
-def foo() -> asd:  # Error: expected a type, got a variable name 'asd'
+def foo() -> asd:  # Error: there is no type named 'asd'
     return 1


### PR DESCRIPTION
Currently AST contains `Type`s, but that won't be good once we have structs: the AST building functions don't have any state apart from the stream of tokens (and I don't want to add any), so can't store a list of previously defined structs there.

This changes the AST to have types in a not-fully-compiled form so that the next compilation step (build_cfg) can handle struct names later.

Purely refactoring / adding boilerplate. No functionality changes.