### PR TITLE
Fix importing methods

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -340,6 +340,12 @@ static void add_imported_symbol(struct FileState *fs, const ExportSymbol *es, As
     }
 }
 
+static bool exportsymbol_matches_import(const ExportSymbol *es, const AstImport *imp)
+{
+    // Method bar in struct Foo appears as a function with name "Foo.bar". Match it when importing Foo.
+    return !strcmp(es->name, imp->symbolname) || (strlen(es->name) > strlen(imp->symbolname) && es->name[strlen(imp->symbolname)] == '.');
+}
+
 static void add_imported_symbols(struct CompileState *compst)
 {
     // TODO: should it be possible for a file to import from itself?
@@ -351,7 +357,7 @@ static void add_imported_symbols(struct CompileState *compst)
             assert(from);
 
             for (struct ExportSymbol *es = from->pending_exports; es->name[0]; es++) {
-                if (!strcmp(imp->symbolname, es->name)) {
+                if (exportsymbol_matches_import(es, imp)) {
                     if (compst->flags.verbose) {
                         const char *kindstr;
                         switch(es->kind) {

--- a/tests/should_succeed/imported/bar.jou
+++ b/tests/should_succeed/imported/bar.jou
@@ -6,6 +6,9 @@ struct Point:
     x: int
     y: int
 
+    def get_sum(self: Point) -> int:
+        return self.x + self.y
+
 enum FooBar:
     Foo
     Bar

--- a/tests/should_succeed/imported/bar.jou
+++ b/tests/should_succeed/imported/bar.jou
@@ -9,6 +9,9 @@ struct Point:
     def get_sum(self: Point) -> int:
         return self.x + self.y
 
+    def increment_y(self: Point*) -> void:
+        self->y += 1
+
 enum FooBar:
     Foo
     Bar

--- a/tests/should_succeed/local_import.jou
+++ b/tests/should_succeed/local_import.jou
@@ -2,7 +2,9 @@ from "stdlib/io.jou" import printf
 from "./imported/bar.jou" import bar, Point, FooBar
 
 def main() -> int:
-    bar(Point{x=1, y=2})  # Output: Bar Bar 1 2
+    p = Point{x=1, y=2}
+    bar(p)  # Output: Bar Bar 1 2
+    printf("%d\n", p.get_sum())  # Output: 3
 
     foo = FooBar::Foo
     if foo == FooBar::Foo:

--- a/tests/should_succeed/local_import.jou
+++ b/tests/should_succeed/local_import.jou
@@ -3,8 +3,9 @@ from "./imported/bar.jou" import bar, Point, FooBar
 
 def main() -> int:
     p = Point{x=1, y=2}
-    bar(p)  # Output: Bar Bar 1 2
     printf("%d\n", p.get_sum())  # Output: 3
+    (&p).increment_y()
+    bar(p)  # Output: Bar Bar 1 3
 
     foo = FooBar::Foo
     if foo == FooBar::Foo:


### PR DESCRIPTION
Previously, importing a struct wouldn't imports methods defined in the struct. Now that works.