### PR TITLE
Fix memory leak in bootstrap_compiler

### DIFF
--- a/bootstrap_compiler/codegen.c
+++ b/bootstrap_compiler/codegen.c
@@ -178,7 +178,9 @@ static LLVMTypeRef codegen_function_type(const Signature *sig)
     else
         returntype = codegen_type(sig->returntype);
 
-    return LLVMFunctionType(returntype, argtypes, sig->nargs, sig->takes_varargs);
+    LLVMTypeRef functype = LLVMFunctionType(returntype, argtypes, sig->nargs, sig->takes_varargs);
+    free(argtypes);
+    return functype;
 }
 
 static LLVMValueRef codegen_function_or_method_decl(const struct State *st, const Signature *sig)


### PR DESCRIPTION
Fixes #619 

Self-hosted compiler already has this code that I somehow forgot when porting to bootstrap compiler.