### PR TITLE
JIT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,7 @@ test: all
 .PHONY: valgrind
 valgrind: all
 	tests/runtests.sh --skip-expected-fails 'valgrind -q --leak-check=full --show-leak-kinds=all --suppressions=valgrind-suppressions.sup ./jou %s'
+
+.PHONY: fulltest
+fulltest: all
+	tests/runtests.sh './jou %s'

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -7,7 +7,9 @@
 #include "util.h"
 
 // don't like repeating "struct" outside this header file
+typedef struct CommandLineFlags CommandLineFlags;
 typedef struct Location Location;
+
 typedef struct Token Token;
 typedef struct Type Type;
 typedef struct Signature Signature;
@@ -36,6 +38,13 @@ typedef struct CfBlock CfBlock;
 typedef struct CfGraph CfGraph;
 typedef struct CfGraphFile CfGraphFile;
 typedef struct CfInstruction CfInstruction;
+
+
+struct CommandLineFlags {
+    bool verbose;  // Whether to print a LOT of debug info
+    bool jit; // Whether to run with LLVM JIT or clang
+    int optlevel;  // Optimization level (0 don't optimize, 3 optimize a lot)
+};
 
 
 struct Location {
@@ -432,8 +441,8 @@ struct CfGraphFile {
 
 
 /*
-The compiling functions, i.e. how to go from source code to LLVM IR.
-Each function's result is fed into the next.
+The compiling functions, i.e. how to go from source code to LLVM IR and
+eventually running the LLVM IR. Each function's result is fed into the next.
 
 Make sure that the filename passed to tokenize() stays alive throughout the
 entire compilation. It is used in error messages.
@@ -443,6 +452,7 @@ AstToplevelNode *parse(const Token *tokens);
 CfGraphFile build_control_flow_graphs(AstToplevelNode *ast);
 void simplify_control_flow_graphs(const CfGraphFile *cfgfile);
 LLVMModuleRef codegen(const CfGraphFile *cfgfile);
+int run_program(LLVMModuleRef module, const CommandLineFlags *flags);
 
 /*
 Use these to clean up return values of compiling functions.

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -452,7 +452,7 @@ AstToplevelNode *parse(const Token *tokens);
 CfGraphFile build_control_flow_graphs(AstToplevelNode *ast);
 void simplify_control_flow_graphs(const CfGraphFile *cfgfile);
 LLVMModuleRef codegen(const CfGraphFile *cfgfile);
-int run_program(LLVMModuleRef module, const CommandLineFlags *flags);
+int run_program(LLVMModuleRef module, const CommandLineFlags *flags);  // destroys the module
 
 /*
 Use these to clean up return values of compiling functions.
@@ -466,7 +466,6 @@ void free_tokens(Token *tokenlist);
 void free_ast(AstToplevelNode *topnodelist);
 void free_control_flow_graphs(const CfGraphFile *cfgfile);
 void free_control_flow_graph_block(const CfGraph *cfg, CfBlock *b);
-// To free LLVM IR, use LLVMDisposeModule
 
 /*
 Functions for printing intermediate data for debugging and exploring the compiler.

--- a/src/main.c
+++ b/src/main.c
@@ -6,77 +6,77 @@
 #include <string.h>
 #include "jou_compiler.h"
 #include <llvm-c/Analysis.h>
+#include <llvm-c/Core.h>
 
-static char TempDir[50];
+static const char usage_fmt[] = "Usage: %s [--help] [--verbose] [--no-jit] [-O0|-O1|-O2|-O3] FILENAME\n";
+static const char long_help[] =
+    "  --help           display this message\n"
+    "  --verbose        display a lot of information about all compilation steps\n"
+    "  --no-jit         compile code to file and run the file (can optimize better)\n"
+    "  -O0/-O1/-O2/-O3  set optimization level (1 = default, 3 = runs fastest)\n"
+    ;
 
-static void cleanup()
+void parse_arguments(int argc, char **argv, CommandLineFlags *flags, const char **filename)
 {
-    char command[200];
-    sprintf(command, "rm -rf '%s'", TempDir);
-    system(command);
-}
+    if (argc < 2)
+        goto usage;
 
-static void make_temp_dir()
-{
-    system("mkdir -p /tmp/jou");
-    strcpy(TempDir, "/tmp/jou/XXXXXX");
-    if (!mkdtemp(TempDir)){
-        fprintf(stderr, "cannot create temporary directory: %s\n", strerror(errno));
-        exit(1);
+    *filename = argv[argc-1];
+    if ((*filename)[0] == '-')
+        goto usage;
+
+    *flags = (CommandLineFlags){ .verbose=false, .jit=true, .optlevel=1 };
+    for (int i = 1; i < argc-1; i++) {
+#define ArgMatches(s) (!strcmp(argv[i], (s)))
+        if (ArgMatches("--help")) {
+            printf(usage_fmt, argv[0]);
+            printf("\n%s\n", long_help);
+            exit(0);
+        } else if (ArgMatches("--verbose"))
+            flags->verbose = true;
+        else if (ArgMatches("--no-jit"))
+            flags->jit = false;
+        else if (ArgMatches("-O0") || ArgMatches("-O1") || ArgMatches("-O2") || ArgMatches("-O3"))
+            flags->optlevel = argv[i][2] - '0';
+        else
+            goto usage;
     }
-    atexit(cleanup);
-}
+    return;
 
-static const char *get_clang_path(void)
-{
-    // Makefile passes e.g. -DJOU_CLANG_PATH=/usr/lib/llvm-11/bin/clang
-    // But retrieving the value is weird...
-#define str(x) #x
-#define str1(x) str(x)
-    return str1(JOU_CLANG_PATH);
-#undef str
-#undef str1
+usage:
+    fprintf(stderr, usage_fmt, argv[0]);
+    exit(2);
 }
 
 int main(int argc, char **argv)
 {
     init_types();
 
-    bool verbose;
+    CommandLineFlags flags;
     const char *filename;
-
-    if (argc == 3 && !strcmp(argv[1], "--verbose")) {
-        verbose = true;
-        filename = argv[2];
-    } else if (argc == 2 && argv[1][0] != '-') {
-        verbose = false;
-        filename = argv[1];
-    } else {
-        fprintf(stderr, "Usage: %s [--verbose] FILENAME\n", argv[0]);
-        return 2;
-    }
+    parse_arguments(argc, argv, &flags, &filename);
 
     Token *tokens = tokenize(filename);
-    if(verbose)
+    if(flags.verbose)
         print_tokens(tokens);
 
     AstToplevelNode *ast = parse(tokens);
     free_tokens(tokens);
-    if(verbose)
+    if(flags.verbose)
         print_ast(ast);
 
     CfGraphFile cfgfile = build_control_flow_graphs(ast);
     free_ast(ast);
-    if(verbose)
+    if(flags.verbose)
         print_control_flow_graphs(&cfgfile);
 
     simplify_control_flow_graphs(&cfgfile);
-    if(verbose)
+    if(flags.verbose)
         print_control_flow_graphs(&cfgfile);
 
     LLVMModuleRef module = codegen(&cfgfile);
     free_control_flow_graphs(&cfgfile);
-    if(verbose)
+    if(flags.verbose)
         print_llvm_ir(module);
 
     /*
@@ -85,23 +85,8 @@ int main(int argc, char **argv)
     */
     LLVMVerifyModule(module, LLVMAbortProcessAction, NULL);
 
-    // TODO: this is a ridiculous way to run the IR, figure out something better
-    make_temp_dir();
-    char irfilename[200];
-    sprintf(irfilename, "%s/ir.bc", TempDir);
-    FILE *f = fopen(irfilename, "wb");
-    assert(f);
-    char *s = LLVMPrintModuleToString(module);
-    fprintf(f, "%s", s);
-    LLVMDisposeMessage(s);
-    fclose(f);
-
+    int ret = run_program(module, &flags);
     LLVMDisposeModule(module);
 
-    char command[2000];
-    snprintf(command, sizeof command, "%s -Wno-override-module -o %s/exe %s/ir.bc && %s/exe",
-        get_clang_path(), TempDir, TempDir, TempDir);
-    if(verbose)
-        puts(command);
-    return !!system(command);
+    return ret;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,12 @@ static const char long_help[] =
     "  -O0/-O1/-O2/-O3  set optimization level (1 = default, 3 = runs fastest)\n"
     ;
 
+static const CommandLineFlags default_flags = {
+    .jit = true,
+    .verbose = false,
+    .optlevel = 1,
+};
+
 void parse_arguments(int argc, char **argv, CommandLineFlags *flags, const char **filename)
 {
     if (argc < 2)
@@ -25,7 +31,7 @@ void parse_arguments(int argc, char **argv, CommandLineFlags *flags, const char 
     if ((*filename)[0] == '-')
         goto usage;
 
-    *flags = (CommandLineFlags){ .verbose=false, .jit=true, .optlevel=1 };
+    *flags = default_flags;
     for (int i = 1; i < argc-1; i++) {
 #define ArgMatches(s) (!strcmp(argv[i], (s)))
         if (ArgMatches("--help")) {

--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,7 @@ static const char usage_fmt[] = "Usage: %s [--help] [--verbose] [--no-jit] [-O0|
 static const char long_help[] =
     "  --help           display this message\n"
     "  --verbose        display a lot of information about all compilation steps\n"
-    "  --no-jit         compile code to file and run the file (can optimize better)\n"
+    "  --no-jit         compile code to file and run the file (can be faster)\n"
     "  -O0/-O1/-O2/-O3  set optimization level (1 = default, 3 = runs fastest)\n"
     ;
 
@@ -85,8 +85,5 @@ int main(int argc, char **argv)
     */
     LLVMVerifyModule(module, LLVMAbortProcessAction, NULL);
 
-    int ret = run_program(module, &flags);
-    LLVMDisposeModule(module);
-
-    return ret;
+    return run_program(module, &flags);
 }

--- a/src/run.c
+++ b/src/run.c
@@ -1,0 +1,105 @@
+#include <errno.h>
+#include <string.h>
+#include "jou_compiler.h"
+#include <llvm-c/Core.h>
+#include <llvm-c/ExecutionEngine.h>
+
+// TODO: this TempDir code is ridiculous
+static char TempDir[50];
+
+static void delete_temp_dir()
+{
+    char command[200];
+    sprintf(command, "rm -rf '%s'", TempDir);
+    system(command);
+}
+
+static void make_temp_dir()
+{
+    system("mkdir -p /tmp/jou");
+    strcpy(TempDir, "/tmp/jou/XXXXXX");
+    if (!mkdtemp(TempDir)){
+        fprintf(stderr, "cannot create temporary directory: %s\n", strerror(errno));
+        exit(1);
+    }
+    atexit(delete_temp_dir);
+}
+
+static const char *get_clang_path(void)
+{
+    // Makefile passes e.g. -DJOU_CLANG_PATH=/usr/lib/llvm-11/bin/clang
+    // But retrieving the value is weird...
+#define str(x) #x
+#define str1(x) str(x)
+    return str1(JOU_CLANG_PATH);
+#undef str
+#undef str1
+}
+
+static int run_main_with_clang(LLVMModuleRef module, const CommandLineFlags *flags)
+{
+    // TODO: this is a bit ridiculous...
+    make_temp_dir();
+
+    char filename[200];
+    sprintf(filename, "%s/ir.bc", TempDir);
+
+    char *errormsg;
+    if (LLVMPrintModuleToFile(module, filename, &errormsg)) {
+        fprintf(stderr, "writing LLVM IR to %s failed: %s\n", filename, errormsg);
+        LLVMDisposeMessage(errormsg);
+    }
+
+    LLVMDisposeModule(module);
+
+    char command[2000];
+    snprintf(command, sizeof command, "%s -O%d -Wno-override-module -o %s/exe %s/ir.bc && %s/exe",
+        get_clang_path(), flags->optlevel, TempDir, TempDir, TempDir);
+    if (flags->verbose)
+        puts(command);
+    return !!system(command);
+}
+
+static int run_main_with_jit(LLVMModuleRef module, const CommandLineFlags *flags)
+{
+    if (LLVMInitializeNativeTarget()) {
+        fprintf(stderr, "LLVMInitializeNativeTarget() failed\n");
+        return 1;
+    }
+
+    // No idea what this function does, but https://stackoverflow.com/a/38801376
+    if (LLVMInitializeNativeAsmPrinter()) {
+        fprintf(stderr, "LLVMInitializeNativeAsmPrinter() failed\n");
+        return 1;
+    }
+
+    LLVMExecutionEngineRef jit;
+    char *errormsg = NULL;
+
+    if (LLVMCreateJITCompilerForModule(&jit, module, flags->optlevel, &errormsg)) {
+        fprintf(stderr, "LLVMCreateJITCompilerForModule() failed: %s\n", errormsg);
+        return 1;
+    }
+    assert(jit);
+    assert(!errormsg);
+
+    LLVMValueRef main = LLVMGetNamedFunction(module, "main");
+    if (!main) {
+        fprintf(stderr, "error: main() function not found\n");
+        return 1;
+    }
+
+    extern char **environ;
+    int result = LLVMRunFunctionAsMain(jit, main, 1, (const char*[]){"jou-program"}, (const char *const*)environ);
+
+    LLVMDisposeExecutionEngine(jit);
+    return result;
+}
+
+int run_program(LLVMModuleRef module, const CommandLineFlags *flags)
+{
+    if (flags->jit)
+        return run_main_with_jit(module, flags);
+    else
+        return run_main_with_clang(module, flags);
+}

--- a/src/run.c
+++ b/src/run.c
@@ -78,7 +78,13 @@ static void optimize(LLVMModuleRef module, int level)
 
 static int run_main_with_jit(LLVMModuleRef module, const CommandLineFlags *flags)
 {
+    if (flags->verbose)
+        printf("Optimizing (level %d)\n", flags->optlevel);
+
     optimize(module, flags->optlevel);
+
+    if (flags->verbose)
+        printf("Initializing JIT\n");
 
     if (LLVMInitializeNativeTarget()) {
         fprintf(stderr, "LLVMInitializeNativeTarget() failed\n");
@@ -108,7 +114,7 @@ static int run_main_with_jit(LLVMModuleRef module, const CommandLineFlags *flags
     }
 
     if (flags->verbose)
-        printf("Running with JIT (optlevel %d)...\n", flags->optlevel);
+        printf("Running with JIT\n\n");
 
     extern char **environ;
     int result = LLVMRunFunctionAsMain(jit, main, 1, (const char*[]){"jou-program"}, (const char *const*)environ);

--- a/src/run.c
+++ b/src/run.c
@@ -1,65 +1,6 @@
-#include <errno.h>
-#include <string.h>
 #include "jou_compiler.h"
-#include <llvm-c/Core.h>
 #include <llvm-c/ExecutionEngine.h>
 #include <llvm-c/Transforms/PassManagerBuilder.h>
-
-// TODO: this TempDir code is ridiculous
-static char TempDir[50];
-
-static void delete_temp_dir()
-{
-    char command[200];
-    sprintf(command, "rm -rf '%s'", TempDir);
-    system(command);
-}
-
-static void make_temp_dir()
-{
-    system("mkdir -p /tmp/jou");
-    strcpy(TempDir, "/tmp/jou/XXXXXX");
-    if (!mkdtemp(TempDir)){
-        fprintf(stderr, "cannot create temporary directory: %s\n", strerror(errno));
-        exit(1);
-    }
-    atexit(delete_temp_dir);
-}
-
-static const char *get_clang_path(void)
-{
-    // Makefile passes e.g. -DJOU_CLANG_PATH=/usr/lib/llvm-11/bin/clang
-    // But retrieving the value is weird...
-#define str(x) #x
-#define str1(x) str(x)
-    return str1(JOU_CLANG_PATH);
-#undef str
-#undef str1
-}
-
-static int run_main_with_clang(LLVMModuleRef module, const CommandLineFlags *flags)
-{
-    // TODO: this is a bit ridiculous...
-    make_temp_dir();
-
-    char filename[200];
-    sprintf(filename, "%s/ir.bc", TempDir);
-
-    char *errormsg;
-    if (LLVMPrintModuleToFile(module, filename, &errormsg)) {
-        fprintf(stderr, "writing LLVM IR to %s failed: %s\n", filename, errormsg);
-        LLVMDisposeMessage(errormsg);
-    }
-
-    LLVMDisposeModule(module);
-
-    char command[2000];
-    snprintf(command, sizeof command, "%s -O%d -Wno-override-module -o %s/exe %s/ir.bc && %s/exe",
-        get_clang_path(), flags->optlevel, TempDir, TempDir, TempDir);
-    if (flags->verbose)
-        puts(command);
-    return !!system(command);
-}
 
 static void optimize(LLVMModuleRef module, int level)
 {
@@ -76,11 +17,10 @@ static void optimize(LLVMModuleRef module, int level)
     LLVMDisposePassManager(pm);
 }
 
-static int run_main_with_jit(LLVMModuleRef module, const CommandLineFlags *flags)
+int run_program(LLVMModuleRef module, const CommandLineFlags *flags)
 {
     if (flags->verbose)
         printf("Optimizing (level %d)\n", flags->optlevel);
-
     optimize(module, flags->optlevel);
 
     if (flags->verbose)
@@ -121,12 +61,4 @@ static int run_main_with_jit(LLVMModuleRef module, const CommandLineFlags *flags
 
     LLVMDisposeExecutionEngine(jit);
     return result;
-}
-
-int run_program(LLVMModuleRef module, const CommandLineFlags *flags)
-{
-    if (flags->jit)
-        return run_main_with_jit(module, flags);
-    else
-        return run_main_with_clang(module, flags);
 }

--- a/src/run.c
+++ b/src/run.c
@@ -8,6 +8,10 @@ static void optimize(LLVMModuleRef module, int level)
 
     LLVMPassManagerRef pm = LLVMCreatePassManager();
 
+    /*
+    The default settings should be fine for Jou because they work well for
+    C and C++, and Jou is quite similar to C.
+    */
     LLVMPassManagerBuilderRef pmbuilder = LLVMPassManagerBuilderCreate();
     LLVMPassManagerBuilderSetOptLevel(pmbuilder, level);
     LLVMPassManagerBuilderPopulateModulePassManager(pmbuilder, pm);


### PR DESCRIPTION
Todo:
- [x] remove `--no-jit` option and clang code (turns out JIT is as fast as clang, at least for a primitive fib benchmark)
- [ ] print optimized LLVM IR, would be curious to see it... :)
- [x] run tests with different optimization levels (except tests that are intentionally a bit UB)
- [x] fix the `--help` option
- [ ] refactor / cleanup

Maybe I will split this PR into two: one PR to add the JIT and another to add command-line optimization options and such.