### PR TITLE
Add test for *array

### DIFF
--- a/tests/wrong_type/deref_array.jou
+++ b/tests/wrong_type/deref_array.jou
@@ -1,0 +1,3 @@
+def foo() -> int:
+    x = [1, 2, 3]
+    return *x  # Error: the dereference operator '*' is only for pointers, not for int[3]


### PR DESCRIPTION
In Jou (unlike in C), you are supposed to use the `*` operator only with pointers, not with arrays. This already works as expected, but there wasn't a test.