### PR TITLE
Improve self-hosted tokenizer

### DIFF
--- a/self_hosted/parses_wrong.txt
+++ b/self_hosted/parses_wrong.txt
@@ -83,15 +83,12 @@ tests/should_succeed/class.jou
 tests/should_succeed/undefined_value_warning.jou
 tests/should_succeed/unreachable_warning.jou
 tests/should_succeed/unused_import.jou
-tests/syntax_error/0b2.jou
-tests/syntax_error/2bad.jou
 tests/syntax_error/and_or_chaining.jou
 tests/syntax_error/array_size.jou
 tests/syntax_error/bad_addressof.jou
 tests/syntax_error/bad_array.jou
 tests/syntax_error/bad_byte.jou
 tests/syntax_error/bad_field.jou
-tests/syntax_error/bin.jou
 tests/syntax_error/chained_eq.jou
 tests/syntax_error/chained_le.jou
 tests/syntax_error/dot_after_e.jou
@@ -99,8 +96,6 @@ tests/syntax_error/double_assignment.jou
 tests/syntax_error/double_not.jou
 tests/syntax_error/double_with_letters_after.jou
 tests/syntax_error/ee.jou
-tests/syntax_error/float.jou
-tests/syntax_error/hex.jou
 tests/syntax_error/import_after_def.jou
 tests/syntax_error/import_missing_comma.jou
 tests/syntax_error/import_missing_comma_with_parens.jou
@@ -111,7 +106,6 @@ tests/syntax_error/infinite_c_style_for.jou
 tests/syntax_error/mismatched_close_brace.jou
 tests/syntax_error/missing_field_names.jou
 tests/syntax_error/missing_import_keyword.jou
-tests/syntax_error/missing_number_after_e.jou
 tests/syntax_error/missing_number_after_eminus.jou
 tests/syntax_error/missing_second_equal_sign.jou
 tests/syntax_error/multidot_float.jou
@@ -120,9 +114,6 @@ tests/syntax_error/class_init_js_syntax.jou
 tests/syntax_error/too_many_closing_parens.jou
 tests/syntax_error/too_many_opening_parens.jou
 tests/syntax_error/triple_equals.jou
-tests/syntax_error/unnecessary_zero.jou
-tests/too_long/int.jou
-tests/too_long/long.jou
 tests/too_long/name.jou
 tests/too_long/nested_parentheses.jou
 tests/wrong_type/arg.jou
@@ -169,3 +160,4 @@ stdlib/str.jou
 stdlib/_windows_startup.jou
 tests/other_errors/method_on_ptr_called_on_class.jou
 tests/syntax_error/self_outside_class.jou
+tests/should_succeed/int_literals.jou

--- a/self_hosted/parses_wrong.txt
+++ b/self_hosted/parses_wrong.txt
@@ -103,7 +103,6 @@ tests/syntax_error/import_missing_dot.jou
 tests/syntax_error/import_missing_quotes.jou
 tests/syntax_error/indexing.jou
 tests/syntax_error/infinite_c_style_for.jou
-tests/syntax_error/mismatched_close_brace.jou
 tests/syntax_error/missing_field_names.jou
 tests/syntax_error/missing_import_keyword.jou
 tests/syntax_error/missing_number_after_eminus.jou
@@ -111,11 +110,8 @@ tests/syntax_error/missing_second_equal_sign.jou
 tests/syntax_error/multidot_float.jou
 tests/syntax_error/python_style_for.jou
 tests/syntax_error/class_init_js_syntax.jou
-tests/syntax_error/too_many_closing_parens.jou
-tests/syntax_error/too_many_opening_parens.jou
 tests/syntax_error/triple_equals.jou
 tests/too_long/name.jou
-tests/too_long/nested_parentheses.jou
 tests/wrong_type/arg.jou
 tests/wrong_type/array_mixed_types.jou
 tests/wrong_type/array_mixed_types_ptr.jou

--- a/self_hosted/token.jou
+++ b/self_hosted/token.jou
@@ -82,6 +82,12 @@ class Token:
     def is_operator(self, op: byte*) -> bool:
         return self->kind == TokenKind::Operator and strcmp(&self->short_string[0], op) == 0
 
