### PR TITLE
Separate type checking and build_cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Hello World
 The compiler is currently written in C. At a high level, the compilation steps are:
 - Tokenize: split the source code into tokens
 - Parse: build an Abstract Syntax Tree from the tokens
+- Typecheck: errors for wrong number or type of function arguments etc, figure out the type of each expression in the AST
 - Build CFG: build Control Flow Graphs for each function from the AST
 - Simplify CFG: simplify and analyze the control flow graphs in various ways, emit warnings as needed
 - Codegen: convert the CFGs into LLVM IR

--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -816,8 +816,8 @@ CfGraphFile build_control_flow_graphs(AstToplevelNode *ast)
     free(st.breakstack.ptr);
     free(st.continuestack.ptr);
     free(st.typectx.expr_types.ptr);
-    /*for (Type *t = st.structs.ptr; t < End(st.structs); t++)
+    for (Type *t = st.typectx.structs.ptr; t < End(st.typectx.structs); t++)
         free_type(t);
-    free(st.structs.ptr);*/
+    free(st.typectx.structs.ptr);
     return result;
 }

--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -23,7 +23,7 @@ static const ExpressionTypes *get_expr_types(const struct State *st, const AstEx
     for (int i = 0; i < st->typectx.expr_types.len; i++)
         if (st->typectx.expr_types.ptr[i]->expr == expr)
             return st->typectx.expr_types.ptr[i];
-    assert(0);
+    return NULL;
 }
 
 static Variable *add_variable(struct State *st, const Type *t, const char *name)
@@ -844,6 +844,9 @@ static CfGraph *build_function(struct State *st, const Signature *sig, const Ast
     // Implicit return at the end of the function
     st->current_block->iftrue = &st->cfg->end_block;
     st->current_block->iffalse = &st->cfg->end_block;
+
+    memcpy(&st->cfg->variables, &st->typectx.variables, sizeof st->typectx.variables);
+    memset(&st->typectx.variables, 0, sizeof st->typectx.variables);
 
     return st->cfg;
 }

--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -715,7 +715,7 @@ static CfGraph *build_function(struct State *st, const AstBody *body)
         free_type(&(*et)->type);
         if ((*et)->type_after_cast) {
             free_type((*et)->type_after_cast);
-            (*et)->type_after_cast = NULL;
+            free((*et)->type_after_cast);
         }
         free(*et);
     }

--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -633,6 +633,7 @@ static const Variable *build_expression(struct State *st, const AstExpression *e
         break;
     }
 
+    assert(types);
     assert(same_type(&result->type, &types->type));
     if (types->type_after_cast)
         return build_cast(st, result, types->type_after_cast, expr->location);
@@ -792,7 +793,7 @@ static CfGraph *build_function(struct State *st, const Signature *sig, const Ast
         Variable *v = add_variable(st, &sig->argtypes[i], sig->argnames[i]);
         v->is_argument = true;
     }
-    if (sig->returntype) 
+    if (sig->returntype)
         add_variable(st, sig->returntype, "return");
     typecheck_function(&st->typectx, sig, body);
 

--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -424,7 +424,6 @@ static const Variable *build_expression(struct State *st, const AstExpression *e
     const ExpressionTypes *types = get_expr_types(st, expr);
 
     const Variable *result, *temp;
-    Type temptype;
 
     switch(expr->kind) {
     case AST_EXPR_FUNCTION_CALL:
@@ -517,9 +516,7 @@ static const Variable *build_expression(struct State *st, const AstExpression *e
         }
     case AST_EXPR_AS:
         temp = build_expression(st, expr->data.as.obj);
-        temptype = type_from_ast(&st->typectx, &expr->data.as.type);
-        result = build_cast(st, temp, &temptype, expr->location);
-        free_type(&temptype);
+        result = build_cast(st, temp, &types->type, expr->location);
         break;
     }
 

--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -732,8 +732,8 @@ CfGraphFile build_control_flow_graphs(AstToplevelNode *ast)
         ast++;
     }
 
+    assert(result.nfuncs == st.typectx.function_signatures.len);
     result.signatures = st.typectx.function_signatures.ptr;
-    result.nfuncs = st.typectx.function_signatures.len;
 
     free(st.breakstack.ptr);
     free(st.continuestack.ptr);

--- a/src/free.c
+++ b/src/free.c
@@ -209,7 +209,7 @@ static void free_cfg(CfGraph *cfg)
     for (CfBlock **b = cfg->all_blocks.ptr; b < End(cfg->all_blocks); b++)
         free_control_flow_graph_block(cfg, *b);
 
