### PR TITLE
Test the produced zip files in GitHub Actions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,6 +61,24 @@ jobs:
       - run: cd "test dir" && source activate && ./runtests.sh --verbose
         shell: bash
 
+  test-zip:
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: repo
+      - uses: actions/download-artifact@v3
+        with:
+          name: windows-zip
+      - run: unzip jou.zip
+      - run: cp -r repo/tests repo/runtests.sh jou
+        shell: bash
+      - run: cd jou && ./jou.exe --verbose examples/hello.jou
+        shell: bash
+      - run: cd jou && ./runtests.sh --verbose
+        shell: bash
+
   compare-compilers:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -76,7 +76,7 @@ jobs:
         shell: bash
       - run: cd jou && ./jou.exe --verbose examples/hello.jou
         shell: bash
-      - run: cd jou && ./runtests.sh --verbose
+      - run: cd jou && ./runtests.sh --dont-run-make --verbose
         shell: bash
 
   compare-compilers:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           name: windows-zip
       - run: unzip jou.zip
-      - run: cp -r repo/tests repo/runtests.sh repo/activate jou
+      - run: cp -r repo/tests repo/runtests.sh jou
         shell: bash
       - run: cd jou && ./jou.exe --verbose examples/hello.jou
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,7 +62,7 @@ jobs:
         shell: bash
 
   test-zip:
-    needs: build
+    needs: build-zip
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           name: windows-zip
       - run: unzip jou.zip
-      - run: cp -r repo/tests repo/runtests.sh jou
+      - run: cp -r repo/tests repo/runtests.sh repo/activate jou
         shell: bash
       - run: cd jou && ./jou.exe --verbose examples/hello.jou
         shell: bash

--- a/runtests.sh
+++ b/runtests.sh
@@ -12,18 +12,20 @@ export LANG=C  # "Segmentation fault" must be in english for this script to work
 set -e -o pipefail
 
 function usage() {
-    echo "Usage: $0 [--valgrind] [--verbose] [TEMPLATE]" >&2
+    echo "Usage: $0 [--valgrind] [--verbose] [--dont-run-make] [TEMPLATE]" >&2
     echo "TEMPLATE can be e.g. './jou %s', where %s will be replaced by a jou file." >&2
     exit 2
 }
 
 valgrind=no
 verbose=no
+run_make=yes
 
 while [[ "$1" =~ ^- ]]; do
     case "$1" in
         --valgrind) valgrind=yes; shift ;;
         --verbose) verbose=yes; shift ;;
+        --dont-run-make) run_make=no; shift ;;
         *) usage ;;
     esac
 done
@@ -45,11 +47,13 @@ if [ $valgrind = yes ]; then
     command_template="valgrind -q --leak-check=full --show-leak-kinds=all --suppressions=valgrind-suppressions.sup $command_template"
 fi
 
-if [[ "$OS" =~ Windows ]]; then
-    source activate
-    mingw32-make
-else
-    make
+if [ $run_make = yes ]; then
+    if [[ "$OS" =~ Windows ]]; then
+        source activate
+        mingw32-make
+    else
+        make
+    fi
 fi
 
 rm -rf tmp/tests


### PR DESCRIPTION
I changed how Windows builds work in #293, and the generated `.zip` files are no longer tested: if they don't work for whatever reason, I probably wouldn't notice it until a user complains. This PR adds a test to improve the situation.