### PR TITLE
Fix valgrind

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -14,6 +14,7 @@ jobs:
         llvm-version: [11, 13, 14]
         # Testing all levels because there was a bug that only happened with -O1. (#224)
         opt-level: ['-O0', '-O1', '-O2', '-O3']
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -225,7 +225,9 @@ function run_test()
         generate_expected_output $joufile $correct_exit_code | tr -d '\r'
     ) <(
         export PATH="$PWD:$PATH"
-        ulimit -v 500000 2>/dev/null
+        if [ $valgrind = no ]; then
+            ulimit -v 500000 2>/dev/null
+        fi
         bash -c "$command; echo Exit code: \$?" 2>&1 | post_process_output $joufile | tr -d '\r'
     ) &>> $diffpath; then
         show_ok "$command"


### PR DESCRIPTION
- Last night, valgrind ran out of memory. Do not enable memory limit when running valgrind, because it consumes more memory than the program by itself, and seems to be somewhat unpredictable.
- If one valgrind run fails, do not immediately stop the others. It can be useful to know which runs fail, e.g. if only one of them fails, it is probably random/undeterministic and doesn't fail every time.

Fixes #557 