-    for (CfVariable **v = cfg->variables.ptr; v < End(cfg->variables); v++) {
+    for (Variable **v = cfg->variables.ptr; v < End(cfg->variables); v++) {
         free_type(&(*v)->type);
         free(*v);
     }

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -110,6 +110,7 @@ struct AstType {
 };
 
 struct AstSignature {
+    Location funcname_location;
     char funcname[100];
     int nargs;
     AstType *argtypes;
@@ -340,7 +341,9 @@ struct TypeContext {
 };
 Type type_from_ast(const TypeContext *ctx, const AstType *asttype);
 Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttype);
-void typecheck_function(TypeContext *ctx, const Signature *sig, const AstBody *body);
+
+// body can be NULL to check a declaration that doesn't define anything
+void typecheck_function(TypeContext *ctx, Location funcname_location, const AstSignature *astsig, const AstBody *body);
 
 /*
 Difference between reset and destroy:

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -340,7 +340,7 @@ struct TypeContext {
 };
 Type type_from_ast(const TypeContext *ctx, const AstType *asttype);
 Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttype);
-void typecheck_function(TypeContext *ctx, const AstBody *body);
+void typecheck_function(TypeContext *ctx, const Signature *sig, const AstBody *body);
 
 
 // Control Flow Graph.

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -339,10 +339,10 @@ struct TypeContext {
     List(Type) structs;
     List(Signature) function_signatures;
 };
-Type type_from_ast(const TypeContext *ctx, const AstType *asttype);
 
-// body can be NULL to check a declaration that doesn't define anything
+// function body can be NULL to check a declaration
 void typecheck_function(TypeContext *ctx, Location funcname_location, const AstSignature *astsig, const AstBody *body);
+void typecheck_struct(TypeContext *ctx, const AstStructDef *structdef, Location location);
 
 /*
 Difference between reset and destroy:

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -338,7 +338,9 @@ struct TypeContext {
     List(Type) structs;
     List(Signature) function_signatures;
 };
-void typecheck_function(TypeContext *ctx, const Signature *sig, const AstBody *body);
+Type type_from_ast(const TypeContext *ctx, const AstType *asttype);
+Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttype);
+void typecheck_function(TypeContext *ctx, const AstBody *body);
 
 
 // Control Flow Graph.

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -342,6 +342,19 @@ Type type_from_ast(const TypeContext *ctx, const AstType *asttype);
 Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttype);
 void typecheck_function(TypeContext *ctx, const Signature *sig, const AstBody *body);
 
+/*
+Difference between reset and destroy:
+
+- reset wipes all function-specific data. For example, the list of local
+  variables is emptied so that the next function doesn't have access to the
+  same local variables. But e.g. the list of all known function signatures
+  is preserved, so that the next function can call the previous function.
+
+- destroy frees all memory used by the type context, making it unusable.
+*/
+void reset_type_context(TypeContext *ctx);
+void destroy_type_context(const TypeContext *ctx);
+
 
 // Control Flow Graph.
 // Struct names not prefixed with Cfg because it looks too much like "config" to me

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -340,7 +340,6 @@ struct TypeContext {
     List(Signature) function_signatures;
 };
 Type type_from_ast(const TypeContext *ctx, const AstType *asttype);
-Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttype);
 
 // body can be NULL to check a declaration that doesn't define anything
 void typecheck_function(TypeContext *ctx, Location funcname_location, const AstSignature *astsig, const AstBody *body);

--- a/src/print.c
+++ b/src/print.c
@@ -349,7 +349,7 @@ void print_ast(const AstToplevelNode *topnodelist)
 }
 
 
-static const char *varname(const CfVariable *var)
+static const char *varname(const Variable *var)
 {
     if (var->name[0])
         return var->name;
@@ -456,7 +456,7 @@ static void print_control_flow_graph_with_indent(const CfGraph *cfg, int indent)
     }
 
     printf("%*sVariables:\n", indent, "");
-    for (CfVariable **var = cfg->variables.ptr; var < End(cfg->variables); var++) {
+    for (Variable **var = cfg->variables.ptr; var < End(cfg->variables); var++) {
         printf("%*s  %-20s  %s\n", indent, "", varname(*var), (*var)->type.name);
     }
 

--- a/src/simplify_cfg.c
+++ b/src/simplify_cfg.c
@@ -9,7 +9,7 @@ static int find_block_index(const CfGraph *cfg, const CfBlock *b)
     assert(0);
 }
 
