### PR TITLE
oct number support

### DIFF
--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -150,11 +150,15 @@ static long long parse_integer(const char *str, Location location, int nbits)
         digits = &str[2];
         valid_digits = "01";
     } else if (str[0] == '0' && str[1] == 'o') {
-        // 0o777
+        // 0o777 = octal number
         base = 8;
         digits = &str[2];
-        valid_digits = "1234567";
+        valid_digits = "01234567";
+    } else if (str[0] == '0' && str[1] != '\0') {
+        // wrong syntax like 0777
+        fail_with_error(location, "unnecessary zero at start of number");
     } else {
+        // default decimal umber
         base = 10;
         digits = &str[0];
         valid_digits = "0123456789";

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -149,9 +149,11 @@ static long long parse_integer(const char *str, Location location, int nbits)
         base = 2;
         digits = &str[2];
         valid_digits = "01";
-    } else if (str[0] == '0' && str[1] != '\0') {
-        // 0777 in C actually means 511. Jou does not allow writing 0777.
-        fail_with_error(location, "unnecessary zero at start of number");
+    } else if (str[0] == '0' && str[1] == 'o') {
+        // 0o777
+        base = 8;
+        digits = &str[2];
+        valid_digits = "1234567";
     } else {
         base = 10;
         digits = &str[0];

--- a/tests/should_succeed/octalnuber.jou
+++ b/tests/should_succeed/octalnuber.jou
@@ -1,7 +1,7 @@
 from "stdlib/io.jou" import printf
 
 def main()-> int:
-    printf("%d", 0o777) # Should be 511
-    printf("%d", 0o337522) # Should be 114514
-    printf("%d", 0o7244314) # Should be 1919180
+    printf("%d\n", 0o777) # Output: 511
+    printf("%d\n", 0o337522) # Output: 114514
+    printf("%d\n", 0o7244314) # Output: 1919180
     return 0

--- a/tests/should_succeed/octalnuber.jou
+++ b/tests/should_succeed/octalnuber.jou
@@ -1,7 +1,7 @@
 from "stdlib/io.jou" import printf
 
 def main()-> int:
-    printf("%d\n", 0o777) # Output: 511
-    printf("%d\n", 0o337522) # Output: 114514
-    printf("%d\n", 0o7244314) # Output: 1919180
+    printf("%d", 0o777) # Should be 511
+    printf("%d", 0o337522) # Should be 114514
+    printf("%d", 0o7244314) # Should be 1919180
     return 0

--- a/tests/should_succeed/octalnuber.jou
+++ b/tests/should_succeed/octalnuber.jou
@@ -1,0 +1,7 @@
+from "stdlib/io.jou" import printf
+
+def main()-> int:
+    printf("%d", 0o777) # Should be 511
+    printf("%d", 0o337522) # Should be 114514
+    printf("%d", 0o7244314) # Should be 1919180
+    return 0


### PR DESCRIPTION
Syntax:
octnumber = 0oxxxxx
Test:
```python
from "stdlib/io.jou" import printf

def main()-> int:
    octnumber = 0o777 # Should be 511
    printf("%d", octnumber)
    return 0
```