### PR TITLE
Use clang to compile the compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ CFLAGS += -Werror=switch -Werror=implicit-function-declaration -Werror=incompati
 CFLAGS += -std=c11
 CFLAGS += -g
 CFLAGS += $(shell $(LLVM_CONFIG) --cflags)
-CFLAGS += -DJOU_CLANG_PATH=$(CC)
 LDFLAGS += $(shell $(LLVM_CONFIG) --ldflags --libs)
 
 obj/%.o: src/%.c $(wildcard src/*.h)

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ LLVM_CONFIG ?= llvm-config-11
 
 SRC := $(wildcard src/*.c)
 
+CC := $(shell $(LLVM_CONFIG) --bindir)/clang
 CFLAGS += -Wall -Wextra -Wpedantic
-CFLAGS += -Werror=switch -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=implicit-fallthrough -Werror=discarded-qualifiers
-CFLAGS += -Wno-format-truncation
+CFLAGS += -Werror=switch -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=implicit-fallthrough
 CFLAGS += -std=c11
 CFLAGS += -g
 CFLAGS += $(shell $(LLVM_CONFIG) --cflags)
-CFLAGS += -DJOU_CLANG_PATH=$(shell $(LLVM_CONFIG) --bindir)/clang
+CFLAGS += -DJOU_CLANG_PATH=$(CC)
 LDFLAGS += $(shell $(LLVM_CONFIG) --ldflags --libs)
 
 obj/%.o: src/%.c $(wildcard src/*.h)

--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -646,7 +646,8 @@ static void build_statement(struct State *st, const AstStatement *stmt)
         const Variable *retvariable = find_variable(st, "return");
         assert(retvariable);
         add_unary_op(st, stmt->location, CF_VARCPY, retvalue, retvariable);
-    }  // fall through
+    }
+    __attribute__((fallthrough));
     case AST_STMT_RETURN_WITHOUT_VALUE:
         st->current_block->iftrue = &st->cfg->end_block;
         st->current_block->iffalse = &st->cfg->end_block;

--- a/src/parse.c
+++ b/src/parse.c
@@ -741,7 +741,7 @@ static AstToplevelNode parse_toplevel_node(const Token **tokens)
             result.data.structdef = parse_structdef(tokens);
             break;
         }
-        // fall through
+        __attribute__((fallthrough));
 
     default:
         fail_with_parse_error(*tokens, "a definition or declaration");

--- a/src/print.c
+++ b/src/print.c
@@ -159,7 +159,7 @@ static void print_ast_expression(const AstExpression *expr, struct TreePrinter t
         break;
     case AST_EXPR_DEREF_AND_GET_FIELD:
         printf("dereference and ");
-        // fall through
+        __attribute__((fallthrough));
     case AST_EXPR_GET_FIELD:
         printf("get field \"%s\"\n", expr->data.field.fieldname);
         print_ast_expression(expr->data.field.obj, print_tree_prefix(tp, true));

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -194,7 +194,7 @@ static char *read_string(struct State *st, char quote, int *len)
             case '0':
                 if (quote == '"')
                     fail_with_error(st->location, "strings cannot contain zero bytes (\\0), because that is the special end marker byte");
-                // fall through
+                __attribute__((fallthrough));
             case '1':
             case '2':
             case '3':


### PR DESCRIPTION
It previously used gcc (actually, whatever the `cc` symlink points to). Using clang makes more sense because we depend on clang anyway.