-static int find_var_index(const CfGraph *cfg, const CfVariable *v)
+static int find_var_index(const CfGraph *cfg, const Variable *v)
 {
     for (int i = 0; i < cfg->variables.len; i++)
         if (cfg->variables.ptr[i] == v)

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -631,6 +631,7 @@ static void typecheck_statement(TypeContext *ctx, const AstStatement *stmt)
                 "initial value for variable of type TO cannot be of type FROM");
         }
         add_variable(ctx, &type, stmt->data.vardecl.name);
+        free_type(&type);
         break;
 
     case AST_STMT_EXPRESSION_STATEMENT:

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -33,7 +33,7 @@ static const Signature *find_function(const TypeContext *ctx, const char *name)
     return NULL;
 }
 
-Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttype)
+static Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttype)
 {
     int npointers = asttype->npointers;
     Type t;

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -1,0 +1,468 @@
+#include "jou_compiler.h"
+
+
+// If error_location is NULL, this will return NULL when variable is not found.
+static const Variable *find_variable(const TypeContext *ctx, const char *name, const Location *error_location)
+{
+    for (Variable **var = ctx->variables.ptr; var < End(ctx->variables); var++)
+        if (!strcmp((*var)->name, name))
+            return *var;
+
+    if (!error_location)
+        return NULL;
+    fail_with_error(*error_location, "no local variable named '%s'", name);
+}
+
+static const Signature *find_function(const TypeContext *ctx, const char *name)
+{
+    for (Signature *sig = ctx->function_signatures.ptr; sig < End(ctx->function_signatures); sig++)
+        if (!strcmp(sig->funcname, name))
+            return sig;
+    return NULL;
+}
+
+static Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttype)
+{
+    int npointers = asttype->npointers;
+    Type t;
+
+    if (!strcmp(asttype->name, "int"))
+        t = intType;
+    else if (!strcmp(asttype->name, "byte"))
+        t = byteType;
+    else if (!strcmp(asttype->name, "bool"))
+        t = boolType;
+    else if (!strcmp(asttype->name, "void")) {
+        if (npointers == 0)
+            return NULL;
+        npointers--;
+        t = voidPtrType;
+    } else {
+        bool found = false;
+        for (struct Type *ptr = ctx->structs.ptr; ptr < End(ctx->structs); ptr++) {
+            if (!strcmp(ptr->name, asttype->name)) {
+                t = copy_type(ptr);
+                found = true;
+                break;
+            }
+        }
+        if(!found)
+            fail_with_error(asttype->location, "there is no type named '%s'", asttype->name);
+    }
+
+    while (npointers--)
+        t = create_pointer_type(&t, asttype->location);
+
+    Type *ptr = malloc(sizeof *ptr);
+    *ptr = t;
+    return ptr;
+}
+
+static Type type_from_ast(const TypeContext *ctx, const AstType *asttype)
+{
+    Type *ptr = type_or_void_from_ast(ctx, asttype);
+    if (!ptr)
+        fail_with_error(asttype->location, "'void' cannot be used here because it is not a type");
+
+    Type t = *ptr;
+    free(ptr);
+    return t;
+}
+
+static noreturn void fail_with_implicit_cast_error(
+    Location location, const char *template, const Type *from, const Type *to)
+{
+    List(char) msg = {0};
+    while(*template){
+        if (!strncmp(template, "FROM", 4)) {
+            AppendStr(&msg, from->name);
+            template += 4;
+        } else if (!strncmp(template, "TO", 2)) {
+            AppendStr(&msg, to->name);
+            template += 2;
+        } else {
+            Append(&msg, template[0]);
+            template++;
+        }
+    }
+    fail_with_error(location, "%.*s", msg.len, msg.ptr);
+}
+
+static void typecheck_implicit_cast(
+    const Type *from, const Type *to, Location location, const char *errormsg_template)
+{
+    bool can_cast =
+        same_type(from, to)
+        || (
+            // Cast to bigger integer types implicitly, unless it is signed-->unsigned.
+            is_integer_type(from)
+            && is_integer_type(to)
+            && from->data.width_in_bits < to->data.width_in_bits
+            && !(from->kind == TYPE_SIGNED_INTEGER && to->kind == TYPE_UNSIGNED_INTEGER)
+        ) || (
+            // Cast implicitly between void pointer and any other pointer.
+            (from->kind == TYPE_POINTER && to->kind == TYPE_VOID_POINTER)
+            || (from->kind == TYPE_VOID_POINTER && to->kind == TYPE_POINTER)
+        );
+
+    if (!can_cast)
+        fail_with_implicit_cast_error(location, errormsg_template, from, to);
+}
+
+static void typecheck_explicit_cast(const Type *from, const Type *to, Location location)
+{
+    if (
+        !same_type(from, to)  // TODO: should probably be error if it's the same type.
+        && !(is_pointer_type(from) && is_pointer_type(to))
+        && !(is_integer_type(from) && is_integer_type(to))
+        // TODO: pointer-to-int, int-to-pointer
+    )
+    {
+        // TODO: test this error
+        fail_with_error(location, "cannot cast from type %s to %s", from->name, to->name);
+    }
+}
+
+static Type typecheck_expression_not_void(const TypeContext *ctx, const AstExpression *expr)
+{
+    Type *checkresult = typecheck_expression(ctx, expr);
+    if (!checkresult) {
+        assert(expr->kind == AST_EXPR_FUNCTION_CALL);
+        fail_with_error(
+            expr->location, "function '%s' does not return a value", expr->data.call.calledname);
+    }
+
+    Type t = *checkresult;
+    free(checkresult);
+    return t;
+}
+
+void typecheck_expression_with_implicit_cast(
+    const TypeContext *ctx,
+    const AstExpression *expr,
+    const Type *casttype,
+    const char *errormsg_template)
+{
+    Type t = typecheck_expression_not_void(ctx, expr);
+    typecheck_implicit_cast(&t, casttype, expr->location, errormsg_template);
+    free_type(&t);
+}
+
+static Type typecheck_binop(
+    enum AstExpressionKind op,
+    Location location,
+    const Type *lhstype,
+    const Type *rhstype)
+{
+    const char *do_what;
+    switch(op) {
+    case AST_EXPR_ADD: do_what = "add"; break;
+    case AST_EXPR_SUB: do_what = "subtract"; break;
+    case AST_EXPR_MUL: do_what = "multiply"; break;
+    case AST_EXPR_DIV: do_what = "divide"; break;
+
+    case AST_EXPR_EQ:
+    case AST_EXPR_NE:
+    case AST_EXPR_GT:
+    case AST_EXPR_GE:
+    case AST_EXPR_LT:
+    case AST_EXPR_LE:
+        do_what = "compare";
+        break;
+
+    default:
+        assert(0);
+    }
+
+    bool got_integers = is_integer_type(lhstype) && is_integer_type(rhstype);
+    bool got_pointers = (
+        is_pointer_type(lhstype)
+        && is_pointer_type(rhstype)
+        && (
+            // Ban comparisons like int* == byte*, unless one of the two types is void*
+            same_type(lhstype, rhstype)
+            || same_type(lhstype, &voidPtrType)
+            || same_type(rhstype, &voidPtrType)
+        )
+    );
+
+    if (!got_integers && !(got_pointers && (op == AST_EXPR_EQ || op == AST_EXPR_NE)))
+        fail_with_error(location, "wrong types: cannot %s %s and %s", do_what, lhstype->name, rhstype->name);
+
+    // TODO: is this a good idea?
+    Type cast_type;
+    if (got_integers) {
+        cast_type = create_integer_type(
+            max(lhstype->data.width_in_bits, rhstype->data.width_in_bits),
+            lhstype->kind == TYPE_SIGNED_INTEGER || lhstype->kind == TYPE_SIGNED_INTEGER
+        );
+    }
+    if (got_pointers) {
+        cast_type = voidPtrType;
+    }
+
+    Type result_type;
+    switch(op) {
+        case AST_EXPR_ADD:
+        case AST_EXPR_SUB:
+        case AST_EXPR_MUL:
+        case AST_EXPR_DIV:
+            return cast_type;
+        case AST_EXPR_EQ:
+        case AST_EXPR_NE:
+        case AST_EXPR_GT:
+        case AST_EXPR_GE:
+        case AST_EXPR_LT:
+        case AST_EXPR_LE:
+            return boolType;
+        default:
+            assert(0);
+    }
+}
+
+static Type typecheck_increment_or_decrement(const TypeContext *ctx, const AstExpression *expr)
+{
+    const char *do_what;
+    switch(expr->kind) {
+    case AST_EXPR_PRE_INCREMENT:
+    case AST_EXPR_POST_INCREMENT:
+        do_what = "increment";
+        break;
+    case AST_EXPR_PRE_DECREMENT:
+    case AST_EXPR_POST_DECREMENT:
+        do_what = "decrement";
+        break;
+    default:
+        assert(0);
+    }
+
+    Type elemtype = typecheck_expression_not_void(ctx, &expr->data.operands[0]);
+    if (!is_integer_type(&elemtype) && !is_pointer_type(&elemtype))
+        fail_with_error(expr->location, "cannot %s a value of type %s", do_what, elemtype.name);
+    return elemtype;
+}
+
+static void typecheck_dereferenced_pointer(Location location, const Type *t)
+{
+    // TODO: improved error message for dereferencing void*
+    if (t->kind != TYPE_POINTER)
+        fail_with_error(location, "the dereference operator '*' is only for pointers, not for %s", t->name);
+}
+
+// ptr[index]
+static Type typecheck_indexing(
+    const TypeContext *ctx, const AstExpression *ptrexpr, const AstExpression *indexexpr)
+{
+    const Type ptrtype = typecheck_expression_not_void(ctx, ptrexpr);
+    if (ptrtype.kind != TYPE_POINTER)
+        fail_with_error(ptrexpr->location, "value of type %s cannot be indexed", ptrtype.name);
+
+    const Type indextype = typecheck_expression_not_void(ctx, indexexpr);
+    if (!is_integer_type(&indextype)) {
+        fail_with_error(
+            indexexpr->location,
+            "the index inside [...] must be an integer, not %s",
+            indextype.name);
+    }
+
+    return *ptrtype.data.valuetype;
+}
+
+static void typecheck_and_or(
+    const TypeContext *ctx, const AstExpression *lhsexpr, const AstExpression *rhsexpr, const char *and_or)
+{
+    assert(!strcmp(and_or, "and") || !strcmp(and_or, "or"));
+    char errormsg[100];
+    sprintf(errormsg, "'%s' only works with booleans, not FROM", and_or);
+
+    typecheck_expression_with_implicit_cast(ctx, lhsexpr, &boolType, errormsg);
+    typecheck_expression_with_implicit_cast(ctx, rhsexpr, &boolType, errormsg);
+}
+
+static const char *nth(int n)
+{
+    assert(n >= 1);
+
+    const char *first_few[] = { NULL, "first", "second", "third", "fourth", "fifth", "sixth" };
+    if (n < (int)(sizeof(first_few)/sizeof(first_few[0])))
+        return first_few[n];
+
+    static char result[100];
+    sprintf(result, "%dth", n);
+    return result;
+}
+
+// returns NULL if the function doesn't return anything
+static const Type *typecheck_function_call(const TypeContext *ctx, const AstCall *call, Location location)
+{
+    const Signature *sig = find_function(ctx, call->calledname);
+    if (!sig)
+        fail_with_error(location, "function \"%s\" not found", call->calledname);
+    char *sigstr = signature_to_string(sig, false);
+
+    if (call->nargs < sig->nargs || (call->nargs > sig->nargs && !sig->takes_varargs)) {
+        fail_with_error(
+            location,
+            "function %s takes %d argument%s, but it was called with %d argument%s",
+            sigstr,
+            sig->nargs,
+            sig->nargs==1?"":"s",
+            call->nargs,
+            call->nargs==1?"":"s"
+        );
+    }
+
+    for (int i = 0; i < sig->nargs; i++) {
+        // This is a common error, so worth spending some effort to get a good error message.
+        char msg[500];
+        snprintf(msg, sizeof msg, "%s argument of function %s should have type TO, not FROM", nth(i+1), sigstr);
+        typecheck_expression_with_implicit_cast(ctx, &call->args[i], &sig->argtypes[i], msg);
+    }
+    for (int i = sig->nargs; i < call->nargs; i++) {
+        // This code runs for varargs, e.g. the things to format in printf().
+        typecheck_expression_not_void(ctx, &call->args[i]);
+    }
+
+    return sig->returntype;
+}
+
+static Type typecheck_struct_field(
+    const Type *structtype, const char *fieldname, Location location)
+{
+    assert(structtype->kind == TYPE_STRUCT);
+
+    for (int i = 0; i < structtype->data.structfields.count; i++)
+        if (!strcmp(structtype->data.structfields.names[i], fieldname))
+            return structtype->data.structfields.types[i];
+
+    fail_with_error(location, "struct %s has no field named '%s'", structtype->name, fieldname);
+}
+
+static Type typecheck_struct_init(const TypeContext *ctx, const AstCall *call, Location location)
+{
+    struct AstType tmp = { .location = location, .npointers = 0 };
+    safe_strcpy(tmp.name, call->calledname);
+    Type t = type_from_ast(ctx, &tmp);
+
+    if (t.kind != TYPE_STRUCT) {
+        // TODO: test this error. Currently it can never happen because
+        // all non-struct types are created with keywords, and this
+        // function is called only when there is a name token followed
+        // by a '{'.
+        fail_with_error(location, "type %s cannot be instantiated with the Foo{...} syntax", t.name);
+    }
+
+    for (int i = 0; i < call->nargs; i++) {
+        Type fieldtype = typecheck_struct_field(&t, call->argnames[i], call->args[i].location);
+        char msg[1000];
+        snprintf(msg, sizeof msg,
+            "value for field '%s' of struct %s must be of type TO, not FROM",
+            call->argnames[i], call->calledname);
+        typecheck_expression_with_implicit_cast(ctx, &call->args[i], &fieldtype, msg);
+    }
+
+    return t;
+}
+
+const Type *typecheck_expression(const TypeContext *ctx, const AstExpression *expr)
+{
+    Type temptype;
+    Type result;
+
+    switch(expr->kind) {
+    case AST_EXPR_FUNCTION_CALL:
+        {
+            const Type *ret = typecheck_function_call(ctx, &expr->data.call, expr->location);
+            if (!ret)
+                return NULL;
+            result = *ret;
+        }
+        break;
+    case AST_EXPR_BRACE_INIT:
+        result = typecheck_struct_init(ctx, &expr->data.call, expr->location);
+        break;
+    case AST_EXPR_GET_FIELD:
+        temptype = typecheck_expression_not_void(ctx, expr->data.field.obj);
+        if (temptype.kind != TYPE_STRUCT)
+            fail_with_error(
+                expr->location,
+                "left side of the '.' operator must be a struct, not %s",
+                temptype.name);
+        result = typecheck_struct_field(&temptype, expr->data.field.fieldname, expr->location);
+        break;
+    case AST_EXPR_DEREF_AND_GET_FIELD:
+        temptype = typecheck_expression_not_void(ctx, expr->data.field.obj);
+        if (temptype.kind != TYPE_POINTER || temptype.data.valuetype->kind != TYPE_STRUCT)
+            fail_with_error(
+                expr->location,
+                "left side of the '->' operator must be a pointer to a struct, not %s",
+                temptype.name);
+        result = typecheck_struct_field(temptype.data.valuetype, expr->data.field.fieldname, expr->location);
+        break;
+    case AST_EXPR_INDEXING:
+        typecheck_indexing(ctx, &expr->data.operands[0], &expr->data.operands[1]);
+        break;
+    case AST_EXPR_ADDRESS_OF:
+        temptype = typecheck_expression_not_void(ctx, &expr->data.operands[0]);
+        result = create_pointer_type(&temptype, expr->location);
+        break;
+    case AST_EXPR_GET_VARIABLE:
+        result = find_variable(ctx, expr->data.varname, &expr->location)->type;
+        break;
+    case AST_EXPR_DEREFERENCE:
+        temptype = typecheck_expression_not_void(ctx, &expr->data.operands[0]);
+        typecheck_dereferenced_pointer(expr->location, &temptype);
+        result = *temptype.data.valuetype;
+        free(temptype.data.valuetype);
+        break;
+    case AST_EXPR_CONSTANT:
+        result = type_of_constant(&expr->data.constant);
+        break;
+    case AST_EXPR_AND:
+        typecheck_and_or(ctx, &expr->data.operands[0], &expr->data.operands[1], "and");
+        result = boolType;
+        break;
+    case AST_EXPR_OR:
+        typecheck_and_or(ctx, &expr->data.operands[0], &expr->data.operands[1], "or");
+        result = boolType;
+        break;
+    case AST_EXPR_NOT:
+        typecheck_expression_with_implicit_cast(
+            ctx, &expr->data.operands[0], &boolType,
+            "value after 'not' must be a boolean, not FROM");
+        result = boolType;
+        break;
+    case AST_EXPR_ADD:
+    case AST_EXPR_SUB:
+    case AST_EXPR_MUL:
+    case AST_EXPR_DIV:
+    case AST_EXPR_EQ:
+    case AST_EXPR_NE:
+    case AST_EXPR_GT:
+    case AST_EXPR_GE:
+    case AST_EXPR_LT:
+    case AST_EXPR_LE:
+        {
+            Type lhstype = typecheck_expression_not_void(ctx, &expr->data.operands[0]);
+            Type rhstype = typecheck_expression_not_void(ctx, &expr->data.operands[1]);
+            result = typecheck_binop(expr->kind, expr->location, &lhstype, &lhstype);
+            break;
+        }
+    case AST_EXPR_PRE_INCREMENT:
+    case AST_EXPR_PRE_DECREMENT:
+    case AST_EXPR_POST_INCREMENT:
+    case AST_EXPR_POST_DECREMENT:
+        result = typecheck_increment_or_decrement(ctx, expr);
+        break;
+    case AST_EXPR_AS:
+        temptype = typecheck_expression_not_void(ctx, expr->data.as.obj);
+        result = type_from_ast(ctx, &expr->data.as.type);
+        typecheck_explicit_cast(&temptype, &result, expr->location);
+        free_type(&temptype);
+        break;
+    }
+
+    Type *t = malloc(sizeof *t);
+    *t = result;
+    return t;
+}

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -322,7 +322,7 @@ static const char *nth(int n)
     return result;
 }
 
