### PR TITLE
Fix running ./runtests.sh locally

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -147,7 +147,7 @@ function run_test()
     #   * the test is supposed to crash, but optimizations are enabled (unpredictable by design)
     #   * the test is supposed to fail (crash or otherwise) and we use valgrind (see README)
     #   * the "test" is actually a GUI program in examples/
-    if ( [[ "$command_template" =~ -O[1-3] ]] && [[ $joufile =~ ^tests/crash/ ]] ) \
+    if ( ! [[ "$command_template" =~ -O0 ]] && [[ $joufile =~ ^tests/crash/ ]] ) \
         || ( [[ "$command_template" =~ valgrind ]] && [ $correct_exit_code != 0 ] ) \
         || [ $joufile = examples/x11_window.jou ]
     then


### PR DESCRIPTION
Since #240 one test has failed if you run `./runtests.sh`. Not caught in github actions, because the bug didn't occur if you pass in an optimize flag explicitly like github does (only the default was changed in #240)