### PR TITLE
Print a little bit more with -v/--verbose

### DIFF
--- a/Makefile.posix
+++ b/Makefile.posix
@@ -29,7 +29,7 @@ config.jou:
 	echo "    return \"$(shell $(LLVM_CONFIG) --bindir)/clang\"" >> config.jou
 
 self_hosted_compiler: jou config.jou $(wildcard self_hosted/*.jou)
-	./jou -v -o $@ --linker-flags "$(LDFLAGS)" self_hosted/main.jou
+	./jou -o $@ --linker-flags "$(LDFLAGS)" self_hosted/main.jou
 
 .PHONY: clean
 clean:

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -31,7 +31,7 @@ config.jou:
 	echo "    return NULL" >> config.jou
 
 self_hosted_compiler.exe: jou.exe config.jou $(wildcard self_hosted/*.jou)
-	./jou.exe -v -o $@ --linker-flags "$(LDFLAGS)" self_hosted/main.jou
+	./jou.exe -o $@ --linker-flags "$(LDFLAGS)" self_hosted/main.jou
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
After #327 the self-hosted compiler compiles in just a few seconds, so the main purpose of `-v` is for someone new to the compiler to learn how it works (see CONTRIBUTING.md). I changed it to print one line for each compilation step (e.g. `Tokenizing /home/akuli/jou/stdlib/_assert_fail.jou`) instead of vaguely combining multiple steps into one (e.g. `Parsing Jou files...`)