### PR TITLE
compare_compilers.sh improvements

### DIFF
--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -38,7 +38,7 @@ function append_line()
     local line="$2"
     echo -e "  ${YELLOW}Adding $line to $file${RESET}"
 
-    if [ grep -q $'\r' $error_list_file ]; then
+    if grep -q $'\r' $error_list_file; then
         # CRLF line endings (likely Windows, but depends on git settings)
         printf "%s\r\n" "$line" >> "$file"
     else

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -34,11 +34,16 @@ fi
 rm -rf tmp/compare_compilers
 mkdir -vp tmp/compare_compilers
 
+YELLOW="\x1b[33m"
+GREEN="\x1b[32m"
+RED="\x1b[31m"
+RESET="\x1b[0m"
+
 function append_line()
 {
     local file="$1"
     local line="$2"
-    echo "  Adding $line to $file"
+    echo -e "  ${YELLOW}Adding $line to $file${RESET}"
 
     if [ grep -q $'\r' $error_list_file ]; then
         # CRLF line endings (likely Windows, but depends on git settings)
@@ -52,7 +57,7 @@ function remove_line()
 {
     local file="$1"
     local line="$2"
-    echo "  Deleting $line from $file"
+    echo -e "  ${GREEN}Deleting $line from $file${RESET}"
     # Filter out the line regardless of whether it has CRLF or LF after it
     cat "$file" | grep -vxF "$line" | grep -vxF "$line"$'\r' > tmp/compare_compilers/newlist.txt
     mv tmp/compare_compilers/newlist.txt "$file"
@@ -65,7 +70,7 @@ for error_list_file in self_hosted/*s_wrong.txt; do
             if [ $fix = yes ]; then
                 remove_line $error_list_file $line
             else
-                echo "  Error: $error_list_file mentions file \"$line\" which does not exist."
+                echo -e "  ${RED}Error: $error_list_file mentions file \"$line\" which does not exist.${RESET}"
                 echo "  To fix this error, delete the \"$line\" line from $error_list_file (or run again with --fix)."
                 exit 1
             fi
@@ -99,7 +104,7 @@ for action in tokenize parse run; do
             if [ $fix = yes ]; then
                 remove_line $error_list_file $file
             else
-                echo "  Error: Compilers behave the same even though the file is listed in $error_list_file."
+                echo -e "  ${RED}Error: Compilers behave the same even though the file is listed in $error_list_file.${RESET}"
                 echo "  To fix this error, delete the \"$file\" line from $error_list_file (or run again with --fix)."
                 exit 1
             fi
@@ -113,7 +118,7 @@ for action in tokenize parse run; do
             if [ $fix = yes ]; then
                 append_line $error_list_file $file
             else
-                echo "  Error: Compilers behave differently when given \"$file\"."
+                echo -e "  ${RED}Error: Compilers behave differently when given \"$file\".${RESET}"
                 echo "  Ideally the compilers would behave in the same way for all files, but we aren't there yet."
                 echo "  To silence this error, add \"$file\" to $error_list_file (or run again with --fix)."
                 exit 1
@@ -125,4 +130,4 @@ done
 
 echo ""
 echo ""
-echo "success :)"
+echo -e "${GREEN}success :)${RESET}"

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -21,7 +21,7 @@ for arg in "$@"; do
 done
 
 if [ ${#files[@]} = 0 ]; then
-    files=$(find stdlib examples tests -name '*.jou' | sort)
+    files=( $(find stdlib examples tests -name '*.jou' | sort) )
 fi
 
 rm -rf tmp/compare_compilers

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -50,7 +50,7 @@ function remove_line()
 {
     local file="$1"
     local line="$2"
-    echo -e "  ${GREEN}Deleting $line from $file${RESET}"
+    echo -e "  ${YELLOW}Deleting $line from $file${RESET}"
     # Filter out the line regardless of whether it has CRLF or LF after it
     cat "$file" | grep -vxF "$line" | grep -vxF "$line"$'\r' > tmp/compare_compilers/newlist.txt
     mv tmp/compare_compilers/newlist.txt "$file"

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -22,8 +22,6 @@ done
 
 if [ ${#files[@]} = 0 ]; then
     files=$(find stdlib examples tests -name '*.jou' | sort)
-else
-    files=$*
 fi
 
 rm -rf tmp/compare_compilers

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -6,22 +6,20 @@
 
 set -e
 
-if [ "$1" = --fix ]; then
-    fix=yes
-    shift
-else
-    fix=no
-fi
+files=()
+for arg in "$@"; do
+    if [ "$arg" = --fix ]; then
+        fix=yes
+    elif [[ "$arg" =~ ^- ]]; then
+        echo "Usage: $0 [--fix] [FILENAME1.jou FILENAME2.jou ...]" >&2
+        exit 2
+    else
+        files+=($arg)
+    fi
+done
 
-if [[ "$1" =~ ^- ]]; then
-    echo "Usage: $0 [--fix] [FILENAME1.jou FILENAME2.jou ...]" >&2
-    exit 2
-fi
-
-if [ $# = 0 ]; then
+if [ ${#files[@]} = 0 ]; then
     files=$(find stdlib examples tests -name '*.jou' | sort)
-else
-    files=$@
 fi
 
 rm -rf tmp/compare_compilers
@@ -78,7 +76,7 @@ else
     make self_hosted_compiler
 fi
 
-for file in $files; do
+for file in ${files[@]}; do
 for action in tokenize parse run; do
     echo "$action $file"
     error_list_file=self_hosted/${action}s_wrong.txt

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -7,6 +7,8 @@
 set -e
 
 files=()
+fix=no
+
 for arg in "$@"; do
     if [ "$arg" = --fix ]; then
         fix=yes

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -24,13 +24,6 @@ else
     files=$@
 fi
 
-if [[ "$OS" =~ Windows ]]; then
-    source activate
-    mingw32-make
-else
-    make
-fi
-
 rm -rf tmp/compare_compilers
 mkdir -vp tmp/compare_compilers
 

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -21,7 +21,7 @@ for arg in "$@"; do
 done
 
 if [ ${#files[@]} = 0 ]; then
-    files=( $(find stdlib examples tests -name '*.jou' | sort) )
+    mapfile -t files < <( find stdlib examples tests -name '*.jou' | sort )
 fi
 
 rm -rf tmp/compare_compilers


### PR DESCRIPTION
- Accept `--fix` anywhere, not only as the first argument
- Don't run `make` twice. It is enough to compile the self-hosted compiler, that will also compiler the compiler written in C if necessary.
- Print some output lines with color. Don't color everything, so you can spot the unusual/colorful lines easily.
- ~Fix CRLF detection in `append_line` function~