### PR TITLE
Use ubuntu-latest for running valgrind

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   valgrind:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:


### PR DESCRIPTION
All other github actions files already use `runs-on: ubuntu-latest`.

Fixes #640 