### PR TITLE
Configure GitHub Actions to run tests with valgrind every night instead of every pull request

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,25 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt update
-      - run: sudo apt install -y llvm-${{ matrix.llvm-version }}-dev clang-${{ matrix.llvm-version }} make valgrind
+      - run: sudo apt install -y llvm-${{ matrix.llvm-version }}-dev clang-${{ matrix.llvm-version }} make
       - run: LLVM_CONFIG=llvm-config-${{ matrix.llvm-version }} make
       - run: ./runtests.sh --verbose --jou-flags "${{ matrix.opt-level }}"
       - run: ./runtests.sh --verbose --jou-flags "${{ matrix.opt-level }} --verbose"
-      # Valgrinding is slow, but many files affect valgrind results.
-      # We skip it when all changes are to .md files (docs, README etc)
-      - name: Figure out if we need to run tests with valgrind
-        id: check-need-valgrind
-        run: |
-          git fetch https://github.com/Akuli/jou main
-          # Find modified non-markdown files. If there are any, set doit=yes.
-          if git diff --name-only FETCH_HEAD HEAD | grep -vE '\.md$'; then
-            echo doit=yes >> $GITHUB_OUTPUT
-          else
-            echo doit=no >> $GITHUB_OUTPUT
-          fi
-      - if: ${{ steps.check-need-valgrind.outputs.doit == 'yes' }}
-        run: ./runtests.sh --verbose --valgrind --jou-flags "${{ matrix.opt-level }}"
-      # valgrind+verbose isn't meaningful: test script would ignore valgrind output
       - run: make clean
       - name: Check that "make clean" deleted all files not committed to Git
         run: |

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -19,9 +19,7 @@ jobs:
       - run: sudo apt update
       - run: sudo apt install -y llvm-${{ matrix.llvm-version }}-dev clang-${{ matrix.llvm-version }} make valgrind
       - run: LLVM_CONFIG=llvm-config-${{ matrix.llvm-version }} make
-      #- run: ./runtests.sh --verbose --valgrind --jou-flags "${{ matrix.opt-level }}"
-      - run: echo "Valgrinding... Brrr..."
-      - run: cat oh no this command will error
+      - run: ./runtests.sh --verbose --valgrind --jou-flags "${{ matrix.opt-level }}"
 
   # Based on: https://github.com/python/typeshed/blob/9f28171658b9ca6c32a7cb93fbb99fc92b17858b/.github/workflows/daily.yml
   create-issue-on-failure:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,7 +20,7 @@ jobs:
       # Do not valgrind when there's nothing new to valgrind in the repo
       - name: Check if there was any commits within the last 24 hours
         run: |
-          if git --no-pager log --oneline --since="24 seconds ago" --exit-code; then
+          if git --no-pager log --oneline --since="24 hours ago" --exit-code; then
             echo "No commits, will not run valgrind"
             echo "recent_commits=false" >> $GITHUB_ENV
           else

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,7 +20,7 @@ jobs:
       # Do not valgrind when there's nothing new to valgrind in the repo
       - name: Check if there was any commits within the last 24 hours
         run: |
-          if git log --oneline --since="24 hours ago" --name-only --pretty=format: | grep -q '.'; then
+          if git log --oneline --since="1 minutes ago" --name-only --pretty=format: | grep -q '.'; then
             echo "recent_commits=true" >> $GITHUB_ENV
           else
             echo "No commits, will not run valgrind"

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -16,10 +16,28 @@ jobs:
         opt-level: ['-O0', '-O1', '-O2', '-O3']
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt update
-      - run: sudo apt install -y llvm-${{ matrix.llvm-version }}-dev clang-${{ matrix.llvm-version }} make valgrind
-      - run: LLVM_CONFIG=llvm-config-${{ matrix.llvm-version }} make
-      - run: ./runtests.sh --verbose --valgrind --jou-flags "${{ matrix.opt-level }}"
+
+      # Do not valgrind when there's nothing new to valgrind in the repo
+      - name: Check if there was any commits within the last 24 hours
+        run: |
+          if git log --oneline --since="24 hours ago" --name-only --pretty=format: | grep -q '.'; then
+            echo "recent_commits=true" >> $GITHUB_ENV
+          else
+            echo "No commits, will not run valgrind"
+            echo "recent_commits=false" >> $GITHUB_ENV
+          fi
+
+      - if: env.recent_commits == 'true'
+        run: sudo apt update
+
+      - if: env.recent_commits == 'true'
+        run: sudo apt install -y llvm-${{ matrix.llvm-version }}-dev clang-${{ matrix.llvm-version }} make valgrind
+
+      - if: env.recent_commits == 'true'
+        run: LLVM_CONFIG=llvm-config-${{ matrix.llvm-version }} make
+
+      - if: env.recent_commits == 'true'
+        run: ./runtests.sh --verbose --valgrind --jou-flags "${{ matrix.opt-level }}"
 
   # Based on: https://github.com/python/typeshed/blob/9f28171658b9ca6c32a7cb93fbb99fc92b17858b/.github/workflows/daily.yml
   create-issue-on-failure:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,7 +20,7 @@ jobs:
       # Do not valgrind when there's nothing new to valgrind in the repo
       - name: Check if there was any commits within the last 24 hours
         run: |
-          if git log --oneline --since="1 minutes ago" --name-only --pretty=format: | grep -q '.'; then
+          if git log --oneline --since="24 hours ago" --name-only --pretty=format: | grep -q '.'; then
             echo "recent_commits=true" >> $GITHUB_ENV
           else
             echo "No commits, will not run valgrind"

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,11 +20,11 @@ jobs:
       # Do not valgrind when there's nothing new to valgrind in the repo
       - name: Check if there was any commits within the last 24 hours
         run: |
-          if git log --oneline --since="24 hours ago" --name-only --pretty=format: | grep '.'; then
-            echo "recent_commits=true" >> $GITHUB_ENV
-          else
+          if git --no-pager log --oneline --since="24 seconds ago" --exit-code; then
             echo "No commits, will not run valgrind"
             echo "recent_commits=false" >> $GITHUB_ENV
+          else
+            echo "recent_commits=true" >> $GITHUB_ENV
           fi
 
       - if: env.recent_commits == 'true'

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,7 +20,7 @@ jobs:
       # Do not valgrind when there's nothing new to valgrind in the repo
       - name: Check if there was any commits within the last 24 hours
         run: |
-          if git log --oneline --since="24 hours ago" --name-only --pretty=format: | grep -q '.'; then
+          if git log --oneline --since="24 hours ago" --name-only --pretty=format: | grep '.'; then
             echo "recent_commits=true" >> $GITHUB_ENV
           else
             echo "No commits, will not run valgrind"


### PR DESCRIPTION
Running tests with valgrind is by far the slowest thing in CI when making a pull request. Let's stop doing that.

See also: #551 