### PR TITLE
Move some logic from release.yml to windows.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           ).data.artifacts;
           console.log(`Found ${allArtifacts.length} artifacts`);
           console.log(allArtifacts.map(a => a.name));
-          const artifact = allArtifacts.filter(a => a.name === 'exe-and-dlls')[0];
+          const artifact = allArtifacts.filter(a => a.name === 'windows-zip')[0];
 
           const zip = await github.rest.actions.downloadArtifact({
               owner: context.repo.owner,
@@ -65,22 +65,19 @@ jobs:
           });
 
           // https://stackoverflow.com/a/46779188
-          fs.writeFileSync("exe-and-dlls.zip", Buffer.from(zip.data));
+          fs.writeFileSync("nested-zip-file.zip", Buffer.from(zip.data));
 
-    # TODO: Ideally the zip file would already contain everything it
-    # needs, and we wouldn't need this step at all.
+    # We get a zip file inside a zip file:
+    #   * Inner zip file: The build creates a releasing-ready zip file. This is
+    #     good because you can test the zip file before Jou is released.
+    #   * Outer zip file: It is possible to include multiple files to the same
+    #     GitHub Actions artifact. We only need to include one file, which is
+    #     the zip file that contains everything you need to run Jou.
     - if: ${{ steps.tagname.outputs.datetag != '' }}
-      name: Create the zip file
-      run: |
-        unzip exe-and-dlls.zip
-        ls -l
-        mkdir -v jou
-        cp -v jou.exe jou
-        cp -v *.dll jou
-        cp -rv stdlib jou
-        cp -rv mingw64 jou
-        cp -v update.ps1 jou
-        zip -r jou_windows_64bit_${{ steps.tagname.outputs.datetag }}.zip jou
+      run: unzip nested-zip-file.zip
+
+    - if: ${{ steps.tagname.outputs.datetag != '' }}
+      run: mv jou.zip jou_windows_64bit_${{ steps.tagname.outputs.datetag }}.zip
 
     - if: ${{ steps.tagname.outputs.datetag != '' }}
       name: Create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,8 @@ jobs:
     #   * Inner zip file: The build creates a releasing-ready zip file. This is
     #     good because you can test the zip file before Jou is released.
     #   * Outer zip file: It is possible to include multiple files to the same
-    #     GitHub Actions artifact. We only need to include one file, which is
-    #     the zip file that contains everything you need to run Jou.
+    #     GitHub Actions artifact, and downloadArtifact() gives a zip of all
+    #     files that the artifact consists of.
     - if: ${{ steps.tagname.outputs.datetag != '' }}
       run: unzip nested-zip-file.zip
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -114,10 +114,15 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: windows-zip
+          path: repo
       - run: unzip jou.zip
