### PR TITLE
Initialize global variables to zero

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -530,7 +530,7 @@ LLVMModuleRef codegen(const CfGraphFile *cfgfile, const FileTypes *ft)
         LLVMTypeRef t = codegen_type((*v)->type);
         LLVMValueRef globalptr = LLVMAddGlobal(st.module, t, (*v)->name);
         if ((*v)->defined_in_current_file)
-            LLVMSetInitializer(globalptr, LLVMGetUndef(t));
+            LLVMSetInitializer(globalptr, LLVMConstNull(t));
     }
 
     for (CfGraph **g = cfgfile->graphs.ptr; g < End(cfgfile->graphs); g++)

--- a/tests/should_succeed/global.jou
+++ b/tests/should_succeed/global.jou
@@ -6,10 +6,10 @@ def increment_x() -> void:
     x++
 
 def main() -> int:
-    x = 123
-    printf("%d\n", x)  # Output: 123
-
+    printf("%d\n", x)  # Output: 0
     increment_x()
-    printf("%d\n", x)  # Output: 124
+    printf("%d\n", x)  # Output: 1
+    increment_x()
+    printf("%d\n", x)  # Output: 2
 
     return 0


### PR DESCRIPTION
There is already code that relies on this, although previously LLVM didn't guarantee it.