### PR TITLE
Compiler refactor: put ExpressionTypes inside AstExpression

### DIFF
--- a/bootstrap_compiler/build_cfg.c
+++ b/bootstrap_compiler/build_cfg.c
@@ -26,14 +26,11 @@ static LocalVariable *add_local_var(struct State *st, const Type *t)
     return var;
 }
 
+// TODO: get rid of this
 static const ExpressionTypes *get_expr_types(const struct State *st, const AstExpression *expr)
 {
-    // TODO: a fancy binary search algorithm (need to add sorting)
-    assert(st->fomtypes);
-    for (int i = 0; i < st->fomtypes->expr_types.len; i++)
-        if (st->fomtypes->expr_types.ptr[i]->expr == expr)
-            return st->fomtypes->expr_types.ptr[i];
-    return NULL;
+    (void)st;
+    return &expr->types;
 }
 
 static CfBlock *add_block(const struct State *st)

--- a/bootstrap_compiler/build_cfg.c
+++ b/bootstrap_compiler/build_cfg.c
@@ -26,13 +26,6 @@ static LocalVariable *add_local_var(struct State *st, const Type *t)
     return var;
 }
 
-// TODO: get rid of this
-static const ExpressionTypes *get_expr_types(const struct State *st, const AstExpression *expr)
-{
-    (void)st;
-    return &expr->types;
-}
-
 static CfBlock *add_block(const struct State *st)
 {
     CfBlock *block = calloc(1, sizeof *block);
@@ -392,7 +385,7 @@ static const LocalVariable *build_address_of_expression(struct State *st, const 
     switch(address_of_what->kind) {
     case AST_EXPR_GET_VARIABLE:
     {
-        const Type *ptrtype = get_pointer_type(get_expr_types(st, address_of_what)->type);
+        const Type *ptrtype = get_pointer_type(address_of_what->types.type);
         const LocalVariable *addr = add_local_var(st, ptrtype);
 
         const LocalVariable *local_var = find_local_var(st, address_of_what->data.varname);
@@ -457,7 +450,7 @@ static const LocalVariable *build_function_or_method_call(
     const Signature *sig = NULL;
 
     if(self) {
-        const Type *selfclass = get_expr_types(st, self)->type;
+        const Type *selfclass = self->types.type;
         if (self_is_a_pointer) {
             assert(selfclass->kind == TYPE_POINTER);
             selfclass = selfclass->data.valuetype;
@@ -572,26 +565,26 @@ static int find_enum_member(const Type *enumtype, const char *name)
 
 static const LocalVariable *build_expression(struct State *st, const AstExpression *expr)
 {
-    const ExpressionTypes *types = get_expr_types(st, expr);
-    if (types && types->implicit_array_to_pointer_cast) {
+    const Type *t = expr->types.type;
+    if (expr->types.implicit_array_to_pointer_cast) {
         const LocalVariable *arrptr = build_address_of_expression(st, expr);
-        const LocalVariable *memberptr = add_local_var(st, types->implicit_cast_type);
+        const LocalVariable *memberptr = add_local_var(st, expr->types.implicit_cast_type);
         add_unary_op(st, expr->location, CF_PTR_CAST, arrptr, memberptr);
         return memberptr;
     }
 
-    if (types && types->implicit_string_to_array_cast) {
-        assert(types->implicit_cast_type);
-        assert(types->implicit_cast_type->kind == TYPE_ARRAY);
+    if (expr->types.implicit_string_to_array_cast) {
+        assert(expr->types.implicit_cast_type);
+        assert(expr->types.implicit_cast_type->kind == TYPE_ARRAY);
         assert(expr->kind == AST_EXPR_CONSTANT);
         assert(expr->data.constant.kind == CONSTANT_STRING);
 
-        char *padded = calloc(1, types->implicit_cast_type->data.array.len);
+        char *padded = calloc(1, expr->types.implicit_cast_type->data.array.len);
         strcpy(padded, expr->data.constant.data.str);
 
-        const LocalVariable *result = add_local_var(st, types->implicit_cast_type);
+        const LocalVariable *result = add_local_var(st, expr->types.implicit_cast_type);
         union CfInstructionData data = { .strarray = {
-            .len = types->implicit_cast_type->data.array.len,
+            .len = expr->types.implicit_cast_type->data.array.len,
             .str = padded,
         }};
         add_instruction(st, expr->location, CF_STRING_ARRAY, &data, NULL, result);
@@ -617,22 +610,22 @@ static const LocalVariable *build_expression(struct State *st, const AstExpressi
             return NULL;
         break;
     case AST_EXPR_BRACE_INIT:
-        result = build_struct_init(st, types->type, &expr->data.call, expr->location);
+        result = build_struct_init(st, t, &expr->data.call, expr->location);
         break;
     case AST_EXPR_ARRAY:
-        assert(types->type->kind == TYPE_ARRAY);
-        assert(types->type->data.array.len == expr->data.array.count);
-        result = build_array(st, types->type, expr->data.array.items, expr->location);
+        assert(t->kind == TYPE_ARRAY);
+        assert(t->data.array.len == expr->data.array.count);
+        result = build_array(st, t, expr->data.array.items, expr->location);
         break;
     case AST_EXPR_GET_FIELD:
         temp = build_expression(st, expr->data.classfield.obj);
         result = build_class_field(st, temp, expr->data.classfield.fieldname, expr->location);
         break;
     case AST_EXPR_GET_ENUM_MEMBER:
-        result = add_local_var(st, types->type);
+        result = add_local_var(st, t);
         Constant c = { CONSTANT_ENUM_MEMBER, {
-            .enum_member.enumtype = types->type,
-            .enum_member.memberidx = find_enum_member(types->type, expr->data.enummember.membername),
+            .enum_member.enumtype = t,
+            .enum_member.memberidx = find_enum_member(t, expr->data.enummember.membername),
         }};
         add_constant(st, expr->location, c, result);
         break;
@@ -645,7 +638,7 @@ static const LocalVariable *build_expression(struct State *st, const AstExpressi
             break;
         }
         if ((temp = find_local_var(st, expr->data.varname))) {
-            if (types->implicit_cast_type == NULL || types->type == types->implicit_cast_type) {
+            if (expr->types.implicit_cast_type == NULL || t == expr->types.implicit_cast_type) {
                 // Must take a "snapshot" of this variable, as it may change soon.
                 result = add_local_var(st, temp->type);
                 add_unary_op(st, expr->location, CF_VARCPY, temp, result);
@@ -669,7 +662,7 @@ static const LocalVariable *build_expression(struct State *st, const AstExpressi
         and we only add a memory offset to it.
         */
         temp = build_address_of_expression(st, expr);
-        result = add_local_var(st, types->type);
+        result = add_local_var(st, t);
         add_unary_op(st, expr->location, CF_PTR_LOAD, temp, result);
         break;
     case AST_EXPR_ADDRESS_OF:
@@ -678,17 +671,17 @@ static const LocalVariable *build_expression(struct State *st, const AstExpressi
     case AST_EXPR_SIZEOF:
         {
             result = add_local_var(st, longType);
-            union CfInstructionData data = { .type = get_expr_types(st, &expr->data.operands[0])->type };
+            union CfInstructionData data = { .type = expr->data.operands[0].types.type };
             add_instruction(st, expr->location, CF_SIZEOF, &data, NULL, result);
         }
         break;
     case AST_EXPR_DEREFERENCE:
         temp = build_expression(st, &expr->data.operands[0]);
-        result = add_local_var(st, types->type);
+        result = add_local_var(st, t);
         add_unary_op(st, expr->location, CF_PTR_LOAD, temp, result);
         break;
     case AST_EXPR_CONSTANT:
-        result = add_local_var(st, types->type);
+        result = add_local_var(st, t);
         add_constant(st, expr->location, expr->data.constant, result);
         break;
     case AST_EXPR_AND:
@@ -730,7 +723,7 @@ static const LocalVariable *build_expression(struct State *st, const AstExpressi
             // order of function arguments.
             const LocalVariable *lhs = build_expression(st, &expr->data.operands[0]);
             const LocalVariable *rhs = build_expression(st, &expr->data.operands[1]);
-            result = build_binop(st, expr->kind, expr->location, lhs, rhs, types->type);
+            result = build_binop(st, expr->kind, expr->location, lhs, rhs, t);
             break;
         }
     case AST_EXPR_PRE_INCREMENT:
@@ -753,14 +746,13 @@ static const LocalVariable *build_expression(struct State *st, const AstExpressi
         }
     case AST_EXPR_AS:
         temp = build_expression(st, expr->data.as.obj);
-        result = build_cast(st, temp, types->type, expr->location);
+        result = build_cast(st, temp, t, expr->location);
         break;
     }
 
-    assert(types);
-    assert(result->type == types->type);
-    if (types->implicit_cast_type)
-        return build_cast(st, result, types->implicit_cast_type, expr->location);
+    assert(result->type == t);
+    if (expr->types.implicit_cast_type)
+        return build_cast(st, result, expr->types.implicit_cast_type, expr->location);
     else
         return result;
 }

--- a/bootstrap_compiler/free.c
+++ b/bootstrap_compiler/free.c
@@ -252,9 +252,6 @@ void free_file_types(const FileTypes *ft)
     for (struct SignatureAndUsedPtr *f = ft->functions.ptr; f < End(ft->functions); f++)
         free_signature(&f->signature);
     for (FunctionOrMethodTypes *f = ft->fomtypes.ptr; f < End(ft->fomtypes); f++) {
-        for (ExpressionTypes **et = f->expr_types.ptr; et < End(f->expr_types); et++)
-            free(*et);
-        free(f->expr_types.ptr);
         free(f->locals.ptr);  // Don't free individual locals because they're owned by CFG now
         free_signature(&f->signature);
     }

--- a/bootstrap_compiler/jou_compiler.h
+++ b/bootstrap_compiler/jou_compiler.h
@@ -169,8 +169,21 @@ struct AstCall {
     int nargs;
 };
 
+struct ExpressionTypes {
+    const Type *type;
+    const Type *implicit_cast_type;  // NULL for no implicit cast
+
+    // Flags to indicate whether special kinds of implicit casts happened
+    bool implicit_array_to_pointer_cast;    // Foo[N] to Foo*
+    bool implicit_string_to_array_cast;     // "..." to byte[N]
+};
+
 struct AstExpression {
     Location location;
+
+    // Populated during type checking. Before that, all fields are zeroed
+    // (e.g. NULL or false).
+    ExpressionTypes types;
 
     enum AstExpressionKind {
         AST_EXPR_CONSTANT,
@@ -461,16 +474,6 @@ struct LocalVariable {
     bool is_argument;    // First n variables are always the arguments
 };
 
-struct ExpressionTypes {
-    const AstExpression *expr;
-    const Type *type;
-    const Type *implicit_cast_type;  // NULL for no implicit cast
-
-    // Flags to indicate whether special kinds of implicit casts happened
-    bool implicit_array_to_pointer_cast;    // Foo[N] to Foo*
-    bool implicit_string_to_array_cast;     // "..." to byte[N]
-};
-
 struct ExportSymbol {
     enum ExportSymbolKind { EXPSYM_FUNCTION, EXPSYM_TYPE, EXPSYM_GLOBAL_VAR } kind;
     char name[200];
@@ -483,7 +486,6 @@ struct ExportSymbol {
 // Type information about a function or method defined in the current file.
 struct FunctionOrMethodTypes {
     Signature signature;
-    List(ExpressionTypes *) expr_types;
     List(LocalVariable *) locals;
 };
 

--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -10,6 +10,7 @@ import "stdlib/str.jou"
 import "stdlib/mem.jou"
 
 import "./errors_and_warnings.jou"
+import "./types.jou"
 import "./utils.jou"
 
 
@@ -133,6 +134,19 @@ class AstInstantiation:
         free(self->field_values)
 
 
+class ExpressionTypes:
+    # Type of value that the expression evaluates to, or NULL if the expression
+    # is calling '-> None' function/method.
+    type: Type*
+
+    # NULL if there's no implicit cast.
+    implicit_cast_type: Type*
+
+    # Flags to indicate whether special kinds of implicit casts happened
+    implicit_array_to_pointer_cast: bool    # Foo[N] to Foo*
+    implicit_string_to_array_cast: bool     # "..." to byte[N]
+
+
 enum AstExpressionKind:
     String
     Int
@@ -181,6 +195,10 @@ class AstExpression:
     location: Location
     kind: AstExpressionKind
 
+    # Populated during type checking. Before that, all fields are zeroed
+    # (e.g. NULL or false).
+    types: ExpressionTypes
+
     union:
         enum_member: AstEnumMember
         class_field: AstClassField
@@ -199,7 +217,12 @@ class AstExpression:
         operands: AstExpression*  # Only for operators. Length is arity, see get_arity()
 
     def print_with_tree_printer(self, tp: TreePrinter) -> None:
-        printf("[line %d] ", self->location.lineno)
+        printf("[line %d", self->location.lineno)
+        if self->types.type != NULL:
+            printf(", type %s", self->types.type->name)
+            # TODO: print casts and other stuff under self->types?
+        printf("] ")
+
         if self->kind == AstExpressionKind::String:
             printf("string ")
             print_string(self->string, strlen(self->string))

--- a/compiler/build_cf_graph.jou
+++ b/compiler/build_cf_graph.jou
@@ -53,14 +53,6 @@ class CfBuilder:
 
         return var
 
-    def get_expr_types(self, expr: AstExpression*) -> ExpressionTypes*:
-        # TODO: a fancy binary search algorithm? (need to add sorting)
-        assert self->fomtypes != NULL
-        for i = 0; i < self->fomtypes->n_expr_types; i++:
-            if self->fomtypes->expr_types[i]->expr == expr:
-                return self->fomtypes->expr_types[i]
-        return NULL
-
     def add_block(self) -> CfBlock*:
         block: CfBlock* = calloc(1, sizeof *block)
 
@@ -436,7 +428,7 @@ class CfBuilder:
 
     def build_address_of_expression(self, address_of_what: AstExpression*) -> LocalVariable*:
         if address_of_what->kind == AstExpressionKind::GetVariable:
-            ptrtype = self->get_expr_types(address_of_what)->type->pointer_type()
+            ptrtype = address_of_what->types.type->pointer_type()
             addr = self->add_var(ptrtype)
 
             local_var = self->find_var(address_of_what->varname)
@@ -455,7 +447,7 @@ class CfBuilder:
             return addr
 
         if address_of_what->kind == AstExpressionKind::Self:
-            ptrtype = self->get_expr_types(address_of_what)->type->pointer_type()
+            ptrtype = address_of_what->types.type->pointer_type()
             addr = self->add_var(ptrtype)
 
             local_var = self->find_var("self")
@@ -500,7 +492,7 @@ class CfBuilder:
         sig: Signature* = NULL
 
         if call->method_call_self != NULL:
-            selfclass = self->get_expr_types(call->method_call_self)->type
+            selfclass = call->method_call_self->types.type
             if call->uses_arrow_operator:
                 assert selfclass->kind == TypeKind::Pointer
                 selfclass = selfclass->value_type
@@ -581,26 +573,24 @@ class CfBuilder:
         return arr
 
     def build_expression(self, expr: AstExpression*) -> LocalVariable*:
-        types = self->get_expr_types(expr)
-
-        if types != NULL and types->implicit_array_to_pointer_cast:
+        if expr->types.implicit_array_to_pointer_cast:
             arrptr = self->build_address_of_expression(expr)
-            memberptr = self->add_var(types->implicit_cast_type)
+            memberptr = self->add_var(expr->types.implicit_cast_type)
             self->unary_op(expr->location, CfInstructionKind::PtrCast, arrptr, memberptr)
             return memberptr
 
-        if types != NULL and types->implicit_string_to_array_cast:
-            assert types->implicit_cast_type != NULL
-            assert types->implicit_cast_type->kind == TypeKind::Array
+        if expr->types.implicit_string_to_array_cast:
+            assert expr->types.implicit_cast_type != NULL
+            assert expr->types.implicit_cast_type->kind == TypeKind::Array
             assert expr->kind == AstExpressionKind::String
 
-            array_size = types->implicit_cast_type->array.len
+            array_size = expr->types.implicit_cast_type->array.len
             assert strlen(expr->string) < array_size
             padded: byte* = calloc(1, array_size)
             assert padded != NULL
             strcpy(padded, expr->string)
 
-            result = self->add_var(types->implicit_cast_type)
+            result = self->add_var(expr->types.implicit_cast_type)
             ins = CfInstruction{
                 location = expr->location,
                 kind = CfInstructionKind::StringArray,
@@ -613,24 +603,29 @@ class CfBuilder:
             self->add_instruction(ins)
             return result
 
+        t = expr->types.type
+        if expr->kind != AstExpressionKind::Call:
+            # Calls do not necessary return anything, all other expressions do.
+            assert t != NULL
+
         if expr->kind == AstExpressionKind::Call:
             result = self->build_call(expr->location, &expr->call)
             if result == NULL:
                 # called function/method has no return value
                 return NULL
         elif expr->kind == AstExpressionKind::Instantiate:
-            result = self->build_instantiation(types->type, &expr->instantiation, expr->location)
+            result = self->build_instantiation(t, &expr->instantiation, expr->location)
         elif expr->kind == AstExpressionKind::Array:
-            assert types->type->kind == TypeKind::Array
-            assert types->type->array.len == expr->array.length
-            result = self->build_array(types->type, expr->array.items, expr->location)
+            assert t->kind == TypeKind::Array
+            assert t->array.len == expr->array.length
+            result = self->build_array(t, expr->array.items, expr->location)
         elif expr->kind == AstExpressionKind::GetEnumMember:
-            result = self->add_var(types->type)
+            result = self->add_var(t)
             c = Constant{
                 kind = ConstantKind::EnumMember,
                 enum_member = EnumMemberConstant{
-                    enumtype = types->type,
-                    memberidx = find_enum_member(types->type, expr->enum_member.member_name),
+                    enumtype = t,
+                    memberidx = find_enum_member(t, expr->enum_member.member_name),
                 }
             }
             self->constant(expr->location, c, result)
@@ -648,7 +643,7 @@ class CfBuilder:
             else:
                 temp = self->find_var(expr->varname)
                 if temp != NULL:
-                    if types->implicit_cast_type == NULL or types->type == types->implicit_cast_type:
+                    if expr->types.implicit_cast_type == NULL or t == expr->types.implicit_cast_type:
                         # Must take a "snapshot" of this variable, as it may change soon.
                         result = self->add_var(temp->type)
                         self->unary_op(expr->location, CfInstructionKind::VarCpy, temp, result)
@@ -658,7 +653,7 @@ class CfBuilder:
                     # For other than local variables we can evaluate as &*variable.
                     # Would also work for locals, but it would confuse simplify_cfg.
                     temp = self->build_address_of_expression(expr)
-                    result = self->add_var(types->type)
+                    result = self->add_var(t)
                     self->unary_op(expr->location, CfInstructionKind::PtrLoad, temp, result)
         elif (
             expr->kind == AstExpressionKind::GetClassField
@@ -681,7 +676,7 @@ class CfBuilder:
             # But &foo->bar and &foo[bar] always work, because foo is already a pointer
             # and we only add a memory offset to it.
             temp = self->build_address_of_expression(expr)
-            result = self->add_var(types->type)
+            result = self->add_var(t)
             self->unary_op(expr->location, CfInstructionKind::PtrLoad, temp, result)
         elif expr->kind == AstExpressionKind::AddressOf:
             result = self->build_address_of_expression(&expr->operands[0])
@@ -690,18 +685,18 @@ class CfBuilder:
             ins = CfInstruction{
                 location = expr->location,
                 kind = CfInstructionKind::SizeOf,
-                type = self->get_expr_types(&expr->operands[0])->type,
+                type = expr->operands[0].types.type,
                 destvar = result,
             }
             self->add_instruction(ins)
         elif expr->kind == AstExpressionKind::Dereference:
             temp = self->build_expression(&expr->operands[0])
-            result = self->add_var(types->type)
+            result = self->add_var(t)
             self->unary_op(expr->location, CfInstructionKind::PtrLoad, temp, result)
         elif expr->kind == AstExpressionKind::Self:
             selfvar = self->find_var("self")
             assert selfvar != NULL
-            if types->implicit_cast_type == NULL or types->type == types->implicit_cast_type:
+            if expr->types.implicit_cast_type == NULL or t == expr->types.implicit_cast_type:
                 # Must take a "snapshot" of this variable, as it may change soon.
                 result = self->add_var(selfvar->type)
                 self->unary_op(expr->location, CfInstructionKind::VarCpy, selfvar, result)
@@ -742,7 +737,7 @@ class CfBuilder:
                 c = Constant{kind = ConstantKind::String, str = strdup(expr->string)}
             else:
                 assert False
-            result = self->add_var(types->type)
+            result = self->add_var(t)
             self->constant(expr->location, c, result)
         elif expr->kind == AstExpressionKind::And:
             result = self->build_and_or(&expr->operands[0], &expr->operands[1], AndOr::And)
@@ -781,7 +776,7 @@ class CfBuilder:
             # evaluate lhs first. C doesn't guarantee evaluation order of function arguments.
             lhs = self->build_expression(&expr->operands[0])
             rhs = self->build_expression(&expr->operands[1])
-            result = self->build_binop(expr->kind, expr->location, lhs, rhs, types->type)
+            result = self->build_binop(expr->kind, expr->location, lhs, rhs, t)
         elif (
             expr->kind == AstExpressionKind::PreIncr
             or expr->kind == AstExpressionKind::PreDecr
@@ -805,15 +800,14 @@ class CfBuilder:
             result = self->build_increment_or_decrement(expr->location, &expr->operands[0], pop, diff)
         elif expr->kind == AstExpressionKind::As:
             temp = self->build_expression(&expr->as_->value)
-            result = self->build_cast(temp, types->type, expr->location)
+            result = self->build_cast(temp, t, expr->location)
         else:
             assert False
 
-        assert types != NULL
-        assert result->type == types->type
-        if types->implicit_cast_type == NULL:
+        assert result->type == t
+        if expr->types.implicit_cast_type == NULL:
             return result
-        return self->build_cast(result, types->implicit_cast_type, expr->location)
+        return self->build_cast(result, expr->types.implicit_cast_type, expr->location)
 
     def build_if_statement(self, ifstmt: AstIfStatement*) -> None:
         assert ifstmt->n_if_and_elifs >= 1

--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -330,6 +330,9 @@ class CompileState:
             if command_line_args.verbosity >= 1:
                 printf("  step 3: %s\n", self->files[i].path)
             typecheck_step3_function_and_method_bodies(&self->files[i].types, &self->files[i].ast)
+            if command_line_args.verbosity >= 3:
+                # AST now contains types. If very verbose, print them.
+                self->files[i].ast.print()
 
         free(pending_exports)
 

--- a/compiler/typecheck/common.jou
+++ b/compiler/typecheck/common.jou
@@ -35,16 +35,6 @@ class LocalVariable:
         self->print_to_width(0)
 
 
-class ExpressionTypes:
-    expr: AstExpression*  # not owned
-    type: Type*
-    implicit_cast_type: Type*  # NULL for no implicit cast
-
-    # Flags to indicate whether special kinds of implicit casts happened
-    implicit_array_to_pointer_cast: bool    # Foo[N] to Foo*
-    implicit_string_to_array_cast: bool     # "..." to byte[N]
-
-
 # Type checking steps 1 and 2 return export symbols to be passed on to the next
 # step. That's how the next step accesses the results of the previous step.
 enum ExportSymbolKind:
@@ -68,8 +58,6 @@ class ExportSymbol:
 # Not created for anything imported from another file.
 class FunctionOrMethodTypes:
     signature: Signature
-    expr_types: ExpressionTypes**
-    n_expr_types: int
     locals: LocalVariable**
     nlocals: int
 
@@ -124,9 +112,6 @@ class FileTypes:
         for func = self->functions; func < &self->functions[self->nfunctions]; func++:
             func->signature.free()
         for fom = self->fomtypes; fom < &self->fomtypes[self->nfomtypes]; fom++:
-            for et = fom->expr_types; et < &fom->expr_types[fom->n_expr_types]; et++:
-                free(*et)
-            free(fom->expr_types)
             free(fom->locals)  # Don't free individual locals because they're owned by CFG now
             fom->signature.free()
         free(self->globals)

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -249,52 +249,56 @@ def can_cast_explicitly(from: Type*, to: Type*) -> bool:
 
 def do_implicit_cast(
     fom: FunctionOrMethodTypes*,
-    types: ExpressionTypes*,
+    expr: AstExpression*,
     to: Type*,
     location: Location,
     errormsg_template: byte*,
 ) -> None:
-    assert types->implicit_cast_type == NULL
-    assert not types->implicit_array_to_pointer_cast
-    from = types->type
+    assert expr->types.type != NULL
+    assert expr->types.implicit_cast_type == NULL
+    assert not expr->types.implicit_array_to_pointer_cast
+
+    from = expr->types.type
     if from == to:
         return
 
     if (
-        types->expr->kind == AstExpressionKind::String
+        expr->kind == AstExpressionKind::String
         and from == byteType->pointer_type()
         and to->kind == TypeKind::Array
         and to->array.item_type == byteType
     ):
-        string_size = strlen(types->expr->string) + 1
+        string_size = strlen(expr->string) + 1
         if to->array.len < string_size:
             msg: byte[500]
             snprintf(msg, sizeof(msg), "a string of %d bytes (including '\\0') does not fit into %s", string_size, to->name)
             fail(location, msg)
-        types->implicit_string_to_array_cast = True
+        expr->types.implicit_string_to_array_cast = True
     # Passing in NULL for errormsg_template can be used to "force" a cast to happen.
     elif errormsg_template != NULL and not can_cast_implicitly(from, to):
         fail_with_implicit_cast_error(location, errormsg_template, from, to)
 
-    types->implicit_cast_type = to
-    types->implicit_array_to_pointer_cast = (from->kind == TypeKind::Array and to->is_pointer_type())
+    expr->types.implicit_cast_type = to
+    expr->types.implicit_array_to_pointer_cast = (from->kind == TypeKind::Array and to->is_pointer_type())
 
-    if types->implicit_array_to_pointer_cast:
+    if expr->types.implicit_array_to_pointer_cast:
         ensure_can_take_address(
             fom,
-            types->expr,
+            expr,
             "cannot create a pointer into an array that comes from %s (try storing it to a local variable first)"
         )
 
 
-def cast_array_to_pointer(fom: FunctionOrMethodTypes*, types: ExpressionTypes*) -> None:
-    assert types->type->kind == TypeKind::Array
-    do_implicit_cast(fom, types, types->type->array.item_type->pointer_type(), Location{}, NULL)
+def cast_array_to_pointer(fom: FunctionOrMethodTypes*, expr: AstExpression*) -> None:
+    assert expr->types.type != NULL
+    assert expr->types.type->kind == TypeKind::Array
+    do_implicit_cast(fom, expr, expr->types.type->array.item_type->pointer_type(), Location{}, NULL)
 
 
-def do_explicit_cast(fom: FunctionOrMethodTypes*, types: ExpressionTypes*, to: Type*, location: Location) -> None:
-    assert types->implicit_cast_type == NULL
-    from = types->type
+def do_explicit_cast(fom: FunctionOrMethodTypes*, expr: AstExpression*, to: Type*, location: Location) -> None:
+    assert expr->types.type != NULL
+    assert expr->types.implicit_cast_type == NULL
+    from = expr->types.type
 
     msg: byte[500]
 
@@ -307,15 +311,16 @@ def do_explicit_cast(fom: FunctionOrMethodTypes*, types: ExpressionTypes*, to: T
         fail(location, msg)
 
     if from->kind == TypeKind::Array and to->is_pointer_type():
-        cast_array_to_pointer(fom, types)
+        cast_array_to_pointer(fom, expr)
 
 
-def typecheck_expression_not_void(ft: FileTypes*, expr: AstExpression*) -> ExpressionTypes*:
-    types: ExpressionTypes* = typecheck_expression(ft, expr)
-    if types != NULL:
-        return types
+def typecheck_expression_not_void(ft: FileTypes*, expr: AstExpression*) -> Type*:
+    typecheck_expression(ft, expr)
+    if expr->types.type != NULL:
+        # The happy path. Evaluating the expression results in a value.
+        return expr->types.type
 
-    # Should be function/method call that returns void
+    # Should be function/method call that returns None
     assert expr->kind == AstExpressionKind::Call
 
     msg: byte[500]
@@ -332,17 +337,20 @@ def typecheck_expression_with_implicit_cast(
     casttype: Type*,
     errormsg_template: byte*,
 ) -> None:
-    types = typecheck_expression_not_void(ft, expr)
-    do_implicit_cast(ft->current_fom_types, types, casttype, expr->location, errormsg_template)
+    typecheck_expression_not_void(ft, expr)
+    do_implicit_cast(ft->current_fom_types, expr, casttype, expr->location, errormsg_template)
 
 
 def check_binop(
     fom: FunctionOrMethodTypes*,
     op: AstExpressionKind,
     location: Location,
-    lhstypes: ExpressionTypes*,
-    rhstypes: ExpressionTypes*,
+    lhs: AstExpression*,
+    rhs: AstExpression*,
 ) -> Type*:
+    assert lhs->types.type != NULL
+    assert rhs->types.type != NULL
+
     do_what: byte*
     if op == AstExpressionKind::Add:
         do_what = "add"
@@ -366,18 +374,18 @@ def check_binop(
     else:
         assert False
 
-    got_bools = lhstypes->type == boolType and rhstypes->type == boolType
-    got_integers = lhstypes->type->is_integer_type() and rhstypes->type->is_integer_type()
-    got_numbers = lhstypes->type->is_number_type() and rhstypes->type->is_number_type()
-    got_enums = lhstypes->type->kind == TypeKind::Enum and rhstypes->type->kind == TypeKind::Enum
+    got_bools = lhs->types.type == boolType and rhs->types.type == boolType
+    got_integers = lhs->types.type->is_integer_type() and rhs->types.type->is_integer_type()
+    got_numbers = lhs->types.type->is_number_type() and rhs->types.type->is_number_type()
+    got_enums = lhs->types.type->kind == TypeKind::Enum and rhs->types.type->kind == TypeKind::Enum
     got_pointers = (
-        lhstypes->type->is_pointer_type()
-        and rhstypes->type->is_pointer_type()
+        lhs->types.type->is_pointer_type()
+        and rhs->types.type->is_pointer_type()
         and (
             # Ban comparisons like int* == byte*, unless one of the two types is void*
-            lhstypes->type == rhstypes->type
-            or lhstypes->type == voidPtrType
-            or rhstypes->type == voidPtrType
+            lhs->types.type == rhs->types.type
+            or lhs->types.type == voidPtrType
+            or rhs->types.type == voidPtrType
         )
     )
 
@@ -402,7 +410,7 @@ def check_binop(
         )
     ):
         msg: byte[500]
-        snprintf(msg, sizeof(msg), "wrong types: cannot %s %s and %s", do_what, lhstypes->type->name, rhstypes->type->name)
+        snprintf(msg, sizeof(msg), "wrong types: cannot %s %s and %s", do_what, lhs->types.type->name, rhs->types.type->name)
         fail(location, msg)
 
     cast_type: Type* = NULL
@@ -410,11 +418,11 @@ def check_binop(
         cast_type = boolType
     if got_integers:
         cast_type = get_integer_type(
-            max(lhstypes->type->size_in_bits, rhstypes->type->size_in_bits),
-            lhstypes->type->kind == TypeKind::SignedInteger or rhstypes->type->kind == TypeKind::SignedInteger
+            max(lhs->types.type->size_in_bits, rhs->types.type->size_in_bits),
+            lhs->types.type->kind == TypeKind::SignedInteger or rhs->types.type->kind == TypeKind::SignedInteger
         )
     if got_numbers and not got_integers:
-        if lhstypes->type == doubleType or rhstypes->type == doubleType:
+        if lhs->types.type == doubleType or rhs->types.type == doubleType:
             cast_type = doubleType
         else:
             cast_type = floatType
@@ -424,8 +432,8 @@ def check_binop(
         cast_type = intType
     assert cast_type != NULL
 
-    do_implicit_cast(fom, lhstypes, cast_type, Location{}, NULL)
-    do_implicit_cast(fom, rhstypes, cast_type, Location{}, NULL)
+    do_implicit_cast(fom, lhs, cast_type, Location{}, NULL)
+    do_implicit_cast(fom, rhs, cast_type, Location{}, NULL)
 
     if (
         op == AstExpressionKind::Add
@@ -463,7 +471,7 @@ def check_increment_or_decrement(ft: FileTypes*, expr: AstExpression*) -> Type*:
 
     ensure_can_take_address(ft->current_fom_types, &expr->operands[0], bad_expr_fmt)
 
-    t = typecheck_expression_not_void(ft, &expr->operands[0])->type
+    t = typecheck_expression_not_void(ft, &expr->operands[0])
     if not t->is_integer_type() and t->kind != TypeKind::Pointer:
         msg: byte[500]
         snprintf(msg, sizeof(msg), bad_type_fmt, t->name)
@@ -487,28 +495,27 @@ def typecheck_indexing(
 ) -> Type*:
     msg: byte[500]
 
-    types = typecheck_expression_not_void(ft, ptrexpr)
-
-    if types->type->kind == TypeKind::Array:
-        cast_array_to_pointer(ft->current_fom_types, types)
-        ptrtype = types->implicit_cast_type
+    ptrtype = typecheck_expression_not_void(ft, ptrexpr)
+    if ptrtype->kind == TypeKind::Array:
+        cast_array_to_pointer(ft->current_fom_types, ptrexpr)
+        ptrtype = ptrexpr->types.implicit_cast_type
     else:
-        if types->type->kind != TypeKind::Pointer:
-            snprintf(msg, sizeof(msg), "value of type %s cannot be indexed", types->type->name)
+        if ptrtype->kind != TypeKind::Pointer:
+            snprintf(msg, sizeof(msg), "value of type %s cannot be indexed", ptrtype->name)
             fail(ptrexpr->location, msg)
-        ptrtype = types->type
 
     assert ptrtype != NULL
     assert ptrtype->kind == TypeKind::Pointer
 
-    indextypes = typecheck_expression_not_void(ft, indexexpr)
-    if not indextypes->type->is_integer_type():
-        snprintf(msg, sizeof(msg), "the index inside [...] must be an integer, not %s", indextypes->type->name)
+    indextype = typecheck_expression_not_void(ft, indexexpr)
+    assert indextype != NULL
+    if not indextype->is_integer_type():
+        snprintf(msg, sizeof(msg), "the index inside [...] must be an integer, not %s", indextype->name)
         fail(indexexpr->location, msg)
 
     # LLVM assumes that indexes smaller than 64 bits are signed.
     # https://github.com/Akuli/jou/issues/48
-    do_implicit_cast(ft->current_fom_types, indextypes, longType, Location{}, NULL)
+    do_implicit_cast(ft->current_fom_types, indexexpr, longType, Location{}, NULL)
 
     return ptrtype->value_type
 
@@ -614,18 +621,14 @@ def typecheck_function_or_method_call(ft: FileTypes*, call: AstCall*, self_type:
 
     for i = k; i < call->nargs; i++:
         # This code runs for varargs, e.g. the things to format in printf().
-        types = typecheck_expression_not_void(ft, &call->args[i])
-
-        if types->type->kind == TypeKind::Array:
-            cast_array_to_pointer(ft->current_fom_types, types)
-        elif (
-            (types->type->is_integer_type() and types->type->size_in_bits < 32)
-            or types->type == boolType
-        ):
+        t = typecheck_expression_not_void(ft, &call->args[i])
+        if t->kind == TypeKind::Array:
+            cast_array_to_pointer(ft->current_fom_types, &call->args[i])
+        elif (t->is_integer_type() and t->size_in_bits < 32) or t == boolType:
             # Add implicit cast to signed int, just like in C.
-            do_implicit_cast(ft->current_fom_types, types, intType, Location{}, NULL)
-        elif types->type == floatType:
-            do_implicit_cast(ft->current_fom_types, types, doubleType, Location{}, NULL)
+            do_implicit_cast(ft->current_fom_types, &call->args[i], intType, Location{}, NULL)
+        elif t == floatType:
+            do_implicit_cast(ft->current_fom_types, &call->args[i], doubleType, Location{}, NULL)
 
     free(sigstr)
     return sig->returntype
@@ -692,22 +695,25 @@ def enum_member_exists(t: Type*, name: byte*) -> bool:
     return False
 
 
-def cast_array_members_to_a_common_type(fom: FunctionOrMethodTypes*, error_location: Location, exprtypes: ExpressionTypes**) -> Type*:
+def cast_array_members_to_a_common_type(fom: FunctionOrMethodTypes*, error_location: Location, array: AstArray) -> Type*:
     # Avoid O(ntypes^2) code in a long array where all or almost all items have the same type.
     # This is at most O(ntypes*k) where k is the number of distinct types.
     distinct: Type** = NULL
     ndistinct = 0
 
-    for et = exprtypes; *et != NULL; et++:
+    for i = 0; i < array.length; i++:
+        itemtype = array.items[i].types.type
+        assert itemtype != NULL
+
         found = False
         for t = distinct; t < &distinct[ndistinct]; t++:
-            if (*et)->type == *t:
+            if itemtype == *t:
                 found = True
                 break
         if not found:
             distinct = realloc(distinct, sizeof(distinct[0]) * (ndistinct + 1))
             assert distinct != NULL
-            distinct[ndistinct++] = (*et)->type
+            distinct[ndistinct++] = itemtype
 
     compatible_with_all: Type** = NULL
     n_compatible_with_all = 0
@@ -751,12 +757,12 @@ def cast_array_members_to_a_common_type(fom: FunctionOrMethodTypes*, error_locat
     free(distinct)
     free(compatible_with_all)
 
-    for et = exprtypes; *et != NULL; et++:
-        do_implicit_cast(fom, *et, elemtype, error_location, NULL)
+    for i = 0; i < array.length; i++:
+        do_implicit_cast(fom, &array.items[i], elemtype, error_location, NULL)
     return elemtype
 
 
-def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> ExpressionTypes*:
+def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> None:
     msg: byte[500]
     result: Type* = NULL
 
@@ -808,17 +814,14 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> ExpressionType
 
     elif expr->kind == AstExpressionKind::Array:
         n = expr->array.length
-        exprtypes: ExpressionTypes** = calloc(sizeof(exprtypes[0]), n+1)
         for i = 0; i < n; i++:
-            exprtypes[i] = typecheck_expression_not_void(ft, &expr->array.items[i])
-
-        membertype = cast_array_members_to_a_common_type(ft->current_fom_types, expr->location, exprtypes)
-        free(exprtypes)
+            typecheck_expression_not_void(ft, &expr->array.items[i])
+        membertype = cast_array_members_to_a_common_type(ft->current_fom_types, expr->location, expr->array)
         result = membertype->array_type(n)
 
     elif expr->kind == AstExpressionKind::GetClassField:
         if expr->class_field.uses_arrow_operator:
-            temptype = typecheck_expression_not_void(ft, expr->class_field.instance)->type
+            temptype = typecheck_expression_not_void(ft, expr->class_field.instance)
             if temptype->kind != TypeKind::Pointer or temptype->value_type->kind != TypeKind::Class:
                 snprintf(
                     msg, sizeof(msg),
@@ -827,7 +830,7 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> ExpressionType
                 fail(expr->location, msg)
             result = typecheck_class_field(temptype->value_type, expr->class_field.field_name, expr->location)->type
         else:
-            temptype = typecheck_expression_not_void(ft, expr->class_field.instance)->type
+            temptype = typecheck_expression_not_void(ft, expr->class_field.instance)
             if temptype->kind != TypeKind::Class:
                 snprintf(
                     msg, sizeof(msg),
@@ -840,7 +843,7 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> ExpressionType
         if expr->call.method_call_self == NULL:
             result = typecheck_function_or_method_call(ft, &expr->call, NULL, expr->location)
         elif expr->call.uses_arrow_operator:
-            temptype = typecheck_expression_not_void(ft, expr->call.method_call_self)->type
+            temptype = typecheck_expression_not_void(ft, expr->call.method_call_self)
             if temptype->kind != TypeKind::Pointer:
                 snprintf(msg, sizeof(msg),
                     "left side of the '->' operator must be a pointer, not %s",
@@ -848,7 +851,7 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> ExpressionType
                 fail(expr->location, msg)
             result = typecheck_function_or_method_call(ft, &expr->call, temptype->value_type, expr->location)
         else:
-            temptype = typecheck_expression_not_void(ft, expr->call.method_call_self)->type
+            temptype = typecheck_expression_not_void(ft, expr->call.method_call_self)
             result = typecheck_function_or_method_call(ft, &expr->call, temptype, expr->location)
 
             # If self argument is passed by pointer, make sure we can create that pointer
@@ -865,14 +868,14 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> ExpressionType
 
         if result == NULL:
             # no return value produced
-            return NULL
+            return
 
     elif expr->kind == AstExpressionKind::Indexing:
         result = typecheck_indexing(ft, &expr->operands[0], &expr->operands[1])
 
     elif expr->kind == AstExpressionKind::AddressOf:
         ensure_can_take_address(ft->current_fom_types, &expr->operands[0], "the '&' operator cannot be used with %s")
-        temptype = typecheck_expression_not_void(ft, &expr->operands[0])->type
+        temptype = typecheck_expression_not_void(ft, &expr->operands[0])
         result = temptype->pointer_type()
 
     elif expr->kind == AstExpressionKind::GetVariable:
@@ -887,7 +890,7 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> ExpressionType
         result = selfvar->type
 
     elif expr->kind == AstExpressionKind::Dereference:
-        temptype = typecheck_expression_not_void(ft, &expr->operands[0])->type
+        temptype = typecheck_expression_not_void(ft, &expr->operands[0])
         typecheck_dereferenced_pointer(expr->location, temptype)
         result = temptype->value_type
 
@@ -906,7 +909,7 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> ExpressionType
         result = boolType
 
     elif expr->kind == AstExpressionKind::Negate:
-        result = typecheck_expression_not_void(ft, &expr->operands[0])->type
+        result = typecheck_expression_not_void(ft, &expr->operands[0])
         if result->kind != TypeKind::SignedInteger and result->kind != TypeKind::FloatingPoint:
             snprintf(msg, sizeof(msg),
                 "value after '-' must be a float or double or a signed integer, not %s",
@@ -926,9 +929,9 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> ExpressionType
         or expr->kind == AstExpressionKind::Lt
         or expr->kind == AstExpressionKind::Le
     ):
-        lhstypes = typecheck_expression_not_void(ft, &expr->operands[0])
-        rhstypes = typecheck_expression_not_void(ft, &expr->operands[1])
-        result = check_binop(ft->current_fom_types, expr->kind, expr->location, lhstypes, rhstypes)
+        typecheck_expression_not_void(ft, &expr->operands[0])
+        typecheck_expression_not_void(ft, &expr->operands[1])
+        result = check_binop(ft->current_fom_types, expr->kind, expr->location, &expr->operands[0], &expr->operands[1])
 
     elif (
         expr->kind == AstExpressionKind::PreIncr
@@ -939,25 +942,16 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> ExpressionType
         result = check_increment_or_decrement(ft, expr)
 
     elif expr->kind == AstExpressionKind::As:
-        origtypes = typecheck_expression_not_void(ft, &expr->as_->value)
+        typecheck_expression_not_void(ft, &expr->as_->value)
         result = type_from_ast(ft, &expr->as_->type)
-        do_explicit_cast(ft->current_fom_types, origtypes, result, expr->location)
+        do_explicit_cast(ft->current_fom_types, &expr->as_->value, result, expr->location)
 
     else:
         printf("%d\n", expr->kind)
         assert False
 
     assert result != NULL
-
-    types: ExpressionTypes* = calloc(1, sizeof *types)
-    types->expr = expr
-    types->type = result
-
-    ft->current_fom_types->expr_types = realloc(ft->current_fom_types->expr_types, sizeof(ft->current_fom_types->expr_types[0]) * (ft->current_fom_types->n_expr_types + 1))
-    assert ft->current_fom_types->expr_types != NULL
-    ft->current_fom_types->expr_types[ft->current_fom_types->n_expr_types++] = types
-
-    return types
+    expr->types.type = result
 
 
 def typecheck_body(ft: FileTypes*, body: AstBody*) -> None:
@@ -1015,8 +1009,8 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
             and ft->find_any_var(targetexpr->varname) == NULL
         ):
             # Making a new variable. Use the type of the value being assigned.
-            types = typecheck_expression_not_void(ft, valueexpr)
-            ft->current_fom_types->add_variable(types->type, targetexpr->varname)
+            type = typecheck_expression_not_void(ft, valueexpr)
+            ft->current_fom_types->add_variable(type, targetexpr->varname)
         else:
             # Convert value to the type of an existing variable or other assignment target.
             ensure_can_take_address(ft->current_fom_types, targetexpr, "cannot assign to %s")
@@ -1027,8 +1021,8 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
                 desc = short_expression_description(targetexpr)
                 snprintf(msg, sizeof msg, "cannot assign a value of type <from> to %s of type <to>", desc)
 
-            targettypes = typecheck_expression_not_void(ft, targetexpr)
-            typecheck_expression_with_implicit_cast(ft, valueexpr, targettypes->type, msg)
+            targettype = typecheck_expression_not_void(ft, targetexpr)
+            typecheck_expression_with_implicit_cast(ft, valueexpr, targettype, msg)
 
     elif (
         stmt->kind == AstStatementKind::InPlaceAdd
@@ -1041,8 +1035,8 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
         valueexpr = &stmt->assignment.value
 
         ensure_can_take_address(ft->current_fom_types, targetexpr, "cannot assign to %s")
-        targettypes = typecheck_expression_not_void(ft, targetexpr)
-        value_types = typecheck_expression_not_void(ft, valueexpr)
+        targettype = typecheck_expression_not_void(ft, targetexpr)
+        value_type = typecheck_expression_not_void(ft, valueexpr)
 
         if stmt->kind == AstStatementKind::InPlaceAdd:
             op = AstExpressionKind::Add
@@ -1062,15 +1056,15 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
         else:
             assert False
 
-        t = check_binop(ft->current_fom_types, op, stmt->location, targettypes, value_types)
-        tempvalue_types = ExpressionTypes{expr = targetexpr, type = t}
+        t = check_binop(ft->current_fom_types, op, stmt->location, targetexpr, valueexpr)
+        targetexpr->types = ExpressionTypes{type = t}
 
         snprintf(msg, sizeof msg, "%s produced a value of type <from> which cannot be assigned back to <to>", opname)
-        do_implicit_cast(ft->current_fom_types, &tempvalue_types, targettypes->type, stmt->location, msg)
+        do_implicit_cast(ft->current_fom_types, targetexpr, targettype, stmt->location, msg)
 
         # I think it is currently impossible to cast target.
         # If this assert fails, we probably need to add another error message for it.
-        assert targettypes->implicit_cast_type == NULL
+        assert targetexpr->types.implicit_cast_type == NULL
 
     elif stmt->kind == AstStatementKind::Return:
         if ft->current_fom_types->signature.is_noreturn:

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -1057,14 +1057,13 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
             assert False
 
         t = check_binop(ft->current_fom_types, op, stmt->location, targetexpr, valueexpr)
-        targetexpr->types = ExpressionTypes{type = t}
-
-        snprintf(msg, sizeof msg, "%s produced a value of type <from> which cannot be assigned back to <to>", opname)
-        do_implicit_cast(ft->current_fom_types, targetexpr, targettype, stmt->location, msg)
-
-        # I think it is currently impossible to cast target.
-        # If this assert fails, we probably need to add another error message for it.
-        assert targetexpr->types.implicit_cast_type == NULL
+        if t != targetexpr->types.type:
+            snprintf(
+                msg, sizeof msg,
+                "%s produced a value of type %s which cannot be assigned back to %s",
+                opname, t->name, targetexpr->types.type->name
+            )
+            fail(stmt->location, msg)
 
     elif stmt->kind == AstStatementKind::Return:
         if ft->current_fom_types->signature.is_noreturn:


### PR DESCRIPTION
**Old approach:** During type checking, we build an array of `ExpressionTypes`, which holds the types of each expression in the function. Each `ExpressionTypes` has a pointer to the corresponding `AstExpression`.

**New approach:** `AstExpression` contains `ExpressionTypes`. It is filled in during type checking.

New approach is simpler. I thought about it when I chose to use the old approach, but my OOP-poisoned brain thought it is somehow worse. It isn't.

I also updated (somewhat lazily) the bootstrap compiler.