### PR TITLE
Valgrind github config improvements

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -61,14 +61,46 @@ jobs:
       issues: write
     steps:
       - run: |
+          # Usage: find_issue <title>
+          # Echos issue number, if any
+          function find_issue() {
+              curl -s "https://api.github.com/repos/${{ github.repository }}/issues?state=open" \
+                  | jq -r --arg t "$1" '.[] | select(.title==$t) | .number'
+          }
+
+          # Usage: get_body <issue_number>
+          function get_body() {
+              curl -s "https://api.github.com/repos/${{ github.repository }}/issues/$1" | jq -r .body
+          }
+
+          # Usage: echo body | set_body <issue_number>
+          function set_body() {
+              curl -s -X PATCH \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  "https://api.github.com/repos/${{ github.repository }}/issues/$1" \
+                  -d "$(jq -n --arg b "$(cat)" '{body: $b}')"
+          }
+
+          # Usage: echo body | new_issue <title>
+          function new_issue() {
+              curl -s -X POST \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  "https://api.github.com/repos/${{ github.repository }}/issues" \
+                  -d "$(jq -n --arg t "$1" --arg b "$(cat)" '{title: $t, body: $b}')"
+          }
+
+          link="- [$(date +%Y-%m-%d)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          echo $link
+
           echo "Checking if there is already an issue about valgrind errors..."
-          if curl -s 'https://api.github.com/repos/${{ github.repository }}/issues?state=open' | jq '.[].title' | grep "Running tests with valgrind failed"; then
-            echo "There is already an open issue about the valgrind errors. Not creating a new one."
+          n=$(find_issue "Running tests with valgrind failed")
+
+          if [ -n "$n" ]; then
+              echo "There is already an open issue about the valgrind errors. Appending link to issue description."
+              ((get_body $n | awk 1) && echo "$link") | set_body $n
           else
-            echo "No open issue found, creating a new one."
-            curl -s -X POST \
-              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              https://api.github.com/repos/${{ github.repository }}/issues \
-              -d '{"title": "Running tests with valgrind failed", "body": "Valgrind output is here: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+              echo "No open issue found, creating a new one."
+              (echo "Valgrind outputs:" && echo "$link") | new_issue "Running tests with valgrind failed"
           fi

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -91,7 +91,7 @@ jobs:
                   -d "$(jq -n --arg t "$1" --arg b "$(cat)" '{title: $t, body: $b}')"
           }
 
-          link="- [$(date +%Y-%m-%d)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          link="- [$(date)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           echo $link
 
           echo "Checking if there is already an issue about valgrind errors..."


### PR DESCRIPTION
- Build a list of failed valgrind runs instead of showing only the first one.
- Refactor the code to use bash functions, so that it's easier to test it locally. You still need to substitute various `${{ github.foo }}` values with find/replace when testing.