-// returns NULL if the function doesn't return anything
+// returns NULL if the function doesn't return anything, otherwise non-owned pointer to non-owned type
 static const Type *typecheck_function_call(TypeContext *ctx, const AstCall *call, Location location)
 {
     const Signature *sig = find_function(ctx, call->calledname);
@@ -406,7 +406,7 @@ static ExpressionTypes *typecheck_expression(TypeContext *ctx, const AstExpressi
             const Type *ret = typecheck_function_call(ctx, &expr->data.call, expr->location);
             if (!ret)
                 return NULL;
-            result = *ret;
+            result = copy_type(ret);
         }
         break;
     case AST_EXPR_BRACE_INIT:

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -390,6 +390,7 @@ static Type typecheck_struct_init(TypeContext *ctx, const AstCall *call, Locatio
             "value for field '%s' of struct %s must be of type TO, not FROM",
             call->argnames[i], call->calledname);
         typecheck_expression_with_implicit_cast(ctx, &call->args[i], &fieldtype, msg);
+        free_type(&fieldtype);
     }
 
     return t;

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -450,6 +450,7 @@ static ExpressionTypes *typecheck_expression(TypeContext *ctx, const AstExpressi
         free(temptype.data.valuetype);
         break;
     case AST_EXPR_CONSTANT:
+        printf("typecheck Constant %p\n", expr);
         result = type_of_constant(&expr->data.constant);
         break;
     case AST_EXPR_AND:
@@ -497,6 +498,7 @@ static ExpressionTypes *typecheck_expression(TypeContext *ctx, const AstExpressi
     }
 
     ExpressionTypes *types = calloc(1, sizeof *types);
+    Append(&ctx->expr_types, types);
     types->expr = expr;
     types->type = result;
     return types;

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -633,9 +633,11 @@ static void typecheck_statement(TypeContext *ctx, const AstStatement *stmt)
             fail_with_error(stmt->location, "a variable named '%s' already exists", stmt->data.vardecl.name);
 
         Type type = type_from_ast(ctx, &stmt->data.vardecl.type);
-        typecheck_expression_with_implicit_cast(
-            ctx, stmt->data.vardecl.initial_value, &type,
-            "initial value for variable of type TO cannot be of type FROM");
+        if (stmt->data.vardecl.initial_value) {
+            typecheck_expression_with_implicit_cast(
+                ctx, stmt->data.vardecl.initial_value, &type,
+                "initial value for variable of type TO cannot be of type FROM");
+        }
         add_variable(ctx, &type, stmt->data.vardecl.name);
         break;
 

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -269,7 +269,7 @@ static Type check_increment_or_decrement(TypeContext *ctx, const AstExpression *
     Type t = typecheck_expression_not_void(ctx, &expr->data.operands[0])->type;
     if (!is_integer_type(&t) && !is_pointer_type(&t))
         fail_with_error(expr->location, "cannot %s a value of type %s", do_what, t.name);
-    return t;
+    return copy_type(&t);
 }
 
 static void typecheck_dereferenced_pointer(Location location, const Type *t)

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -663,3 +663,26 @@ void typecheck_function(TypeContext *ctx, const Signature *sig, const AstBody *b
         ctx->current_function_signature = NULL;
     }
 }
