### PR TITLE
Change union codegen to be aligned properly

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -18,7 +18,7 @@ My first idea was to use an array of bytes that is big enough to fit anything.
 However, that might not be aligned properly.
 
 Then I tried choosing the member type that has the biggest align, and making a large enough array of it.
-Because the align is always a power of two, the memory was be suitably aligned for all member types.
+Because the align is always a power of two, the memory will be suitably aligned for all member types.
 But it didn't work for some reason I still don't understand.
 
 Then I figured out how clang does it and did it the same way.
@@ -38,6 +38,7 @@ static LLVMTypeRef codegen_union_type(const LLVMTypeRef *types, int ntypes)
 
         // If this assert fails, you need to figure out which of the size functions should be used.
         // I don't know what their difference is.
+        // And if you need the alignment, there's 3 different functions for that...
         assert(size1 == size2);
         sizeneeded = max(sizeneeded, size1);
     }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -37,10 +37,6 @@ For some reason this breaks if I make the struct packed. But it seems to work no
 */
 static LLVMTypeRef codegen_union_type(const LLVMTypeRef *types, int ntypes)
 {
-    // Make the IR easier to read when unions aren't actually used
-    if (ntypes == 1)
-        return types[0];
-
     for (int i = 0; i < ntypes; i++) {
         assert(size(types[i]) > 0);
         assert(align(types[i])==1 || align(types[i])==2 || align(types[i])==4 || align(types[i])==8);


### PR DESCRIPTION
~Similar to how clang works, at least according to https://stackoverflow.com/a/12757239~

The previous solution of just using i8 array won't work on platforms that need stuff to be aligned. On x86_64 you don't need to align things, so that's why it worked, but it could cause problems if I port Jou to a different platform.

I changed it to array of i64 (of appropriate size), so it is always aligned as needed. It can be larger than necessary though, if your union is very small otherwise.