### PR TITLE
Do not rely on argv[0] to locate the executable

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -248,15 +248,9 @@ static char *find_stdlib()
     char *exe = find_this_executable();
     const char *exedir = dirname(exe);
 
-    char *path;
-    if (!strcmp(exedir, ".")) {
-        // ./stdlib looks a bit ugly in error messages and debug output IMO
-        path = strdup("stdlib");
-    } else {
-        path = malloc(strlen(exedir) + 10);
-        strcpy(path, exedir);
-        strcat(path, "/stdlib");
-    }
+    char *path = malloc(strlen(exedir) + 10);
+    strcpy(path, exedir);
+    strcat(path, "/stdlib");
     free(exe);
 
     char *iojou = malloc(strlen(path) + 10);

--- a/tests/404/file.jou
+++ b/tests/404/file.jou
@@ -1,1 +1,1 @@
-from "stdlib/foobar.jou" import x  # Error: cannot import from "stdlib/foobar.jou": No such file or directory
+from "stdlib/foobar.jou" import x  # Error: cannot import from "<joudir>/stdlib/foobar.jou": No such file or directory

--- a/tests/404/import_symbol.jou
+++ b/tests/404/import_symbol.jou
@@ -1,1 +1,1 @@
-from "stdlib/io.jou" import asd  # Error: file "stdlib/io.jou" does not contain a function named 'asd'
+from "stdlib/io.jou" import asd  # Error: file "<joudir>/stdlib/io.jou" does not contain a function named 'asd'

--- a/tests/404/import_symbol_multiline.jou
+++ b/tests/404/import_symbol_multiline.jou
@@ -2,6 +2,6 @@
 from "stdlib/io.jou" import (
     printf,
     scanf,
-    asd,  # Error: file "stdlib/io.jou" does not contain a function named 'asd'
+    asd,  # Error: file "<joudir>/stdlib/io.jou" does not contain a function named 'asd'
     puts,
 )

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -55,8 +55,9 @@ function post_process_output()
         # mentions "Segmentation fault" somewhere inside it.
         grep -oE "Segmentation fault|Exit code: .*"
     else
-        # Pass the output through unchanged.
-        cat
+        # Pass the output through almost unchanged, but replace
+        # path to the project (e.g. /home/akuli/jou) with <joudir>.
+        sed "s,$(pwd),<joudir>,g"
     fi
 }
 

--- a/tests/should_succeed/compiler_cli.jou
+++ b/tests/should_succeed/compiler_cli.jou
@@ -27,8 +27,8 @@ def main() -> int:
 
     # With optimizations enabled, we see also the optimized LLVM IR.
     system("./jou --verbose -O1 examples/hello.jou | grep 'LLVM IR for file'")
-    # Output: ===== Unoptimized LLVM IR for file "stdlib/io.jou" =====
-    # Output: ===== Optimized LLVM IR for file "stdlib/io.jou" =====
+    # Output: ===== Unoptimized LLVM IR for file "<joudir>/stdlib/io.jou" =====
+    # Output: ===== Optimized LLVM IR for file "<joudir>/stdlib/io.jou" =====
     # Output: ===== Unoptimized LLVM IR for file "examples/hello.jou" =====
     # Output: ===== Optimized LLVM IR for file "examples/hello.jou" =====
 
@@ -37,6 +37,6 @@ def main() -> int:
 
     # Executable in weird place
     system("cp jou tmp/tests/jou_executable")
-    system("tmp/tests/jou_executable 2>&1")  # Output: error: cannot find the Jou standard library in tmp/tests/stdlib
+    system("tmp/tests/jou_executable 2>&1")  # Output: error: cannot find the Jou standard library in <joudir>/tmp/tests/stdlib
 
     return 0


### PR DESCRIPTION
Fixes #118 