### PR TITLE
Use LLVM i8* for all pointers

### DIFF
--- a/compiler/codegen.jou
+++ b/compiler/codegen.jou
@@ -86,17 +86,15 @@ def codegen_class_type(type: Type*) -> LLVMType*:
 def codegen_type(type: Type*) -> LLVMType*:
     if type->kind == TypeKind.Array:
         return LLVMArrayType(codegen_type(type->array.item_type), type->array.len)
-    if type->kind == TypeKind.Pointer:
-        return LLVMPointerType(codegen_type(type->value_type), 0)
+    if type->is_pointer_type():
+        # Element type is ignored in new LLVM versions.
+        return LLVMPointerType(LLVMInt8Type(), 0)
     if type->kind == TypeKind.FloatingPoint:
         if type->size_in_bits == 32:
             return LLVMFloatType()
         if type->size_in_bits == 64:
             return LLVMDoubleType()
         assert False
-    if type->kind == TypeKind.VoidPointer:
-        # just use i8* as here https://stackoverflow.com/q/36724399
-        return LLVMPointerType(LLVMInt8Type(), 0)
     if (
         type->kind == TypeKind.SignedInteger
         or type->kind == TypeKind.UnsignedInteger
@@ -198,7 +196,10 @@ class CodeGen:
         assert cfvar != NULL
         for i = 0; &self->cfvars[i] < self->cfvars_end; i++:
             if self->cfvars[i] == cfvar:
-                LLVMBuildStore(self->builder, value, self->llvm_locals[i])
+                var_ptr = self->llvm_locals[i]
+                # TODO: The following line can be removed once we drop LLVM 14 support.
+                var_ptr = LLVMBuildBitCast(self->builder, var_ptr, LLVMPointerType(LLVMTypeOf(value), 0), "legacy_llvm14_cast")
+                LLVMBuildStore(self->builder, value, var_ptr)
                 return
         assert False
 
@@ -330,7 +331,10 @@ class CodeGen:
         elif ins->kind == CfInstructionKind.PtrLoad:
             self->setlocal(ins->destvar, LLVMBuildLoad2(self->builder, codegen_type(ins->operands[0]->type->value_type), self->getlocal(ins->operands[0]), "ptr_load"))
         elif ins->kind == CfInstructionKind.PtrStore:
-            LLVMBuildStore(self->builder, self->getlocal(ins->operands[1]), self->getlocal(ins->operands[0]))
+            ptr = self->getlocal(ins->operands[0])
+            # TODO: The following line can be removed once we drop LLVM 14 support.
+            ptr = LLVMBuildBitCast(self->builder, ptr, LLVMPointerType(LLVMTypeOf(self->getlocal(ins->operands[1])), 0), "legacy_llvm14_cast")
+            LLVMBuildStore(self->builder, self->getlocal(ins->operands[1]), ptr)
         elif ins->kind == CfInstructionKind.PtrToInt64:
             self->setlocal(ins->destvar, LLVMBuildPtrToInt(self->builder, self->getlocal(ins->operands[0]), LLVMInt64Type(), "ptr_as_long"))
         elif ins->kind == CfInstructionKind.Int64ToPtr:
@@ -343,10 +347,6 @@ class CodeGen:
                 f++
                 assert f < &classtype->classdata.fields[classtype->classdata.nfields]
             val = LLVMBuildStructGEP2(self->builder, codegen_type(classtype), self->getlocal(ins->operands[0]), f->union_id, ins->fieldname)
-            # This cast is needed in two cases:
-            #  * All pointers are i8* in structs so we can do self-referencing classes.
-            #  * This is how unions work.
-            val = LLVMBuildBitCast(self->builder, val, LLVMPointerType(codegen_type(f->type), 0), "struct_member_cast")
             self->setlocal(ins->destvar, val)
         elif ins->kind == CfInstructionKind.PtrMemsetToZero:
             size = LLVMSizeOf(codegen_type(ins->operands[0]->type->value_type))
@@ -383,9 +383,12 @@ class CodeGen:
                 assert False
         elif ins->kind == CfInstructionKind.BoolNegate:
             self->setlocal(ins->destvar, LLVMBuildXor(self->builder, self->getlocal(ins->operands[0]), LLVMConstInt(LLVMInt1Type(), 1, False as int), "bool_negate"))
-        elif ins->kind == CfInstructionKind.PtrCast:
-            self->setlocal(ins->destvar, LLVMBuildBitCast(self->builder, self->getlocal(ins->operands[0]), codegen_type(ins->destvar->type), "ptr_cast"))
-        elif ins->kind == CfInstructionKind.VarCpy or ins->kind == CfInstructionKind.Int32ToEnum or ins->kind == CfInstructionKind.EnumToInt32:
+        elif (
+            ins->kind == CfInstructionKind.VarCpy
+            or ins->kind == CfInstructionKind.PtrCast
+            or ins->kind == CfInstructionKind.Int32ToEnum
+            or ins->kind == CfInstructionKind.EnumToInt32
+        ):
             self->setlocal(ins->destvar, self->getlocal(ins->operands[0]))
         elif ins->kind == CfInstructionKind.NumAdd or ins->kind == CfInstructionKind.NumSub or ins->kind == CfInstructionKind.NumMul or ins->kind == CfInstructionKind.NumDiv or ins->kind == CfInstructionKind.NumMod:
             self->do_arithmetic_instruction(ins)

--- a/examples/aoc2023/day20/part1.jou
+++ b/examples/aoc2023/day20/part1.jou
@@ -13,11 +13,9 @@ enum ModuleKind:
 class Module:
     name: byte[15]
 
-    # TODO: use Module* instead of void*
-    # https://github.com/Akuli/jou/issues/473
-    sources: void*[10]
+    sources: Module*[10]
     nsources: int
-    destinations: void*[10]
+    destinations: Module*[10]
     ndestinations: int
 
     kind: ModuleKind

--- a/examples/aoc2023/day20/part2.jou
+++ b/examples/aoc2023/day20/part2.jou
@@ -13,11 +13,9 @@ enum ModuleKind:
 class Module:
     name: byte[15]
 
-    # TODO: use Module* instead of void*
-    # https://github.com/Akuli/jou/issues/473
-    sources: void*[10]
+    sources: Module*[10]
     nsources: int
-    destinations: void*[10]
+    destinations: Module*[10]
     ndestinations: int
 
     kind: ModuleKind

--- a/examples/aoc2024/day16/part2.jou
+++ b/examples/aoc2024/day16/part2.jou
@@ -42,7 +42,7 @@ def direction_to_0123(dir: int[2]) -> int:
 
 class StateStats:
     best_score: int
-    sources: void*[10]  # TODO: https://github.com/Akuli/jou/issues/473
+    sources: StateStats*[10]
     sources_len: int
     x: int
     y: int

--- a/examples/aoc2024/day23/part1.jou
+++ b/examples/aoc2024/day23/part1.jou
@@ -5,7 +5,7 @@ import "stdlib/io.jou"
 
 class Computer:
     name: byte[3]
-    connections: void*[100]  # TODO: should be Computer*[100], can't be due to compiler bug
+    connections: Computer*[100]
 
     def connect(self, other: Computer*) -> None:
         assert other != NULL

--- a/tests/should_succeed/nested_pointers.jou
+++ b/tests/should_succeed/nested_pointers.jou
@@ -1,0 +1,37 @@
+import "stdlib/io.jou"
+
+class Foo:
+    name: byte[50]
+    subfoos: Foo*[5]
+
+    def print(self, level: int) -> None:
+        for i = 0; i < level; i++:
+            printf("  ")
+        printf("%s\n", self->name)
+
+        for i = 0; self->subfoos[i] != NULL; i++:
+            self->subfoos[i]->print(level+1)
+
+def main() -> int:
+    parent = Foo{name = "Parent"}
+    a = Foo{name = "Aaaa"}
+    a1 = Foo{name = "a111"}
+    a2 = Foo{name = "a222"}
+    b = Foo{name = "Bbbb"}
+    bsub = Foo{name = "Bsub"}
+
+    parent.subfoos[0] = &a
+    parent.subfoos[1] = &b
+    a.subfoos[0] = &a1
+    a.subfoos[1] = &a2
+    b.subfoos[0] = &bsub
+
+    # Output: Parent
+    # Output:   Aaaa
+    # Output:     a111
+    # Output:     a222
+    # Output:   Bbbb
+    # Output:     Bsub
+    parent.print(0)
+
+    return 0


### PR DESCRIPTION
Starting with LLVM 15, the type of the pointed object is fully ignored, so always set it to `i8`. LLVM documentation about this: https://llvm.org/docs/OpaquePointers.html#version-support

Fixes #473 