+
+void reset_type_context(TypeContext *ctx)
+{
+    for (ExpressionTypes **et = ctx->expr_types.ptr; et < End(ctx->expr_types); et++) {
+        free_type(&(*et)->type);
+        if ((*et)->type_after_cast) {
+            free_type((*et)->type_after_cast);
+            free((*et)->type_after_cast);
+        }
+        free(*et);
+    }
+    ctx->expr_types.len = 0;
+    ctx->variables.len = 0;
+}
+
+void destroy_type_context(const TypeContext *ctx)
+{
+    free(ctx->expr_types.ptr);
+    free(ctx->variables.ptr);
+    for (Type *t = ctx->structs.ptr; t < End(ctx->structs); t++)
+        free_type(t);
+    free(ctx->structs.ptr);
+}

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -506,6 +506,7 @@ static ExpressionTypes *typecheck_expression(TypeContext *ctx, const AstExpressi
 static int compare_exprtypes(const void *aptr, const void *bptr)
 {
     const ExpressionTypes *a = aptr, *b = bptr;
+    // Need integers, because comparing pointers to different memory areas is UB.
     uintptr_t aval = (uintptr_t)a->expr;
     uintptr_t bval = (uintptr_t)b->expr;
     return (aval>bval) - (aval<bval);

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -450,7 +450,6 @@ static ExpressionTypes *typecheck_expression(TypeContext *ctx, const AstExpressi
         free(temptype.data.valuetype);
         break;
     case AST_EXPR_CONSTANT:
-        printf("typecheck Constant %p\n", expr);
         result = type_of_constant(&expr->data.constant);
         break;
     case AST_EXPR_AND:

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -30,7 +30,7 @@ static const Signature *find_function(const TypeContext *ctx, const char *name)
     return NULL;
 }
 
-static Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttype)
+Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttype)
 {
     int npointers = asttype->npointers;
     Type t;
@@ -67,7 +67,7 @@ static Type *type_or_void_from_ast(const TypeContext *ctx, const AstType *asttyp
     return ptr;
 }
 
-static Type type_from_ast(const TypeContext *ctx, const AstType *asttype)
+Type type_from_ast(const TypeContext *ctx, const AstType *asttype)
 {
     Type *ptr = type_or_void_from_ast(ctx, asttype);
     if (!ptr)
@@ -646,9 +646,8 @@ static void typecheck_statement(TypeContext *ctx, const AstStatement *stmt)
     }
 }
 
