### PR TITLE
compare_compilers.sh improvements

### DIFF
--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -102,7 +102,7 @@ for action in ${actions[@]}; do
     # Run compilers in parallel to speed up.
     (
         set +e
-        ./jou $flag $file 2>&1 | grep -vE 'undefined reference to|[/\\]ld: '
+        ./jou $flag $file 2>&1 | grep -vE 'undefined reference to|\bld: '
     ) > tmp/compare_compilers/compiler_written_in_c.txt &
     (
         set +e

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -106,7 +106,7 @@ for action in ${actions[@]}; do
     ) > tmp/compare_compilers/compiler_written_in_c.txt &
     (
         set +e
-        ./self_hosted_compiler $flag $file 2>&1 | grep -vE 'undefined reference to|linking failed|[/\\]ld: '
+        ./self_hosted_compiler $flag $file 2>&1 | grep -vE 'undefined reference to|linking failed|\bld: '
     ) > tmp/compare_compilers/self_hosted.txt &
     wait
 

--- a/compare_compilers.sh
+++ b/compare_compilers.sh
@@ -102,11 +102,11 @@ for action in ${actions[@]}; do
     # Run compilers in parallel to speed up.
     (
         set +e
-        ./jou $flag $file 2>&1 | grep -vE 'undefined reference to|\bld: '
+        ./jou $flag $file 2>&1 | grep -vE 'undefined reference to|multiple definition of|\bld: '
     ) > tmp/compare_compilers/compiler_written_in_c.txt &
     (
         set +e
-        ./self_hosted_compiler $flag $file 2>&1 | grep -vE 'undefined reference to|linking failed|\bld: '
+        ./self_hosted_compiler $flag $file 2>&1 | grep -vE 'undefined reference to|multiple definition of|\bld: |linking failed'
     ) > tmp/compare_compilers/self_hosted.txt &
     wait
 

--- a/self_hosted/runs_wrong.txt
+++ b/self_hosted/runs_wrong.txt
@@ -59,7 +59,6 @@ tests/should_succeed/indirect_method_import.jou
 tests/404/indirect_import_symbol.jou
 tests/other_errors/noreturn_but_return_without_value.jou
 tests/other_errors/noreturn_but_return_with_value.jou
-stdlib/_assert_fail.jou
 tests/other_errors/assert_fail.jou
 tests/wrong_type/assert.jou
 tests/should_succeed/union.jou

--- a/self_hosted/runs_wrong.txt
+++ b/self_hosted/runs_wrong.txt
@@ -1,11 +1,6 @@
 # This is a list of files that don't behave correctly when ran with the self-hosted compiler.
-examples/x11_window.jou
-stdlib/io.jou
 stdlib/math.jou
-stdlib/mem.jou
-stdlib/process.jou
 stdlib/str.jou
-stdlib/_windows_startup.jou
 tests/404/method_on_class_ptr.jou
 tests/404/method_on_int.jou
 tests/already_exists_error/class_import.jou


### PR DESCRIPTION
- Run both compilers at the same time to speed things up.
- Add `--tokenize`, `--parse` and `--run` options to only compare the compilers in one of the three possible ways. If none are given, compare in all three ways.
- Don't compare linker error messages that don't have to match, e.g. different offsets within binary files, different paths to object files.