### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
       - run: shellcheck --color=always --shell=bash --exclude=SC2086,SC2059,SC2046,SC2235,SC2002,SC2206,SC2068,SC2207,SC2013 *.sh activate
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         llvm-version: [11, 13, 14]
@@ -49,7 +49,7 @@ jobs:
           fi
 
   doctest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt update
@@ -62,7 +62,7 @@ jobs:
       - run: LLVM_CONFIG=llvm-config-14 ./doctest.sh
 
   compare-compilers:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt update


### PR DESCRIPTION
CI is failing on `main` branch.

Apparently GitHub recently changed `ubuntu-latest` so it points at Ubuntu 24.04, which doesn't have old versions of LLVM/clang that are still supported in Jou.