### PR TITLE
Add shellcheck

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: shellcheck -s bash -e SC2086,SC2059,SC2046,SC2235,SC2002,SC2206,SC2068 *.sh activate
+      - run: shellcheck --color=always --shell=bash --exclude=SC2086,SC2059,SC2046,SC2235,SC2002,SC2206,SC2068 *.sh activate
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt install -y shellcheck
       - run: shellcheck -s bash -e SC2086,SC2059,SC2046,SC2235,SC2002,SC2206,SC2068 *.sh activate
 
   test:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           commit_message: "Change files to use LF line endings"
 
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt install -y shellcheck
+      - run: shellcheck -s bash -e SC2086,SC2059,SC2046,SC2235,SC2002,SC2206,SC2068 *.sh activate
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -21,7 +21,7 @@ fi
 if [ $# = 0 ]; then
     files=$(find stdlib examples tests -name '*.jou' | sort)
 else
-    files=$@
+    files=$*
 fi
 
 if [[ "$OS" =~ Windows ]]; then
@@ -40,7 +40,7 @@ function append_line()
     local line="$2"
     echo "  Adding $line to $file"
 
-    if [ grep -q $'\r' $error_list_file ]; then
+    if grep -q $'\r' $error_list_file; then
         # CRLF line endings (likely Windows, but depends on git settings)
         printf "%s\r\n" "$line" >> "$file"
     else

--- a/runtests.sh
+++ b/runtests.sh
@@ -139,10 +139,8 @@ function run_test()
     local correct_exit_code="$2"
     local counter="$3"
 
-    local command diffpath
-    command="$(printf "$command_template" $joufile)"
-    diffpath=tmp/tests/diff$(printf "%04d" $counter).txt  # consistent alphabetical order
-
+    local command="$(printf "$command_template" $joufile)"
+    local diffpath=tmp/tests/diff$(printf "%04d" $counter).txt  # consistent alphabetical order
     printf "\n\n\x1b[33m*** Command: %s ***\x1b[0m\n\n" "$command" > $diffpath
 
     # Skip tests when:

--- a/runtests.sh
+++ b/runtests.sh
@@ -139,8 +139,10 @@ function run_test()
     local correct_exit_code="$2"
     local counter="$3"
 
-    local command="$(printf "$command_template" $joufile)"
-    local diffpath=tmp/tests/diff$(printf "%04d" $counter).txt  # consistent alphabetical order
+    local command diffpath
+    command="$(printf "$command_template" $joufile)"
+    diffpath=tmp/tests/diff$(printf "%04d" $counter).txt  # consistent alphabetical order
+
     printf "\n\n\x1b[33m*** Command: %s ***\x1b[0m\n\n" "$command" > $diffpath
 
     # Skip tests when:


### PR DESCRIPTION
There are many bash scripts :)

There's a lot of excludes in the shellcheck command, because in this repo I prefer to *not* handle whitespaces in file paths properly. All paths are relative to the repository, and the repository itself doesn't contain file paths with spaces, for example.

Also fixes the CRLF detection bug mentioned in #322. I originally discovered it without shellcheck though.