-      - run: mv jou/jou.exe jou/*.dll .
+      - name: Rearrange files
         shell: bash
-      - run: .\jou.exe --verbose examples/hello.jou
+        run: |
+          mv jou/* .
+          mv repo/tests .
+          mv repo/runtests.sh .
+      - run: .\jou.exe --verbose repo/examples/hello.jou
       - run: ./runtests.sh
         shell: bash
 
@@ -129,8 +134,13 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: windows-zip
+          path: repo
       - run: unzip jou.zip
-      - run: mv jou/jou.exe jou/*.dll .
+      - name: Rearrange files
         shell: bash
+        run: |
+          mv jou/* .
+          mv repo/tests .
+          mv repo/runtests.sh .
       - run: ./fuzzer.sh
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -116,9 +116,10 @@ jobs:
           name: windows-zip
       - run: unzip jou.zip
       - run: mv jou.zip/jou.exe jou.zip/*.dll .
+        shell: bash
       - run: .\jou.exe --verbose examples/hello.jou
-      - shell: bash
-        run: ./runtests.sh
+      - run: ./runtests.sh
+        shell: bash
 
   fuzzer:
     needs: build
@@ -130,5 +131,5 @@ jobs:
           name: windows-zip
       - run: unzip jou.zip
       - run: mv jou.zip/jou.exe jou.zip/*.dll .
-      - shell: bash
-        run: ./fuzzer.sh
+      - run: ./fuzzer.sh
+        shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,12 +89,13 @@ jobs:
       # Using gcc instead of clang, because gcc "just works".
       - run: sudo apt install -y llvm-13-dev gcc-mingw-w64-x86-64-win32
       - run: CC=x86_64-w64-mingw32-gcc LDFLAGS=lib/LLVM-C.lib make
-      - run: mkdir exe-and-dlls
-      - run: cp -rv jou.exe mingw64 bin/*.dll exe-and-dlls/
+      - run: mkdir jou
+      - run: cp -rv jou.exe bin/*.dll stdlib mingw64 update.ps1 jou
+      - run: zip -r jou.zip jou
       - uses: actions/upload-artifact@v3
         with:
-          name: exe-and-dlls
-          path: exe-and-dlls
+          name: windows-zip
+          path: jou.zip
 
   codeblocks-project:
     # Ensure that the codeblocks project contains all source files.
@@ -112,7 +113,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
-          name: exe-and-dlls
+          name: windows-zip
+      - run: unzip jou.zip
+      - run: mv jou.zip/jou.exe jou.zip/*.dll .
       - run: .\jou.exe --verbose examples/hello.jou
       - shell: bash
         run: ./runtests.sh
@@ -124,6 +127,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
-          name: exe-and-dlls
+          name: windows-zip
+      - run: unzip jou.zip
+      - run: mv jou.zip/jou.exe jou.zip/*.dll .
       - shell: bash
         run: ./fuzzer.sh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -117,13 +117,9 @@ jobs:
         with:
           name: windows-zip
       - run: unzip jou.zip
-      - name: Rearrange files
+      - run: mv jou/* repo/tests repo/runtests.sh repo/examples .
         shell: bash
-        run: |
-          mv jou/* .
-          mv repo/tests .
-          mv repo/runtests.sh .
-      - run: .\jou.exe --verbose repo/examples/hello.jou
+      - run: .\jou.exe --verbose examples/hello.jou
       - run: ./runtests.sh
         shell: bash
 
@@ -138,11 +134,7 @@ jobs:
         with:
           name: windows-zip
       - run: unzip jou.zip
-      - name: Rearrange files
+      - run: mv jou/* repo/tests repo/fuzzer.sh .
         shell: bash
-        run: |
-          mv jou/* .
-          mv repo/tests .
-          mv repo/runtests.sh .
       - run: ./fuzzer.sh
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,6 +90,7 @@ jobs:
       - run: sudo apt install -y llvm-13-dev gcc-mingw-w64-x86-64-win32
       - run: CC=x86_64-w64-mingw32-gcc LDFLAGS=lib/LLVM-C.lib make
       - run: mkdir jou
+      # Please keep this list of files in sync with update.ps1
       - run: cp -rv jou.exe bin/*.dll stdlib mingw64 update.ps1 jou
       - run: zip -r jou.zip jou
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           name: windows-zip
       - run: unzip jou.zip
-      - run: mv jou.zip/jou.exe jou.zip/*.dll .
+      - run: mv jou/jou.exe jou/*.dll .
         shell: bash
       - run: .\jou.exe --verbose examples/hello.jou
       - run: ./runtests.sh
@@ -130,7 +130,7 @@ jobs:
         with:
           name: windows-zip
       - run: unzip jou.zip
-      - run: mv jou.zip/jou.exe jou.zip/*.dll .
+      - run: mv jou/jou.exe jou/*.dll .
         shell: bash
       - run: ./fuzzer.sh
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -111,10 +111,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: repo
       - uses: actions/download-artifact@v3
         with:
           name: windows-zip
-          path: repo
       - run: unzip jou.zip
       - name: Rearrange files
         shell: bash
@@ -131,10 +132,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: repo
       - uses: actions/download-artifact@v3
         with:
           name: windows-zip
-          path: repo
       - run: unzip jou.zip
       - name: Rearrange files
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -131,5 +131,6 @@ jobs:
           name: windows-zip
       - run: unzip jou.zip
       - run: mv jou.zip/jou.exe jou.zip/*.dll .
+        shell: bash
       - run: ./fuzzer.sh
         shell: bash

--- a/fuzzer.sh
+++ b/fuzzer.sh
@@ -39,7 +39,8 @@ while [ $(date +%s) -lt $end ]; do
             if [ "$CI" = "true" ]; then
                 echo ""
                 echo "For CI environments and such, here's a hexdump of $file:"
-                hexdump -C $file
+                # git bash on windows doesn't have hexdump, but has od which can also output hex
+                od -t x1 $file | cut -s -d' ' -f2-
             fi
             exit 1
         fi

--- a/fuzzer.sh
+++ b/fuzzer.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -e -o pipefail
 
-if ! [[ "$OS" =~ Windows ]]; then
+if [[ "$OS" =~ Windows ]]; then
+    jouexe="./jou.exe"
+else
     make
+    jouexe="./jou"
 fi
 
 rm -rf tmp/fuzzer
@@ -22,7 +25,7 @@ while [ $(date +%s) -lt $end ]; do
     #cat tests/*/*.jou | shuf -n 10 | rev > tmp/fuzzer/input3.jou
 
     for file in tmp/fuzzer/input*.jou; do
-        (bash -c "./jou $file 2>&1" || true) | tr -d '\r' > tmp/fuzzer/log.txt
+        (bash -c "$jouexe $file 2>&1" || true) | tr -d '\r' > tmp/fuzzer/log.txt
 
         # One-line compiler error message made up of printable ASCII chars = good
         # https://unix.stackexchange.com/a/194538
@@ -35,7 +38,7 @@ while [ $(date +%s) -lt $end ]; do
             echo ""
             echo "*** found a possible bug ***"
             echo ""
-            echo "To reproduce, run:  ./jou $file"
+            echo "To reproduce, run:  $jouexe $file"
             if [ "$CI" = "true" ]; then
                 echo ""
                 echo "For CI environments and such, here's a hexdump of $file:"


### PR DESCRIPTION
CONTRIBUTING.md explains the main reason why this is a good idea. It could also make GitHub Actions faster, because currently it spends a lot of time uploading and downloading many small files that will now be zipped.