+    def is_open_paren(self) -> bool:
+        return self->is_operator("(") or self->is_operator("[") or self->is_operator("{")
+
+    def is_close_paren(self) -> bool:
+        return self->is_operator(")") or self->is_operator("]") or self->is_operator("}")
+
     def fail_expected_got(self, what_was_expected_instead: byte*) -> void:
         got: byte[100]
         if self->kind == TokenKind::Int:

--- a/self_hosted/tokenizer.jou
+++ b/self_hosted/tokenizer.jou
@@ -101,6 +101,22 @@ def parse_integer(string: byte*, location: Location, nbits: int) -> long:
 
     return result
 
+def flip_paren(c: byte) -> byte:
+    if c == '(':
+        return ')'
+    if c == ')':
+        return '('
+    if c == '[':
+        return ']'
+    if c == ']':
+        return '['
+    if c == '{':
+        return '}'
+    if c == '}':
+        return '{'
+    assert(False)
+    return 'x'  # never actually runs, but silences compiler warning
+
 
 class Tokenizer:
     f: FILE*
@@ -110,8 +126,8 @@ class Tokenizer:
     # Parens array isn't dynamic, so that you can't segfault
     # the compiler by feeding it lots of nested parentheses,
     # which would make it recurse too deep.
-    parens: Token[50]
-    parens_len: int
+    open_parens: Token[50]
+    open_parens_len: int
 
     def read_byte(self) -> byte:
         EOF = -1  # FIXME
@@ -347,6 +363,29 @@ class Tokenizer:
         fail(self->location, &message[0])
         return operator  # TODO: never actually runs, but causes a compiler warning
 
+    def handle_parentheses(self, token: Token*) -> void:
+        if token->kind == TokenKind::EndOfFile and self->open_parens_len > 0:
+            open_token = self->open_parens[0]
+            actual_open = open_token.short_string[0]
+            expected_close = flip_paren(actual_open)
+
+            message = malloc(100)
+            sprintf(message, "'%c' without a matching '%c'", actual_open, expected_close)
+            fail(open_token.location, message)
+
+        if token->is_open_paren():
+            if self->open_parens_len == sizeof self->open_parens / sizeof self->open_parens[0]:
+                fail(token->location, "too many nested parentheses")
+            self->open_parens[self->open_parens_len++] = *token
+
+        if token->is_close_paren():
+            actual_close = token->short_string[0]
+            expected_open = flip_paren(actual_close)
+            if self->open_parens_len == 0 or self->open_parens[--self->open_parens_len].short_string[0] != expected_open:
+                message = malloc(100)
+                sprintf(message, "'%c' without a matching '%c'", actual_close, expected_open)
+                fail(token->location, message)
+
     def read_token(self) -> Token:
         while True:
             token = Token{location = self->location}
@@ -359,7 +398,7 @@ class Tokenizer:
                 continue
 
             if b == '\n':
-                if self->parens_len > 0:
+                if self->open_parens_len > 0:
                     continue
                 token.kind = TokenKind::Newline
                 token.indentation_level = self->read_newline_token()
@@ -393,6 +432,8 @@ class Tokenizer:
                 message: byte[100]
                 sprintf(&message[0], "unexpected byte %#02x", b)
                 fail(self->location, &message[0])
+
+            self->handle_parentheses(&token)
             return token
 
 

--- a/self_hosted/tokenizer.jou
+++ b/self_hosted/tokenizer.jou
@@ -81,7 +81,7 @@ def parse_integer(string: byte*, location: Location, nbits: int) -> long:
             digit_value = digits[i] - '0'
 
         # Overflow isn't UB in Jou
-        if result * base < 0:
+        if (result * base) / base != result:
             overflow = True
             break
         result *= base

--- a/self_hosted/tokenizer.jou
+++ b/self_hosted/tokenizer.jou
@@ -1,11 +1,10 @@
 from "stdlib/io.jou" import printf, FILE, fgetc, ferror, fopen
-from "stdlib/str.jou" import sprintf, strlen, strchr, strcmp, starts_with
+from "stdlib/str.jou" import sprintf, strlen, strchr, strcmp, strspn, starts_with
 from "stdlib/mem.jou" import malloc, realloc, free, memset, memmove
 from "./errors_and_warnings.jou" import Location, fail, assert
 from "./token.jou" import Token, TokenKind
 
 # TODO: move these to stdlib
