### PR TITLE
Separate valgrind from "make test"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,13 @@ jobs:
     - run: sudo apt install -y llvm-11-dev clang-11 make valgrind
     - run: make test
 
+  valgrind:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: sudo apt install -y llvm-11-dev clang-11 make valgrind
+    - run: make valgrind
+
   fuzzer:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,7 @@ clean:
 .PHONY: test
 test: all
 	tests/runtests.sh './jou %s'
+
+.PHONY: valgrind
+valgrind: all
 	tests/runtests.sh --skip-expected-fails 'valgrind -q --leak-check=full --show-leak-kinds=all --suppressions=valgrind-suppressions.sup ./jou %s'

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ but does not do anything with tests that are supposed to fail with an error, for
 - Most problems in error message code are spotted by non-valgrinded tests.
 
 Sometimes the fuzzer discovers a bug that hasn't been caught with tests.
-This mostly finds bugs in the tokenizer,
+It mostly finds bugs in the tokenizer,
 because the fuzzer works by feeding random bytes to the compiler.
 
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ read `src/jou_compiler.h` and have a quick look at `src/util.h`.
 
 ## Tests
 
+GitHub Actions runs all tests when you make a pull request,
+so you don't need to run tests locally if you only intend to fix a couple small things.
+That said, running the tests is a good way to add features and fix bugs in a compiler.
 There should be a test (or a TODO comment about adding a test)
 for every feature and for every compiler error/warning.
 
@@ -133,20 +136,24 @@ The command that was ran (e.g. `./jou examples/hello.jou`) is shown just above t
 and you can run it again manually to debug a test failure.
 You can also put e.g. `valgrind` or `gdb --args` in front of the command.
 
-If all tests succeed, the tests in `examples/` and `tests/should_succeed/`
-automatically run again with `valgrind` to find missing `free()`s and various other memory bugs.
-This isn't done for tests that are supposed to fail with a compiler error, for a few reasons:
+You can also run tests in `examples/` and `tests/should_succeed/` with `valgrind`:
+
+```
+$ make valgrind
+```
+
+This finds missing `free()`s and various other memory bugs,
+but does not do anything with tests that are supposed to fail with an error, for a few reasons:
 - The compiler does not free memory allocations when it exits with an error.
     This is fine because the operating system will free the memory anyway,
-    but `valgrind` doesn't like it.
+    but `valgrind` would see it as many memory leaks.
 - Valgrinding is slow. Most tests are about compiler errors,
-    and `make test` would take several minutes if they weren't skipped.
+    and `make valgrind` would take several minutes if they weren't skipped.
 - Most problems in error message code are spotted by non-valgrinded tests.
 
-I often skip valgrinding with Ctrl+C when the non-valgrinded tests succeed,
-because it will run in the CI anyway (see `.github/workflows/`).
-
-Sometimes (very rarely) the fuzzer discovers a bug that hasn't been caught with tests:
+Sometimes the fuzzer discovers a bug that hasn't been caught with tests.
+This mostly finds bugs in the tokenizer,
+because the fuzzer works by feeding random bytes to the compiler.
 
 ```
 $ ./fuzzer.sh

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ read `src/jou_compiler.h` and have a quick look at `src/util.h`.
 
 GitHub Actions runs all tests when you make a pull request,
 so you don't need to run tests locally if you only intend to fix a couple small things.
-That said, running the tests is a good way to add features and fix bugs in a compiler.
+That said, test-driven development works very well for developing compilers.
 There should be a test (or a TODO comment about adding a test)
 for every feature and for every compiler error/warning.
 


### PR DESCRIPTION
Found myself almost always pressing Ctrl+C to interupt valgrind