### PR TITLE
Fix compiler crash when trying to use the return value of a '-> void' method

### DIFF
--- a/self_hosted/parses_wrong.txt
+++ b/self_hosted/parses_wrong.txt
@@ -156,3 +156,4 @@ stdlib/_windows_startup.jou
 tests/other_errors/method_on_ptr_called_on_class.jou
 tests/syntax_error/self_outside_class.jou
 tests/should_succeed/int_literals.jou
+tests/other_errors/using_void_method.jou

--- a/self_hosted/runs_wrong.txt
+++ b/self_hosted/runs_wrong.txt
@@ -162,3 +162,4 @@ tests/wrong_type/pointer_eq.jou
 tests/wrong_type/var_assignment.jou
 tests/wrong_type/void_main.jou
 tests/wrong_type/while.jou
+tests/other_errors/using_void_method.jou

--- a/tests/other_errors/using_void_function.jou
+++ b/tests/other_errors/using_void_function.jou
@@ -1,5 +1,7 @@
-def f() -> void:
-    return
+class Foo:
+    def f(self) -> void:
+        return
 
 def g() -> void:
-    x = f() + 123  # Error: function 'f' does not return a value
+    foo = Foo{}
+    x = foo.f() + 123  # Error: method 'f' does not return a value

--- a/tests/other_errors/using_void_function.jou
+++ b/tests/other_errors/using_void_function.jou
@@ -1,7 +1,5 @@
-class Foo:
-    def f(self) -> void:
-        return
+def f() -> void:
+    return
 
 def g() -> void:
-    foo = Foo{}
-    x = foo.f() + 123  # Error: method 'f' does not return a value
+    x = f() + 123  # Error: function 'f' does not return a value

--- a/tests/other_errors/using_void_method.jou
+++ b/tests/other_errors/using_void_method.jou
@@ -1,0 +1,5 @@
+def f() -> void:
+    return
+
+def g() -> void:
+    x = f() + 123  # Error: function 'f' does not return a value

--- a/tests/other_errors/using_void_method.jou
+++ b/tests/other_errors/using_void_method.jou
@@ -1,5 +1,7 @@
-def f() -> void:
-    return
+class Foo:
+    def f(self) -> void:
+        return
 
 def g() -> void:
-    x = f() + 123  # Error: function 'f' does not return a value
+    foo = Foo{}
+    x = foo.f() + 123  # Error: method 'f' does not return a value


### PR DESCRIPTION
There was already a nice error message for functions. I changed it to do the same thing for methods.