### PR TITLE
Pointer comparisons

### DIFF
--- a/self_hosted/parser.jou
+++ b/self_hosted/parser.jou
@@ -802,8 +802,8 @@ def check_class_for_duplicate_names(classdef: AstClassDef*) -> void:
 
     assert destptr == &infos[n]
 
-    for p1 = infos; p1 != destptr; p1++:
-        for p2 = &p1[1]; p2 != destptr; p2++:
+    for p1 = infos; p1 < destptr; p1++:
+        for p2 = &p1[1]; p2 < destptr; p2++:
             if strcmp(p1->name, p2->name) == 0:
                 message: byte[500]
                 snprintf(
@@ -949,7 +949,7 @@ def parse(tokens: Token*, stdlib_path: byte*) -> AstFile:
         result.body[result.body_len++] = parse_toplevel_node(&tokens, stdlib_path)
 
     # This simplifies the compiler: it's easy to loop through all imports of the file.
-    for p = &result.body[1]; p != &result.body[result.body_len]; p++:
+    for p = &result.body[1]; p < &result.body[result.body_len]; p++:
         if p[-1].kind != AstToplevelStatementKind::Import and p->kind == AstToplevelStatementKind::Import:
             fail(p->location, "imports must be in the beginning of the file")
 

--- a/src/build_cfg.c
+++ b/src/build_cfg.c
@@ -152,6 +152,12 @@ static const LocalVariable *build_cast(
     if (obj->type == boolType && is_integer_type(to))
         return build_bool_to_int_conversion(st, obj, location, to);
 
+    if (is_pointer_type(obj->type) && is_integer_type(to) && to->data.width_in_bits == 64) {
+        const LocalVariable *result = add_local_var(st, to);
+        add_unary_op(st, location, CF_PTR_TO_INT64, obj, result);
+        return result;
+    }
+
     assert(0);
 }
 
@@ -177,8 +183,8 @@ static const LocalVariable *build_binop(
         case AST_EXPR_MUL: k = CF_NUM_MUL; break;
         case AST_EXPR_DIV: k = CF_NUM_DIV; break;
         case AST_EXPR_MOD: k = CF_NUM_MOD; break;
-        case AST_EXPR_EQ: k = got_pointers?CF_PTR_EQ:CF_NUM_EQ; break;
-        case AST_EXPR_NE: k = got_pointers?CF_PTR_EQ:CF_NUM_EQ; negate=true; break;
+        case AST_EXPR_EQ: k = CF_NUM_EQ; break;
+        case AST_EXPR_NE: k = CF_NUM_EQ; negate=true; break;
         case AST_EXPR_LT: k = CF_NUM_LT; break;
         case AST_EXPR_GT: k = CF_NUM_LT; swap=true; break;
         case AST_EXPR_LE: k = CF_NUM_LT; negate=true; swap=true; break;

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -325,13 +325,7 @@ static void codegen_instruction(const struct State *st, const CfInstruction *ins
         case CF_ADDRESS_OF_GLOBAL_VAR: setdest(LLVMGetNamedGlobal(st->module, ins->data.globalname)); break;
         case CF_PTR_LOAD: setdest(LLVMBuildLoad(st->builder, getop(0), "ptr_load")); break;
         case CF_PTR_STORE: LLVMBuildStore(st->builder, getop(1), getop(0)); break;
-        case CF_PTR_EQ:
-            {
-                LLVMValueRef lhsint = LLVMBuildPtrToInt(st->builder, getop(0), LLVMInt64Type(), "ptreq_lhs");
-                LLVMValueRef rhsint = LLVMBuildPtrToInt(st->builder, getop(1), LLVMInt64Type(), "ptreq_rhs");
-                setdest(LLVMBuildICmp(st->builder, LLVMIntEQ, lhsint, rhsint, "ptr_eq"));
-            }
-            break;
+        case CF_PTR_TO_INT64: setdest(LLVMBuildPtrToInt(st->builder, getop(0), LLVMInt64Type(), "ptr_as_int")); break;
         case CF_PTR_CLASS_FIELD:
             {
                 const Type *classtype = ins->operands[0]->type->data.valuetype;

--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -531,7 +531,7 @@ struct CfInstruction {
         CF_PTR_MEMSET_TO_ZERO,  // takes one operand, a pointer: memset(ptr, 0, sizeof(*ptr))
         CF_PTR_STORE,  // *op1 = op2 (does not use destvar, takes 2 operands)
         CF_PTR_LOAD,  // aka dereference
-        CF_PTR_EQ,
+        CF_PTR_TO_INT64,
         CF_PTR_CLASS_FIELD,  // takes 1 operand (pointer), sets destvar to &op->fieldname
         CF_PTR_CAST,
         CF_PTR_ADD_INT,

--- a/src/print.c
+++ b/src/print.c
@@ -540,6 +540,9 @@ static void print_cf_instruction(const CfInstruction *ins)
     case CF_INT32_TO_ENUM:
         printf("cast %s from 32-bit signed int to enum", varname(ins->operands[0]));
         break;
+    case CF_PTR_TO_INT64:
+        printf("cast %s to 64-bit integer", varname(ins->operands[0]));
+        break;
     case CF_CONSTANT:
         print_constant(&ins->data.constant);
         break;
@@ -551,7 +554,6 @@ static void print_cf_instruction(const CfInstruction *ins)
     case CF_NUM_MOD:
     case CF_NUM_EQ:
     case CF_NUM_LT:
-    case CF_PTR_EQ:
         switch(ins->kind){
             case CF_NUM_ADD: printf("num add "); break;
             case CF_NUM_SUB: printf("num sub "); break;
@@ -560,7 +562,6 @@ static void print_cf_instruction(const CfInstruction *ins)
             case CF_NUM_MOD: printf("num mod "); break;
             case CF_NUM_EQ: printf("num eq "); break;
             case CF_NUM_LT: printf("num lt "); break;
-            case CF_PTR_EQ: printf("ptr eq "); break;
             default: assert(0);
         }
         printf("%s, %s", varname(ins->operands[0]), varname(ins->operands[1]));

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -80,15 +80,15 @@ static void read_identifier_or_number(struct State *st, char firstbyte, char (*d
 
     assert(is_identifier_or_number_byte(firstbyte));
     (*dest)[destlen++] = firstbyte;
-    bool is_number = '0'<=firstbyte && firstbyte<='9';
 
     while(1) {
         char c = read_byte(st);
         if (is_identifier_or_number_byte(c)
-            || (is_number && (c=='.' || (c=='-' && (*dest)[destlen-1]=='e'))))
+            || ('0'<=firstbyte && firstbyte<='9' && c=='.')
+            || ('0'<=firstbyte && firstbyte<='9' && (*dest)[destlen-1]=='e' && c=='-'))
         {
             if (destlen == sizeof *dest - 1)
-                fail_with_error(st->location, "%s is too long: %.20s...", is_number?"number":"name", *dest);
+                fail_with_error(st->location, "%s is too long: %.20s...", isdigit(firstbyte)?"number":"name", *dest);
             (*dest)[destlen++] = c;
         } else {
             unread_byte(st, c);

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -80,15 +80,15 @@ static void read_identifier_or_number(struct State *st, char firstbyte, char (*d
 
     assert(is_identifier_or_number_byte(firstbyte));
     (*dest)[destlen++] = firstbyte;
+    bool is_number = '0'<=firstbyte && firstbyte<='9';
 
     while(1) {
         char c = read_byte(st);
         if (is_identifier_or_number_byte(c)
-            || ('0'<=firstbyte && firstbyte<='9' && c=='.')
-            || ('0'<=firstbyte && firstbyte<='9' && (*dest)[destlen-1]=='e' && c=='-'))
+            || (is_number && (c=='.' || (c=='-' && (*dest)[destlen-1]=='e'))))
         {
             if (destlen == sizeof *dest - 1)
-                fail_with_error(st->location, "%s is too long: %.20s...", isdigit(firstbyte)?"number":"name", *dest);
+                fail_with_error(st->location, "%s is too long: %.20s...", is_number?"number":"name", *dest);
             (*dest)[destlen++] = c;
         } else {
             unread_byte(st, c);

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -627,7 +627,8 @@ static const Type *check_binop(
 
     if (
         (!got_numbers && !got_enums && !got_pointers)
-        || (op != AST_EXPR_EQ && op != AST_EXPR_NE && !got_numbers)
+        || (got_enums && op != AST_EXPR_EQ && op != AST_EXPR_NE)
+        || (got_pointers && op != AST_EXPR_EQ && op != AST_EXPR_NE && op != AST_EXPR_GT && op != AST_EXPR_GE && op != AST_EXPR_LT && op != AST_EXPR_LE)
     )
         fail_with_error(location, "wrong types: cannot %s %s and %s", do_what, lhstypes->type->name, rhstypes->type->name);
 
@@ -641,7 +642,7 @@ static const Type *check_binop(
     if (got_numbers && !got_integers)
         cast_type = (lhstypes->type == doubleType || rhstypes->type == doubleType) ? doubleType : floatType;
     if (got_pointers)
-        cast_type = voidPtrType;
+        cast_type = longType;
     if (got_enums)
         cast_type = intType;
     assert(cast_type);

--- a/src/typecheck.c
+++ b/src/typecheck.c
@@ -642,7 +642,7 @@ static const Type *check_binop(
     if (got_numbers && !got_integers)
         cast_type = (lhstypes->type == doubleType || rhstypes->type == doubleType) ? doubleType : floatType;
     if (got_pointers)
-        cast_type = longType;
+        cast_type = get_integer_type(64, false);  // unsigned long
     if (got_enums)
         cast_type = intType;
     assert(cast_type);

--- a/tests/should_succeed/pointer.jou
+++ b/tests/should_succeed/pointer.jou
@@ -54,4 +54,11 @@ def main() -> int:
     foo(&x)  # Output: Got 123
     foo(NULL)  # Output: Got NULL
 
+    # comparing pointers
+    my_string = "hello"
+    printf("%d\n", my_string == my_string)      # Output: 1
+    printf("%d\n", my_string == &my_string[1])  # Output: 0
+    printf("%d\n", my_string < my_string)       # Output: 0
+    printf("%d\n", my_string < &my_string[1])   # Output: 1
+
     return 0


### PR DESCRIPTION
E.g. `&foo[0] < &foo[1]`. Fixes #279 