-declare atoi(s: byte*) -> int
 declare isprint(b: int) -> int
 
 def is_identifier_or_number_byte(b: byte) -> bool:
@@ -37,6 +36,70 @@ def is_keyword(word: byte*) -> bool:
         if strcmp(keywords[i], word) == 0:
             return True
     return False
+
+def parse_integer(string: byte*, location: Location, nbits: int) -> long:
+    if starts_with(string, "0b"):
+        base = 2
+        digits = &string[2]
+        valid_digits = "01"
+    elif starts_with(string, "0o"):
+        base = 8
+        digits = &string[2]
+        valid_digits = "01234567"
+    elif starts_with(string, "0x"):
+        base = 16
+        digits = &string[2]
+        valid_digits = "0123456789ABCDEFabcdef"
+    elif starts_with(string, "0") and strlen(string) >= 2:
+        # wrong syntax like 0777
+        fail(location, "unnecessary zero at start of number")
+        # silence compiler warnings... this code can never actually run
+        base = 0
+        digits = ""
+        valid_digits = ""
+    else:
+        # default decimal number
+        base = 10
+        digits = string
+        valid_digits = "0123456789"
+
+    if strlen(digits) == 0 or strspn(digits, valid_digits) != strlen(digits):
+        message = malloc(strlen(string) + 100)
+        sprintf(message, "invalid number or variable name \"%s\"", string)
+        fail(location, message)
+
+    # We can't use strtoll() or similar, because there's not yet a way to check errno.
+    # We would need it to check for overflow.
+    result = 0L
+    overflow = False
+    for i = 0; i < strlen(digits); i++:
+        if 'A' <= digits[i] and digits[i] <= 'F':
+            digit_value = 10 + (digits[i] - 'A')
+        elif 'a' <= digits[i] and digits[i] <= 'f':
+            digit_value = 10 + (digits[i] - 'a')
+        else:
+            digit_value = digits[i] - '0'
+
+        # Overflow isn't UB in Jou
+        if result * base < 0:
+            overflow = True
+            break
+        result *= base
+        if result + digit_value < 0:
+            overflow = True
+            break
+        result += digit_value
+
+    assert(nbits == 32 or nbits == 64)
+    if nbits == 32 and (result as int) != result:
+        overflow = True
+
+    if overflow:
+        message = malloc(100)
+        sprintf(message, "value does not fit in a signed %d-bit integer", nbits)
+        fail(location, message)
+
+    return result
 
 
 class Tokenizer:
@@ -311,9 +374,13 @@ class Tokenizer:
                 if is_keyword(&token.short_string[0]):
                     token.kind = TokenKind::Keyword
                 elif '0' <= token.short_string[0] and token.short_string[0] <= '9':
-                    # TODO: support various other things
-                    token.kind = TokenKind::Int
-                    token.int_value = atoi(&token.short_string[0])
+                    if token.short_string[strlen(&token.short_string[0]) - 1] == 'L':
+                        token.short_string[strlen(&token.short_string[0]) - 1] = '\0'
+                        token.kind = TokenKind::Long
+                        token.long_value = parse_integer(&token.short_string[0], token.location, 64)
+                    else:
+                        token.kind = TokenKind::Int
+                        token.int_value = parse_integer(&token.short_string[0], token.location, 32) as int
                 else:
                     token.kind = TokenKind::Name
             elif is_operator_byte(b):

--- a/self_hosted/tokenizes_wrong.txt
+++ b/self_hosted/tokenizes_wrong.txt
@@ -1,24 +1,16 @@
 # This is a list of files that are not yet supported by the tokenizer of the self-hosted compiler.
 examples/x11_window.jou
-tests/syntax_error/hex.jou
 tests/syntax_error/double_with_letters_after.jou
 tests/syntax_error/dot_after_e.jou
-tests/syntax_error/unnecessary_zero.jou
-tests/syntax_error/bin.jou
 tests/syntax_error/triple_equals.jou
-tests/syntax_error/2bad.jou
 tests/syntax_error/multidot_float.jou
-tests/syntax_error/0b2.jou
 tests/syntax_error/ee.jou
 tests/syntax_error/bad_byte.jou
 tests/syntax_error/too_many_closing_parens.jou
 tests/syntax_error/mismatched_close_brace.jou
 tests/syntax_error/missing_number_after_eminus.jou
