### PR TITLE
Add `.` syntax for enums

### DIFF
--- a/bootstrap_compiler/typecheck.c
+++ b/bootstrap_compiler/typecheck.c
@@ -1047,8 +1047,56 @@ static const Type *cast_array_members_to_a_common_type(const FunctionOrMethodTyp
     return elemtype;
 }
 
+/*
+The AST "foo.bar" may be:
+  - field "bar" of an instance of some class stored to variable "foo"
+  - member "bar" of enum "foo"
+
+The parser assumes it is always a field on an instance, because it's more
+general: "foo" can be any expression, not necessarily enum name.
+
+This function modifies the AST so that it sometimes changes from accessing
+class fields to accessing enum members. This cannot be done in the parser
+because it doesn't know what enums exist (they may be e.g. imported from
+other files). Feels like a hack, but works great :)
+*/
+static void handle_conflicting_class_field_and_enum_member_syntax(const FileTypes *ft, AstExpression *expr)
+{
+    if (expr->kind != AST_EXPR_GET_FIELD) {
+        // not foo.bar
+        return;
+    }
+
+    if (expr->data.classfield.obj->kind != AST_EXPR_GET_VARIABLE) {
+        // the "foo" part is something more complicated than a variable name
+        return;
+    }
+
+    char enum_name[100];
+    char member_name[100];
+    safe_strcpy(enum_name, expr->data.classfield.obj->data.varname);
+    safe_strcpy(member_name, expr->data.classfield.fieldname);
+
+    if (find_any_var(ft, enum_name) != NULL) {
+        // there is a variable named "foo", use that
+        return;
+    }
+
+    const Type *t = find_type(ft, expr->data.classfield.obj->data.varname);
+    if (t == NULL || t->kind != TYPE_ENUM) {
+        return;
+    }
+
+    expr->kind = AST_EXPR_GET_ENUM_MEMBER;
+    memset(&expr->data, 0, sizeof(expr->data));
+    safe_strcpy(expr->data.enummember.enumname, enum_name);
+    safe_strcpy(expr->data.enummember.membername, member_name);
+}
+
 static ExpressionTypes *typecheck_expression(FileTypes *ft, AstExpression *expr)
 {
+    handle_conflicting_class_field_and_enum_member_syntax(ft, expr);
+
     const Type *temptype;
     const Type *result;
 

--- a/bootstrap_compiler/typecheck.c
+++ b/bootstrap_compiler/typecheck.c
@@ -1049,8 +1049,8 @@ static const Type *cast_array_members_to_a_common_type(const FunctionOrMethodTyp
 
 /*
 The AST "foo.bar" may be:
-  - field "bar" of an instance of some class stored to variable "foo"
-  - member "bar" of enum "foo"
+    - field "bar" of an instance of some class stored to variable "foo"
+    - member "bar" of enum "foo"
 
 The parser assumes it is always a field on an instance, because it's more
 general: "foo" can be any expression, not necessarily enum name.

--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -216,6 +216,9 @@ class AstExpression:
         float_or_double_text: byte[100]
         operands: AstExpression*  # Only for operators. Length is arity, see get_arity()
 
+    def print(self) -> None:
+        self->print_with_tree_printer(TreePrinter{})
+
     def print_with_tree_printer(self, tp: TreePrinter) -> None:
         printf("[line %d", self->location.lineno)
         if self->types.type != NULL:

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -821,6 +821,9 @@ def handle_conflicting_class_field_and_enum_member_syntax(ft: FileTypes*, expr: 
             )
             fail(expr->location, msg)
 
+    if expr->class_field.uses_arrow_operator:
+        fail(expr->location, "the '->' operator cannot be used to look up enum members")
+
     expr->kind = AstExpressionKind::GetEnumMember
     expr->enum_member = AstEnumMember{
         enum_name = enum_name,

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -127,6 +127,16 @@ def short_expression_description(expr: AstExpression*) -> byte[200]:
 def ensure_can_take_address(fom: FunctionOrMethodTypes*, expr: AstExpression*, errmsg_template: byte*) -> None:
     assert fom != NULL
 
+    # If this assertion fails, it means you called ensure_can_take_address()
+    # before type-checking the expression. That's bad because this depends on
+    # the results of type checking.
+    #
+    # The dependency is a bit surprising. Jou code "foo.bar" can be either an
+    # enum member, or a field on an instance of a class. That is determined
+    # when type checking. Members of instances can be (usually) assigned to,
+    # but enum members cannot.
+    assert expr->types.type != NULL
+
     if (
         expr->kind == AstExpressionKind::Dereference
         or expr->kind == AstExpressionKind::Indexing  # &foo[bar]
@@ -469,13 +479,13 @@ def check_increment_or_decrement(ft: FileTypes*, expr: AstExpression*) -> Type*:
     else:
         assert False
 
-    ensure_can_take_address(ft->current_fom_types, &expr->operands[0], bad_expr_fmt)
-
     t = typecheck_expression_not_void(ft, &expr->operands[0])
     if not t->is_integer_type() and t->kind != TypeKind::Pointer:
         msg: byte[500]
         snprintf(msg, sizeof(msg), bad_type_fmt, t->name)
         fail(expr->location, msg)
+
+    ensure_can_take_address(ft->current_fom_types, &expr->operands[0], bad_expr_fmt)
     return t
 
 
@@ -762,9 +772,67 @@ def cast_array_members_to_a_common_type(fom: FunctionOrMethodTypes*, error_locat
     return elemtype
 
 
+# The AST "foo.bar" may be:
+#   - field "bar" of an instance of some class stored to variable "foo"
+#   - member "bar" of enum "foo"
+#
+# The parser assumes it is always a field on an instance, because it's more
+# general: "foo" can be any expression, not necessarily enum name.
+#
+# This function modifies the AST so that it sometimes changes from accessing
+# class fields to accessing enum members. This cannot be done in the parser
+# because it doesn't know what enums exist (they may be e.g. imported from
+# other files). Feels like a hack, but works great :)
+def handle_conflicting_class_field_and_enum_member_syntax(ft: FileTypes*, expr: AstExpression*) -> None:
+    if expr->kind != AstExpressionKind::GetClassField:
+        # not foo.bar
+        return
+
+    if expr->class_field.instance->kind != AstExpressionKind::GetVariable:
+        # the "foo" part is something more complicated than a variable name
+        return
+
+    enum_name: byte[100] = expr->class_field.instance->varname
+    member_name: byte[100] = expr->class_field.field_name
+
+    if ft->find_any_var(enum_name) != NULL:
+        # there is a variable named "foo", use that
+        # TODO: test this
+        return
+
+    t = ft->find_type(expr->class_field.instance->varname)
+    if t == NULL:
+        # no enum or variable, show variable not found error
+        return
+
+    if t->kind != TypeKind::Enum:
+        # attempting to do Foo.bar, where Foo is a type but not enum type
+        if t->kind == TypeKind::Class:
+            fail(expr->location, "class members cannot be accessed directly on the class, they only exist on instances")
+        else:
+            # TODO: Currently this cannot happen. Built-in types like "int" are
+            # keywords so that they cannot appear as expressions. A test should
+            # be added if this becomes possible in the future.
+            msg: byte[500]
+            snprintf(
+                msg, sizeof(msg),
+                "type '%s' has no members because it is not a class or an enum",
+                enum_name,
+            )
+            fail(expr->location, msg)
+
+    expr->kind = AstExpressionKind::GetEnumMember
+    expr->enum_member = AstEnumMember{
+        enum_name = enum_name,
+        member_name = member_name,
+    }
+
+
 def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> None:
     msg: byte[500]
     result: Type* = NULL
+
+    handle_conflicting_class_field_and_enum_member_syntax(ft, expr)
 
     if expr->kind == AstExpressionKind::Bool:
         result = boolType
@@ -874,9 +942,8 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> None:
         result = typecheck_indexing(ft, &expr->operands[0], &expr->operands[1])
 
     elif expr->kind == AstExpressionKind::AddressOf:
+        result = typecheck_expression_not_void(ft, &expr->operands[0])->pointer_type()
         ensure_can_take_address(ft->current_fom_types, &expr->operands[0], "the '&' operator cannot be used with %s")
-        temptype = typecheck_expression_not_void(ft, &expr->operands[0])
-        result = temptype->pointer_type()
 
     elif expr->kind == AstExpressionKind::GetVariable:
         result = ft->find_any_var(expr->varname)
@@ -1013,6 +1080,7 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
             ft->current_fom_types->add_variable(type, targetexpr->varname)
         else:
             # Convert value to the type of an existing variable or other assignment target.
+            targettype = typecheck_expression_not_void(ft, targetexpr)
             ensure_can_take_address(ft->current_fom_types, targetexpr, "cannot assign to %s")
 
             if targetexpr->kind == AstExpressionKind::Dereference:
@@ -1020,8 +1088,6 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
             else:
                 desc = short_expression_description(targetexpr)
                 snprintf(msg, sizeof msg, "cannot assign a value of type <from> to %s of type <to>", desc)
-
-            targettype = typecheck_expression_not_void(ft, targetexpr)
             typecheck_expression_with_implicit_cast(ft, valueexpr, targettype, msg)
 
     elif (
@@ -1034,9 +1100,9 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
         targetexpr = &stmt->assignment.target
         valueexpr = &stmt->assignment.value
 
-        ensure_can_take_address(ft->current_fom_types, targetexpr, "cannot assign to %s")
         targettype = typecheck_expression_not_void(ft, targetexpr)
         value_type = typecheck_expression_not_void(ft, valueexpr)
+        ensure_can_take_address(ft->current_fom_types, targetexpr, "cannot assign to %s")
 
         if stmt->kind == AstStatementKind::InPlaceAdd:
             op = AstExpressionKind::Add

--- a/tests/404/enum.jou
+++ b/tests/404/enum.jou
@@ -1,2 +1,6 @@
+enum Foo:
+    Bar
+    Baz
+
 def foo() -> None:
-    x = Foo::Bar  # Error: there is no type named 'Foo'
+    x = Foooooo.Bar  # Error: no variable named 'Foooooo'

--- a/tests/404/enum_member.jou
+++ b/tests/404/enum_member.jou
@@ -3,4 +3,4 @@ enum FooBar:
     Bar
 
 def foo() -> None:
-    x = FooBar::Asdf  # Error: enum FooBar has no member named 'Asdf'
+    x = FooBar.Asdf  # Error: enum FooBar has no member named 'Asdf'

--- a/tests/already_exists_error/enum.jou
+++ b/tests/already_exists_error/enum.jou
@@ -1,0 +1,7 @@
+enum Foo:
+    Bar
+    Baz
+
+enum Foo:  # Error: asd asd
+    Lol
+    Wat

--- a/tests/already_exists_error/enum.jou
+++ b/tests/already_exists_error/enum.jou
@@ -2,6 +2,6 @@ enum Foo:
     Bar
     Baz
 
-enum Foo:  # Error: asd asd
+enum Foo:  # Error: an enum named 'Foo' already exists
     Lol
     Wat

--- a/tests/other_errors/assign_to_enum.jou
+++ b/tests/other_errors/assign_to_enum.jou
@@ -1,0 +1,6 @@
+enum Foo:
+    Bar
+    Baz
+
+def foo() -> None:
+    Foo.Bar = Foo.Baz  # Error: asd asd

--- a/tests/other_errors/assign_to_enum.jou
+++ b/tests/other_errors/assign_to_enum.jou
@@ -3,4 +3,4 @@ enum Foo:
     Baz
 
 def foo() -> None:
-    Foo.Bar = Foo.Baz  # Error: asd asd
+    Foo.Bar = Foo.Baz  # Error: cannot assign to an enum member

--- a/tests/other_errors/enum_arrow.jou
+++ b/tests/other_errors/enum_arrow.jou
@@ -1,0 +1,7 @@
+enum Foo:
+    Bar
+    Baz
+
+def main() -> int:
+    x = Foo->Bar  # Error: the '->' operator cannot be used to look up enum members
+    return 0

--- a/tests/should_succeed/enum.jou
+++ b/tests/should_succeed/enum.jou
@@ -5,19 +5,19 @@ enum FooBar:
     Bar
 
 def main() -> int:
-    printf("%d\n", FooBar::Foo as int)  # Output: 0
-    printf("%d\n", FooBar::Bar as int)  # Output: 1
+    printf("%d\n", FooBar.Foo as int)  # Output: 0
+    printf("%d\n", FooBar.Bar as int)  # Output: 1
 
-    printf("%d\n", FooBar::Foo as byte)  # Output: 0
-    printf("%d\n", FooBar::Bar as byte)  # Output: 1
+    printf("%d\n", FooBar.Foo as byte)  # Output: 0
+    printf("%d\n", FooBar.Bar as byte)  # Output: 1
 
-    printf("%lld\n", FooBar::Foo as long)  # Output: 0
-    printf("%lld\n", FooBar::Bar as long)  # Output: 1
+    printf("%lld\n", FooBar.Foo as long)  # Output: 0
+    printf("%lld\n", FooBar.Bar as long)  # Output: 1
 
-    x = FooBar::Foo
-    if x == FooBar::Foo:
+    x = FooBar.Foo
+    if x == FooBar.Foo:
         printf("yass\n")  # Output: yass
-    if x == FooBar::Bar:
+    if x == FooBar.Bar:
         printf("wut wut why dis\n")
 
     return 0

--- a/tests/should_succeed/enum_and_local_var.jou
+++ b/tests/should_succeed/enum_and_local_var.jou
@@ -1,0 +1,10 @@
+import "stdlib/io.jou"
+
+enum Foo:
+    Bar
+    Baz
+
+def main() -> int:
+    Foo = 123
+    printf("%d\n", Foo)  # Output: 123
+    return 0

--- a/tests/should_succeed/local_import.jou
+++ b/tests/should_succeed/local_import.jou
@@ -7,10 +7,10 @@ def main() -> int:
     p.increment_y()
     bar(p)  # Output: Bar Bar 1 3
 
-    foo = FooBar::Foo
-    if foo == FooBar::Foo:
+    foo = FooBar.Foo
+    if foo == FooBar.Foo:
         printf("Yay\n")  # Output: Yay
-    if foo == FooBar::Bar:
+    if foo == FooBar.Bar:
         printf("waaaat\n")
 
     return 0

--- a/tests/wrong_type/enum_member_from_class.jou
+++ b/tests/wrong_type/enum_member_from_class.jou
@@ -1,5 +1,0 @@
-class BlahBlah:
-    x: int
-
-def foo() -> int:
-    wat = BlahBlah::x  # Error: the '::' syntax is only for enums, but BlahBlah is a class

--- a/tests/wrong_type/int_to_enum.jou
+++ b/tests/wrong_type/int_to_enum.jou
@@ -3,4 +3,4 @@ enum FooBar:
     Bar
 
 def main() -> int:
-    x: int = FooBar::Foo  # Error: initial value for variable of type int cannot be of type FooBar
+    x: int = FooBar.Foo  # Error: initial value for variable of type int cannot be of type FooBar

--- a/tests/wrong_type/using_class_like_enum.jou
+++ b/tests/wrong_type/using_class_like_enum.jou
@@ -2,4 +2,4 @@ class BlahBlah:
     x: int
 
 def foo() -> int:
-    wat = BlahBlah.x  # Error: no variable named 'BlahBlah'
+    wat = BlahBlah.x  # Error: class members cannot be accessed directly on the class, they only exist on instances

--- a/tests/wrong_type/using_class_like_enum.jou
+++ b/tests/wrong_type/using_class_like_enum.jou
@@ -1,0 +1,5 @@
+class BlahBlah:
+    x: int
+
+def foo() -> int:
+    wat = BlahBlah.x  # Error: no variable named 'BlahBlah'


### PR DESCRIPTION
Part 1/3 of #599 
Closes #357 

There will temporarily be two enum syntaxes: `::` and `.` will both work. The `::` syntax will go away soon.