### PR TITLE
Compilers: clean up pointer handling in codegen

### DIFF
--- a/bootstrap_compiler/codegen.c
+++ b/bootstrap_compiler/codegen.c
@@ -76,14 +76,8 @@ static LLVMTypeRef codegen_type(const Type *type)
             int n = type->data.classdata.fields.len;
 
             LLVMTypeRef *flat_elems = malloc(sizeof(flat_elems[0]) * n);  // NOLINT
-            for (int i = 0; i < n; i++) {
-                // Treat all pointers inside structs as if they were void*.
-                // This allows structs to contain pointers to themselves.
-                if (type->data.classdata.fields.ptr[i].type->kind == TYPE_POINTER)
-                    flat_elems[i] = codegen_type(voidPtrType);
-                else
-                    flat_elems[i] = codegen_type(type->data.classdata.fields.ptr[i].type);
-            }
+            for (int i = 0; i < n; i++)
+                flat_elems[i] = codegen_type(type->data.classdata.fields.ptr[i].type);
 
             // Combine together fields of the same union.
             LLVMTypeRef *combined = malloc(sizeof(combined[0]) * n);  // NOLINT

--- a/compiler/codegen.jou
+++ b/compiler/codegen.jou
@@ -61,12 +61,7 @@ def codegen_class_type(type: Type*) -> LLVMType*:
 
     flat_elems: LLVMType** = malloc(sizeof(flat_elems[0]) * n)
     for i = 0; i < n; i++:
-        # Treat all pointers inside classes as if they were void*.
-        # This allows classes to contain pointers to themselves.
-        if type->classdata.fields[i].type->kind == TypeKind.Pointer:
-            flat_elems[i] = codegen_type(voidPtrType)
-        else:
-            flat_elems[i] = codegen_type(type->classdata.fields[i].type)
+        flat_elems[i] = codegen_type(type->classdata.fields[i].type)
 
     # Combine together fields of the same union.
     combined: LLVMType** = malloc(sizeof(combined[0]) * n)


### PR DESCRIPTION
This is a leftover from #614 that is no longer needed.