-void typecheck_function(TypeContext *ctx, const Signature *sig, const AstBody *body)
+void typecheck_function(TypeContext *ctx, const AstBody *body)
 {
-    ctx->current_function_signature = sig;
     ctx->expr_types.len = 0;
     typecheck_body(ctx, body);
     qsort(

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -493,7 +493,6 @@ static ExpressionTypes *typecheck_expression(TypeContext *ctx, const AstExpressi
         temptype = typecheck_expression_not_void(ctx, expr->data.as.obj)->type;
         result = type_from_ast(ctx, &expr->data.as.type);
         check_explicit_cast(&temptype, &result, expr->location);
-        free_type(&temptype);
         break;
     }
 

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -364,7 +364,7 @@ static Type typecheck_struct_field(
 
     for (int i = 0; i < structtype->data.structfields.count; i++)
         if (!strcmp(structtype->data.structfields.names[i], fieldname))
-            return structtype->data.structfields.types[i];
+            return copy_type(&structtype->data.structfields.types[i]);
 
     fail_with_error(location, "struct %s has no field named '%s'", structtype->name, fieldname);
 }
@@ -435,6 +435,7 @@ static ExpressionTypes *typecheck_expression(TypeContext *ctx, const AstExpressi
         break;
     case AST_EXPR_ADDRESS_OF:
         temptype = typecheck_expression_not_void(ctx, &expr->data.operands[0])->type;
+        temptype = copy_type(&temptype);
         result = create_pointer_type(&temptype, expr->location);
         break;
     case AST_EXPR_GET_VARIABLE:


### PR DESCRIPTION
Adds quite a lot more code, but will be needed for arrays: `foo[bar]` needs to take the address of the `foo` variable if it's an array, and otherwise it uses the *value* of the variable as the pointer.