### PR TITLE
GitHub Actions: bump test timeouts to 10 minutes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: macos-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         llvm-version: [14, 15, 16]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -149,7 +149,7 @@ jobs:
 
   test:
     runs-on: windows-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
         with:
@@ -180,7 +180,7 @@ jobs:
   test-zip:
     needs: build-zip
     runs-on: windows-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The CI sometimes fails because it goes a few seconds over 5 minutes for whatever reason. Let's give it some "breathing room".