### PR TITLE
move run_exe() to separate file

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -184,27 +184,3 @@ char *compile_to_object_file(LLVMModuleRef module)
     assert(!error);
     return path;
 }
-
-int run_exe(const char *exepath, bool valgrind)
-{
-    char *command = malloc(strlen(exepath) + 1000);
-#ifdef _WIN32
-    sprintf(command, "\"%s\"", exepath);
-    char *p;
-    while ((p = strchr(command, '/')))
-        *p = '\\';
-#else
-    if (valgrind)
-        sprintf(command, "valgrind -q --leak-check=full --show-leak-kinds=all --error-exitcode=1 '%s'", exepath);
-    else
-        sprintf(command, "'%s'", exepath);
-#endif
-
-    // Make sure that everything else shows up before the user's prints.
-    fflush(stdout);
-    fflush(stderr);
-
-    int ret = system(command);
-    free(command);
-    return !!ret;
-}

--- a/src/run.c
+++ b/src/run.c
@@ -1,0 +1,29 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "jou_compiler.h"
+
+
+int run_exe(const char *exepath, bool valgrind)
+{
+    char *command = malloc(strlen(exepath) + 1000);
+#ifdef _WIN32
+    sprintf(command, "\"%s\"", exepath);
+    char *p;
+    while ((p = strchr(command, '/')))
+        *p = '\\';
+#else
+    if (valgrind)
+        sprintf(command, "valgrind -q --leak-check=full --show-leak-kinds=all --error-exitcode=1 '%s'", exepath);
+    else
+        sprintf(command, "'%s'", exepath);
+#endif
+
+    // Make sure that everything else shows up before the user's prints.
+    fflush(stdout);
+    fflush(stderr);
+
+    int ret = system(command);
+    free(command);
+    return !!ret;
+}


### PR DESCRIPTION
Will be a tiny file, but doesn't make sense to have it in `output.c`.

For now this isn't needed on the self-hosted side, because it has running in `main.jou`