### PR TITLE
compare_compilers.sh improvements

### DIFF
--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -93,12 +93,6 @@ for action in tokenize parse run; do
     (./jou $flag $file || true) &> tmp/compare_compilers/compiler_written_in_c.txt
     (./self_hosted_compiler $flag $file || true) &> tmp/compare_compilers/self_hosted.txt
 
-    if grep -q $'\r' $error_list_file; then
-        newline=crlf
-    else
-        newline=lf
-    fi
-
     if grep -qxF $file <(cat $error_list_file | tr -d '\r'); then
         # The file is skipped, so the two compilers should behave differently
         if diff tmp/compare_compilers/compiler_written_in_c.txt tmp/compare_compilers/self_hosted.txt >/dev/null; then

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -4,6 +4,8 @@
 # They should be able to tokenize and parse each Jou file in exactly the same way.
 # If tokenizing/parsing a Jou file fails, both compilers should fail with the same error message.
 
+set -e
+
 if [ "$1" = --fix ]; then
     fix=yes
     shift
@@ -29,10 +31,47 @@ else
     make
 fi
 
-set -e
-
 rm -rf tmp/compare_compilers
 mkdir -vp tmp/compare_compilers
+
+function append_line()
+{
+    local file="$1"
+    local line="$2"
+    echo "  Adding $line to $file"
+
+    if [ grep -q $'\r' $error_list_file ]; then
+        # CRLF line endings (Windows, but also depends on git settings)
+        printf "%s\r\n" "$line" >> "$file"
+    else
+        printf "%s\n" "$line" >> "$file"
+    fi
+}
+
+function remove_line()
+{
+    local file="$1"
+    local line="$2"
+    echo "  Deleting $line from $file"
+    # Filter out the line regardless of whether it has CRLF or LF after it
+    cat "$file" | grep -vxF "$line" | grep -vxF "$line"$'\r' > tmp/compare_compilers/newlist.txt
+    mv tmp/compare_compilers/newlist.txt "$file"
+}
+
+for error_list_file in self_hosted/*s_wrong.txt; do
+    echo "Checking that all files mentioned in $error_list_file exist..."
+    for line in $(grep -v '^#' $error_list_file); do
+        if ! [ -f $line ]; then
+            if [ $fix = yes ]; then
+                remove_line $error_list_file $line
+            else
+                echo "  Error: $error_list_file mentions file \"$line\" which does not exist."
+                echo "  To fix this error, delete the \"$line\" line from $error_list_file (or run again with --fix)."
+                exit 1
+            fi
+        fi
+    done
+done
 
 echo "Compiling the self-hosted compiler..."
 if [[ "$OS" =~ Windows ]]; then
@@ -64,9 +103,7 @@ for action in tokenize parse run; do
         # The file is skipped, so the two compilers should behave differently
         if diff tmp/compare_compilers/compiler_written_in_c.txt tmp/compare_compilers/self_hosted.txt >/dev/null; then
             if [ $fix = yes ]; then
-                echo "  Deleting $file from $error_list_file"
-                grep -vxF $file <(cat $error_list_file | tr -d '\r') > tmp/compare_compilers/newlist.txt
-                mv tmp/compare_compilers/newlist.txt $error_list_file
+                delete_line $error_list_file $file
             else
                 echo "  Error: Compilers behave the same even though the file is listed in $error_list_file."
                 echo "  To fix this error, delete the \"$file\" line from $error_list_file (or run again with --fix)."
@@ -80,8 +117,7 @@ for action in tokenize parse run; do
             echo "  Compilers behave the same as expected"
         else
             if [ $fix = yes ]; then
-                echo "  Adding $file to $error_list_file"
-                echo $file >> $error_list_file
+                append_line $error_list_file $file
             else
                 echo "  Error: Compilers behave differently when given \"$file\"."
                 echo "  Ideally the compilers would behave in the same way for all files, but we aren't there yet."
@@ -89,11 +125,6 @@ for action in tokenize parse run; do
                 exit 1
             fi
         fi
-    fi
-
-    if [ $newline = crlf ] && [ $fix = yes ]; then
-        # Some of the edits (e.g. appending with echo) leave LF line endings
-        unix2dos -q $error_list_file
     fi
 done
 done

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -60,7 +60,7 @@ function remove_line()
 
 for error_list_file in self_hosted/*s_wrong.txt; do
     echo "Checking that all files mentioned in $error_list_file exist..."
-    for line in $(grep -v '^#' $error_list_file); do
+    for line in $(cat $error_list_file | tr -d '\r' | grep -v '^#'); do
         if ! [ -f $line ]; then
             if [ $fix = yes ]; then
                 remove_line $error_list_file $line

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -41,7 +41,7 @@ function append_line()
     echo "  Adding $line to $file"
 
     if [ grep -q $'\r' $error_list_file ]; then
-        # CRLF line endings (Windows, but also depends on git settings)
+        # CRLF line endings (likely Windows, but depends on git settings)
         printf "%s\r\n" "$line" >> "$file"
     else
         printf "%s\n" "$line" >> "$file"

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -54,7 +54,7 @@ for action in tokenize parse run; do
     (./jou $flag $file || true) &> tmp/compare_compilers/compiler_written_in_c.txt
     (./self_hosted_compiler $flag $file || true) &> tmp/compare_compilers/self_hosted.txt
 
-    if grep -q '\r' $error_list_file; then
+    if grep -q $'\r' $error_list_file; then
         newline=crlf
     else
         newline=lf

--- a/self_hosted/parses_wrong.txt
+++ b/self_hosted/parses_wrong.txt
@@ -2,11 +2,7 @@
 examples/x11_window.jou
 tests/404/enum.jou
 tests/404/enum_member.jou
-tests/404/import_symbol_multiline.jou
 tests/404/method_on_int.jou
-tests/404/method_on_int_ptr.jou
-tests/404/method_on_ptr_called_on_class.jou
-tests/404/method_on_class_called_on_ptr.jou
 tests/404/method_on_class.jou
 tests/404/method_on_class_ptr.jou
 tests/404/class_field.jou
@@ -21,7 +17,6 @@ tests/other_errors/array0.jou
 tests/other_errors/brace_init_dupe.jou
 tests/other_errors/duplicate_arg_name.jou
 tests/other_errors/duplicate_enum_member.jou
-tests/other_errors/duplicate_field_name.jou
 tests/other_errors/dynamic_array_length.jou
 tests/other_errors/immediate_member_assign.jou
 tests/other_errors/imported_error.jou
@@ -42,7 +37,6 @@ tests/should_succeed/imported/cycle.jou
 tests/should_succeed/local_import.jou
 tests/should_succeed/mathlibtest.jou
 tests/should_succeed/method.jou
-tests/should_succeed/octalnuber.jou
 tests/should_succeed/plusplus_minusminus.jou
 tests/should_succeed/pointer.jou
 tests/should_succeed/printf.jou
@@ -62,13 +56,10 @@ tests/syntax_error/dot_after_e.jou
 tests/syntax_error/double_with_letters_after.jou
 tests/syntax_error/ee.jou
 tests/syntax_error/import_after_def.jou
-tests/syntax_error/import_missing_comma.jou
-tests/syntax_error/import_missing_comma_with_parens.jou
 tests/syntax_error/import_missing_dot.jou
 tests/syntax_error/import_missing_quotes.jou
 tests/syntax_error/indexing.jou
 tests/syntax_error/missing_field_names.jou
-tests/syntax_error/missing_import_keyword.jou
 tests/syntax_error/missing_number_after_eminus.jou
 tests/syntax_error/multidot_float.jou
 tests/syntax_error/class_init_js_syntax.jou

--- a/self_hosted/parses_wrong.txt
+++ b/self_hosted/parses_wrong.txt
@@ -2,6 +2,7 @@
 examples/x11_window.jou
 tests/404/enum.jou
 tests/404/enum_member.jou
+tests/404/import_symbol_multiline.jou
 tests/404/method_on_int.jou
 tests/404/method_on_class.jou
 tests/404/method_on_class_ptr.jou
@@ -56,10 +57,13 @@ tests/syntax_error/dot_after_e.jou
 tests/syntax_error/double_with_letters_after.jou
 tests/syntax_error/ee.jou
 tests/syntax_error/import_after_def.jou
+tests/syntax_error/import_missing_comma.jou
+tests/syntax_error/import_missing_comma_with_parens.jou
 tests/syntax_error/import_missing_dot.jou
 tests/syntax_error/import_missing_quotes.jou
 tests/syntax_error/indexing.jou
 tests/syntax_error/missing_field_names.jou
+tests/syntax_error/missing_import_keyword.jou
 tests/syntax_error/missing_number_after_eminus.jou
 tests/syntax_error/multidot_float.jou
 tests/syntax_error/class_init_js_syntax.jou
@@ -99,7 +103,3 @@ tests/already_exists_error/class_field.jou
 tests/already_exists_error/method.jou
 tests/should_succeed/imported/point_factory.jou
 tests/should_succeed/indirect_method_import.jou
-tests/404/import_symbol_multiline.jou
-tests/syntax_error/import_missing_comma.jou
-tests/syntax_error/import_missing_comma_with_parens.jou
-tests/syntax_error/missing_import_keyword.jou

--- a/self_hosted/parses_wrong.txt
+++ b/self_hosted/parses_wrong.txt
@@ -99,3 +99,7 @@ tests/already_exists_error/class_field.jou
 tests/already_exists_error/method.jou
 tests/should_succeed/imported/point_factory.jou
 tests/should_succeed/indirect_method_import.jou
+tests/404/import_symbol_multiline.jou
+tests/syntax_error/import_missing_comma.jou
+tests/syntax_error/import_missing_comma_with_parens.jou
+tests/syntax_error/missing_import_keyword.jou

--- a/self_hosted/runs_wrong.txt
+++ b/self_hosted/runs_wrong.txt
@@ -12,6 +12,8 @@ tests/404/class_field.jou
 tests/404/enum.jou
 tests/404/enum_member.jou
 tests/404/file.jou
+tests/404/import_symbol.jou
+tests/404/import_symbol_multiline.jou
 tests/404/method_on_class.jou
 tests/404/method_on_class_ptr.jou
 tests/404/method_on_int.jou
@@ -99,10 +101,13 @@ tests/syntax_error/dot_after_e.jou
 tests/syntax_error/double_with_letters_after.jou
 tests/syntax_error/ee.jou
 tests/syntax_error/import_after_def.jou
+tests/syntax_error/import_missing_comma.jou
+tests/syntax_error/import_missing_comma_with_parens.jou
 tests/syntax_error/import_missing_dot.jou
 tests/syntax_error/import_missing_quotes.jou
 tests/syntax_error/indexing.jou
 tests/syntax_error/missing_field_names.jou
+tests/syntax_error/missing_import_keyword.jou
 tests/syntax_error/missing_number_after_eminus.jou
 tests/syntax_error/multidot_float.jou
 tests/syntax_error/self_outside_class.jou
@@ -150,8 +155,3 @@ tests/already_exists_error/class_field.jou
 tests/already_exists_error/method.jou
 tests/should_succeed/imported/point_factory.jou
 tests/should_succeed/indirect_method_import.jou
-tests/404/import_symbol.jou
-tests/404/import_symbol_multiline.jou
-tests/syntax_error/import_missing_comma.jou
-tests/syntax_error/import_missing_comma_with_parens.jou
-tests/syntax_error/missing_import_keyword.jou

--- a/self_hosted/runs_wrong.txt
+++ b/self_hosted/runs_wrong.txt
@@ -150,3 +150,8 @@ tests/already_exists_error/class_field.jou
 tests/already_exists_error/method.jou
 tests/should_succeed/imported/point_factory.jou
 tests/should_succeed/indirect_method_import.jou
+tests/404/import_symbol.jou
+tests/404/import_symbol_multiline.jou
+tests/syntax_error/import_missing_comma.jou
+tests/syntax_error/import_missing_comma_with_parens.jou
+tests/syntax_error/missing_import_keyword.jou

--- a/self_hosted/runs_wrong.txt
+++ b/self_hosted/runs_wrong.txt
@@ -12,8 +12,6 @@ tests/404/class_field.jou
 tests/404/enum.jou
 tests/404/enum_member.jou
 tests/404/file.jou
-tests/404/import_symbol.jou
-tests/404/import_symbol_multiline.jou
 tests/404/method_on_class.jou
 tests/404/method_on_class_ptr.jou
 tests/404/method_on_int.jou
@@ -40,7 +38,6 @@ tests/other_errors/dumb_assignment.jou
 tests/other_errors/dumb_assignment_with_plusequals.jou
 tests/other_errors/duplicate_arg_name.jou
 tests/other_errors/duplicate_enum_member.jou
-tests/other_errors/duplicate_field_name.jou
 tests/other_errors/dynamic_array_length.jou
 tests/other_errors/immediate_member_assign.jou
 tests/other_errors/imported_error.jou
@@ -102,13 +99,10 @@ tests/syntax_error/dot_after_e.jou
 tests/syntax_error/double_with_letters_after.jou
 tests/syntax_error/ee.jou
 tests/syntax_error/import_after_def.jou
-tests/syntax_error/import_missing_comma.jou
-tests/syntax_error/import_missing_comma_with_parens.jou
 tests/syntax_error/import_missing_dot.jou
 tests/syntax_error/import_missing_quotes.jou
 tests/syntax_error/indexing.jou
 tests/syntax_error/missing_field_names.jou
-tests/syntax_error/missing_import_keyword.jou
 tests/syntax_error/missing_number_after_eminus.jou
 tests/syntax_error/multidot_float.jou
 tests/syntax_error/self_outside_class.jou


### PR DESCRIPTION
- Fix CRLF problems on Linux (and on Windows, if your git config doesn't have autocrlf enabled)
- Complain if error list files mention nonexistent files (also works with `--fix`)
- Move `set -e` where it belongs, so that errors in argument handling will not be ignored