-tests/syntax_error/missing_number_after_e.jou
-tests/syntax_error/float.jou
 tests/syntax_error/too_many_opening_parens.jou
 tests/wrong_type/float_and_double.jou
-tests/should_succeed/octalnuber.jou
 tests/should_succeed/add_sub_mul_div_mod.jou
 tests/should_succeed/printf.jou
 tests/should_succeed/mathlibtest.jou
@@ -29,7 +21,5 @@ tests/should_succeed/as.jou
 tests/should_succeed/unused_import.jou
 tests/should_succeed/array.jou
 tests/404/import_symbol_multiline.jou
-tests/too_long/long.jou
 tests/too_long/nested_parentheses.jou
 tests/too_long/name.jou
-tests/too_long/int.jou

--- a/self_hosted/tokenizes_wrong.txt
+++ b/self_hosted/tokenizes_wrong.txt
@@ -1,25 +1,16 @@
 # This is a list of files that are not yet supported by the tokenizer of the self-hosted compiler.
-examples/x11_window.jou
 tests/syntax_error/double_with_letters_after.jou
 tests/syntax_error/dot_after_e.jou
 tests/syntax_error/triple_equals.jou
 tests/syntax_error/multidot_float.jou
 tests/syntax_error/ee.jou
 tests/syntax_error/bad_byte.jou
-tests/syntax_error/too_many_closing_parens.jou
-tests/syntax_error/mismatched_close_brace.jou
 tests/syntax_error/missing_number_after_eminus.jou
-tests/syntax_error/too_many_opening_parens.jou
 tests/wrong_type/float_and_double.jou
 tests/should_succeed/add_sub_mul_div_mod.jou
 tests/should_succeed/printf.jou
 tests/should_succeed/mathlibtest.jou
-tests/should_succeed/file.jou
 tests/should_succeed/expfloat.jou
 tests/should_succeed/implicit_conversions.jou
 tests/should_succeed/as.jou
-tests/should_succeed/unused_import.jou
-tests/should_succeed/array.jou
-tests/404/import_symbol_multiline.jou
-tests/too_long/nested_parentheses.jou
 tests/too_long/name.jou

--- a/stdlib/str.jou
+++ b/stdlib/str.jou
@@ -34,6 +34,9 @@ def ends_with(s: byte*, suffix: byte*) -> bool:
     offset = strlen(s) - strlen(suffix)
     return offset >= 0 and strcmp(&s[offset], suffix) == 0
 
+# Return how many bytes at start of s appear in the accept string.
+declare strspn(s: byte*, accept: byte*) -> long
+
 # Copy a string. Assumes it fits. Returned value is dest.
 declare strcpy(dest: byte*, source: byte*) -> byte*
 

--- a/tests/should_succeed/int_literals.jou
+++ b/tests/should_succeed/int_literals.jou
@@ -1,0 +1,16 @@
+from "stdlib/io.jou" import printf
+
+def main()-> int:
+    # binary
+    printf("%d\n", 0b11111100111)  # Output: 2023
+    printf("%lld\n", 0b110110110100110110100101111011001101100111000111011101010L)  # Output: 123456789876543210
+
+    # octal
+    printf("%d\n", 0o777) # Output: 511
+    printf("%lld\n", 0o6664664573154707352L) # Output: 123456789876543210
+
+    # hex
+    printf("%d\n", 0xCafe012)  # Output: 212852754
+    printf("%lld\n", 0x1b69b4bd9b38eeaL)  # Output: 123456789876543210
+
+    return 0

--- a/tests/should_succeed/octalnuber.jou
+++ b/tests/should_succeed/octalnuber.jou
@@ -1,7 +1,0 @@
-from "stdlib/io.jou" import printf
-
-def main()-> int:
-    printf("%d\n", 0o777) # Output: 511
-    printf("%d\n", 0o337522) # Output: 114514
-    printf("%d\n", 0o7244314) # Output: 1919180
-    return 0


### PR DESCRIPTION
- Parse ints and longs in all supported bases (binary, octal, decimal, hex)
- Support space-ignoring mode (see syntax docs)
- Emit good error messages for mismatched parentheses