### PR TITLE
Read assertion from file with offsets

### DIFF
--- a/src/jou_compiler.h
+++ b/src/jou_compiler.h
@@ -91,7 +91,6 @@ struct Token {
         TOKEN_OPERATOR,
         TOKEN_END_OF_FILE,  // Marks the end of an array of Token
     } type;
-    Location location;
     union {
         int16_t short_value; // TOKEN_SHORT
         int32_t int_value;  // TOKEN_INT
@@ -102,6 +101,16 @@ struct Token {
         char name[100];  // TOKEN_NAME and TOKEN_KEYWORD. Also TOKEN_DOUBLE & TOKEN_FLOAT (LLVM wants a string anyway)
         char operator[4];  // TOKEN_OPERATOR
     } data;
+
+    /*
+    Contains only the line number, not column. In some cases you can use
+    start_offset and end_offset to work around that.
+    */
+    Location location;
+
+    // Number of bytes from start of file to start/end of this token.
+    long start_offset;
+    long end_offset;
 };
 
 // Constants can appear in AST and also compilation steps after AST.

--- a/src/parse.c
+++ b/src/parse.c
@@ -750,9 +750,6 @@ static char *read_assertion_from_file(Location error_location, const Token *star
 
         if (t == end-1 || t[0].location.lineno != t[1].location.lineno) {
             // Last token of a line. Read code from file.
-            char *line = malloc(oend - ostart + 1);
-            if (!line)
-                goto error;
             if (fseek(f, ostart, SEEK_SET) < 0)
                 goto error;
             if (result.len > 0)
@@ -780,6 +777,8 @@ static char *read_assertion_from_file(Location error_location, const Token *star
             *p = ' ';  // join lines with a space
         }
     }
+
+    fclose(f);
     return result.ptr;
 
 error:

--- a/src/parse.c
+++ b/src/parse.c
@@ -728,8 +728,10 @@ static enum AstStatementKind determine_the_kind_of_a_statement_that_starts_with_
 static char *read_assertion_from_file(Location error_location, const Token *start, const Token *end)
 {
     FILE *f = fopen(error_location.filename, "rb");
-    if (!f)
+    if (!f) {
+        printf("FAIL 1 fopen\n");
         goto error;
+    }
 
     List(char) result = {0};
 
@@ -750,14 +752,18 @@ static char *read_assertion_from_file(Location error_location, const Token *star
 
         if (t == end-1 || t[0].location.lineno != t[1].location.lineno) {
             // Last token of a line. Read code from file.
-            if (fseek(f, ostart, SEEK_SET) < 0)
+            if (fseek(f, ostart, SEEK_SET) < 0) {
+                printf("FAIL 2 fseek\n");
                 goto error;
+            }
             if (result.len > 0)
                 Append(&result, '\n');
             for (long i = ostart; i < oend; i++) {
                 int c = fgetc(f);
-                if (c == EOF || c == '\r' || c == '\n')
+                if (c == EOF || c == '\r' || c == '\n') {
+                    printf("FAIL 3 fgetc %d\n", c);
                     goto error;
+                }
                 Append(&result, (char)c);
             }
         }

--- a/src/parse.c
+++ b/src/parse.c
@@ -762,6 +762,10 @@ static char *read_assertion_from_file(Location error_location, const Token *star
                 int c = fgetc(f);
                 if (c == EOF || c == '\r' || c == '\n') {
                     printf("FAIL 3 fgetc %d\n", c);
+                    printf("File name: %s\n", error_location.filename);
+                    printf("Start offset: %ld\n", ostart);
+                    printf("End offset: %ld\n", oend);
+                    printf("The i variable: %ld\n", i);
                     goto error;
                 }
                 Append(&result, (char)c);

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -420,10 +420,20 @@ static void handle_parentheses(struct State *st, const struct Token *t)
     }
 }
 
+// Returns the offset of the current location as number of bytes from start of file.
+static long get_offset(const struct State *st)
+{
+    long off = ftell(st->f);
+    if (off < 0)
+        fail(st->location, "internal error: ftell() failed");
+
+    return off - st->pushback.len;
+}
+
 static Token read_token(struct State *st)
 {
     while(1) {
-        Token t = { .location = st->location };
+        Token t = { .location = st->location, .start_offset = get_offset(st) };
         char c = read_byte(st);
 
         switch(c) {
@@ -482,6 +492,8 @@ static Token read_token(struct State *st)
             }
             break;
         }
+
+        t.end_offset = get_offset(st);
         return t;
     }
 }


### PR DESCRIPTION
The fix for ugly assertion reading. Adds file offsets to tokens, so that `fseek()` can be used to go to where the assertion starts and ends in the file. This way we can read the file contents after tokenizing.

- [ ] Fix weird error that only happens on Windows
- [ ] Port to self-hosted