### PR TITLE
Add timeouts to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   fix-line-endings:
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       # git-auto-commit-action is a bit tricky to use, see its README
       - uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,12 +6,25 @@ on:
 
 jobs:
   shellcheck:
+    timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: shellcheck --color=always --shell=bash --exclude=SC2086,SC2059,SC2046,SC2235,SC2002,SC2206,SC2068,SC2207,SC2013 *.sh activate
 
+  editorconfig-checker:
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Hard-coded commit, because the latest changes aren't tagged.
+      - uses: editorconfig-checker/action-editorconfig-checker@d4fca16fc71adef10fbe101903b654449fa9570c
+        with:
+          version: 2.7.0
+      - run: editorconfig-checker
+
   test:
+    timeout-minutes: 5
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -35,6 +48,7 @@ jobs:
 
   doctest:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt update
@@ -48,6 +62,7 @@ jobs:
 
   compare-compilers:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt update
@@ -58,13 +73,3 @@ jobs:
       - run: LLVM_CONFIG=llvm-config-13 ./compare_compilers.sh
       - run: make clean
       - run: LLVM_CONFIG=llvm-config-14 ./compare_compilers.sh
-
-  editorconfig-checker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      # Hard-coded commit, because the latest changes aren't tagged.
-      - uses: editorconfig-checker/action-editorconfig-checker@d4fca16fc71adef10fbe101903b654449fa9570c
-        with:
-          version: 2.7.0
-      - run: editorconfig-checker

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: macos-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         # Testing all levels because there was a bug that only happened with -O1. (#224)
@@ -37,6 +38,7 @@ jobs:
 
   doctest:
     runs-on: macos-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - run: brew install bash diffutils llvm@{13,14}
@@ -47,6 +49,7 @@ jobs:
 
   compare-compilers:
     runs-on: macos-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - run: brew install bash diffutils llvm@{13,14}

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: cross-platform-actions/action@v0.26.0

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: cross-platform-actions/action@v0.26.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - run: git fetch --tags

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   valgrind:
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     strategy:
       matrix:
         llvm-version: [11, 13, 14]
@@ -44,6 +45,7 @@ jobs:
   create-issue-on-failure:
     name: Create an issue if valgrind failed
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [valgrind]
     #if: ${{ github.repository == 'Akuli/jou' && always() && github.event_name == 'schedule' && needs.valgrind.result == 'failure' }}
     if: ${{ github.repository == 'Akuli/jou' && always() && needs.valgrind.result == 'failure' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,6 +22,7 @@ jobs:
   #   * I can be sure that I didn't accidentally include something unnecessary or do something else dumb.
   check-small-mingw64:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       # Same URLs as in windows_setup.sh
       - name: Download the small mingw64
@@ -66,6 +67,7 @@ jobs:
 
   build-zip:
     runs-on: windows-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       # TODO: figure out why --small doesn't work here
@@ -147,6 +149,7 @@ jobs:
 
   test:
     runs-on: windows-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
         with:
@@ -159,6 +162,7 @@ jobs:
 
   doctest:
     runs-on: windows-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - run: ./windows_setup.sh --small
@@ -169,6 +173,7 @@ jobs:
   test-zip:
     needs: build-zip
     runs-on: windows-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
         with:
@@ -186,6 +191,7 @@ jobs:
 
   compare-compilers:
     runs-on: windows-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - run: source activate && ./windows_setup.sh --small


### PR DESCRIPTION
This is a best practice that I forgot to do. I noticed this when I somehow managed to freeze the netbsd build in #562.