### PR TITLE
Improve ensure_can_take_address

### DIFF
--- a/self_hosted/parses_wrong.txt
+++ b/self_hosted/parses_wrong.txt
@@ -78,3 +78,7 @@ tests/already_exists_error/class_field_and_union_member.jou
 tests/other_errors/instantiation_dupe.jou
 tests/syntax_error/bad_class_field_name.jou
 tests/syntax_error/union_1only.jou
+tests/other_errors/field_of_a_field_of_a_field_error.jou
+tests/other_errors/function_call_indexing.jou
+tests/other_errors/increment_indirect_addressof_fails.jou
+tests/other_errors/instantiation_address_of_field.jou

--- a/self_hosted/runs_wrong.txt
+++ b/self_hosted/runs_wrong.txt
@@ -147,3 +147,7 @@ tests/already_exists_error/class_field_and_union_member.jou
 tests/other_errors/instantiation_dupe.jou
 tests/syntax_error/bad_class_field_name.jou
 tests/syntax_error/union_1only.jou
+tests/other_errors/field_of_a_field_of_a_field_error.jou
+tests/other_errors/function_call_indexing.jou
+tests/other_errors/increment_indirect_addressof_fails.jou
+tests/other_errors/instantiation_address_of_field.jou

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -611,6 +611,8 @@ static void ensure_can_take_address(const AstExpression *expr, const char *errms
     case AST_EXPR_GET_FIELD:
         // &foo.bar = &foo + offset
         {
+            // Turn "cannot assign to %s" into "cannot assign to a field of %s".
+            // This assumes that errmsg_template is relatively simple, i.e. it only contains one %s somewhere.
             char *newtemplate = malloc(strlen(errmsg_template) + 100);
             sprintf(newtemplate, errmsg_template, "a field of %s");
             ensure_can_take_address(&expr->data.operands[0], newtemplate);

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -610,7 +610,12 @@ static void ensure_can_take_address(const AstExpression *expr, const char *errms
         break;
     case AST_EXPR_GET_FIELD:
         // &foo.bar = &foo + offset
-        ensure_can_take_address(&expr->data.operands[0], errmsg_template);
+        {
+            char *newtemplate = malloc(strlen(errmsg_template) + 100);
+            sprintf(newtemplate, errmsg_template, "a field of %s");
+            ensure_can_take_address(&expr->data.operands[0], newtemplate);
+            free(newtemplate);
+        }
         break;
     default:
         fail_with_error(expr->location, errmsg_template, short_expression_description(expr));
@@ -839,7 +844,7 @@ static const char *very_short_type_description(const Type *t)
         case TYPE_ARRAY:
             return "an array type";
         case TYPE_BOOL:
-            return "the built-in boolean type";
+            return "the built-in bool type";
     }
 }
 

--- a/tests/other_errors/field_of_a_field_of_a_field_error.jou
+++ b/tests/other_errors/field_of_a_field_of_a_field_error.jou
@@ -1,0 +1,9 @@
+class FooX:
+    x: int
+class FooY:
+    y: FooX
+class FooZ:
+    z: FooY
+
+def bar() -> void:
+    FooZ{}.z.y.x++  # Error: cannot increment a field of a field of a field of a newly created instance

--- a/tests/other_errors/function_call_indexing.jou
+++ b/tests/other_errors/function_call_indexing.jou
@@ -1,0 +1,5 @@
+def foo() -> int[3]:
+    return [1, 2, 3]
+
+def bar() -> int:
+    return foo()[1]  # Error: cannot create a pointer into an array that comes from a function call

--- a/tests/other_errors/immediate_member_assign.jou
+++ b/tests/other_errors/immediate_member_assign.jou
@@ -2,5 +2,5 @@ class Foo:
     x: int
 
 def main() -> int:
-    Foo{x=1}.x = 2  # Error: cannot assign to a newly created instance
+    Foo{x=1}.x = 2  # Error: cannot assign to a field of a newly created instance
     return 0

--- a/tests/other_errors/increment_indirect_addressof_fails.jou
+++ b/tests/other_errors/increment_indirect_addressof_fails.jou
@@ -1,0 +1,5 @@
+class Foo:
+    x: int
+
+def bar() -> void:
+    Foo{x=1}.x++  # Error: cannot increment a field of a newly created instance

--- a/tests/other_errors/instantiation_address_of_field.jou
+++ b/tests/other_errors/instantiation_address_of_field.jou
@@ -1,0 +1,11 @@
+import "stdlib/mem.jou"
+
+class Foo:
+    x: int
+
+def make_foo_pointer() -> Foo*:
+    return malloc(123)
+
+def asdf() -> void:
+    magic_pointer = &make_foo_pointer()->x  # This succeeds
+    magic_pointer = &Foo{}.x  # Error: the '&' operator cannot be used with a field of a newly created instance


### PR DESCRIPTION
The purpose of `ensure_can_take_address()` is to check that making a pointer to something (as in `&foo`) makes sense. But unlike you would expect, it isn't used just in the `&foo` syntax. Several other things, such as `foo = bar` and `&foo.bar`, also need a pointer to `foo`. The `ensure_can_take_address()` function handles them all.

This means that it is important for `ensure_can_take_address()` to generate good error messages. The error message logic is also a bit complicated, and previously behaved wrong in some corner cases: `Foo{}.x++` resulted in an error message saying you are trying to increment a newly created instance. It now says that you are trying to increment a *field* of a newly created instance.