### PR TITLE
Typecheck error messages: boolean --> bool

### DIFF
--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -533,7 +533,7 @@ def typecheck_and_or(
     assert strcmp(and_or, "and") == 0 or strcmp(and_or, "or") == 0
 
     errormsg: byte[100]
-    snprintf(errormsg, sizeof(errormsg), "'%s' only works with booleans, not <from>", and_or)
+    snprintf(errormsg, sizeof(errormsg), "'%s' only works with bools, not <from>", and_or)
 
     typecheck_expression_with_implicit_cast(ft, lhsexpr, boolType, errormsg)
     typecheck_expression_with_implicit_cast(ft, rhsexpr, boolType, errormsg)
@@ -982,7 +982,7 @@ def typecheck_expression(ft: FileTypes*, expr: AstExpression*) -> None:
         case AstExpressionKind.Not:
             typecheck_expression_with_implicit_cast(
                 ft, &expr->operands[0], boolType,
-                "value after 'not' must be a boolean, not <from>")
+                "value after 'not' must be a bool, not <from>")
             result = boolType
 
         case AstExpressionKind.Negate:
@@ -1040,9 +1040,9 @@ def typecheck_body(ft: FileTypes*, body: AstBody*) -> None:
 def typecheck_if_statement(ft: FileTypes*, ifstmt: AstIfStatement*) -> None:
     for i = 0; i < ifstmt->n_if_and_elifs; i++:
         if i == 0:
-            errmsg = "'if' condition must be a boolean, not <from>"
+            errmsg = "'if' condition must be a bool, not <from>"
         else:
-            errmsg = "'elif' condition must be a boolean, not <from>"
+            errmsg = "'elif' condition must be a bool, not <from>"
 
         typecheck_expression_with_implicit_cast(
             ft, &ifstmt->if_and_elifs[i].condition, boolType, errmsg)
@@ -1140,14 +1140,14 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
         case AstStatementKind.WhileLoop:
             typecheck_expression_with_implicit_cast(
                 ft, &stmt->while_loop.condition, boolType,
-                "'while' condition must be a boolean, not <from>")
+                "'while' condition must be a bool, not <from>")
             typecheck_body(ft, &stmt->while_loop.body)
 
         case AstStatementKind.ForLoop:
             typecheck_statement(ft, stmt->for_loop.init)
             typecheck_expression_with_implicit_cast(
                 ft, &stmt->for_loop.cond, boolType,
-                "'for' condition must be a boolean, not <from>")
+                "'for' condition must be a bool, not <from>")
             typecheck_body(ft, &stmt->for_loop.body)
             typecheck_statement(ft, stmt->for_loop.incr)
 
@@ -1274,7 +1274,7 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
             typecheck_expression(ft, &stmt->expression)
 
         case AstStatementKind.Assert:
-            typecheck_expression_with_implicit_cast(ft, &stmt->expression, boolType, "assertion must be a boolean, not <from>")
+            typecheck_expression_with_implicit_cast(ft, &stmt->expression, boolType, "assertion must be a bool, not <from>")
 
         case (
             AstStatementKind.FunctionDeclare

--- a/tests/wrong_type/assert.jou
+++ b/tests/wrong_type/assert.jou
@@ -1,2 +1,2 @@
 def main() -> int:
-    assert 123  # Error: assertion must be a boolean, not int
+    assert 123  # Error: assertion must be a bool, not int

--- a/tests/wrong_type/elif.jou
+++ b/tests/wrong_type/elif.jou
@@ -1,6 +1,6 @@
 def main() -> int:
     if True:
         return 1
-    elif 7:  # Error: 'elif' condition must be a boolean, not int
+    elif 7:  # Error: 'elif' condition must be a bool, not int
         return 2
     return 0

--- a/tests/wrong_type/for.jou
+++ b/tests/wrong_type/for.jou
@@ -1,4 +1,4 @@
 def main() -> int:
-    for i = 0; i; i = i+1:   # Error: 'for' condition must be a boolean, not int
+    for i = 0; i; i = i+1:   # Error: 'for' condition must be a bool, not int
         return 1
     return 0

--- a/tests/wrong_type/if.jou
+++ b/tests/wrong_type/if.jou
@@ -1,4 +1,4 @@
 def main() -> int:
-    if 7:  # Error: 'if' condition must be a boolean, not int
+    if 7:  # Error: 'if' condition must be a bool, not int
         return 1
     return 0

--- a/tests/wrong_type/not.jou
+++ b/tests/wrong_type/not.jou
@@ -1,4 +1,4 @@
 def main() -> int:
-    if not 1:  # Error: value after 'not' must be a boolean, not int
+    if not 1:  # Error: value after 'not' must be a bool, not int
         return 1
     return 0

--- a/tests/wrong_type/or.jou
+++ b/tests/wrong_type/or.jou
@@ -1,4 +1,4 @@
 def one_or_two(x: int) -> bool:
-    if x == 1 or 2:  # Error: 'or' only works with booleans, not int
+    if x == 1 or 2:  # Error: 'or' only works with bools, not int
         return True
     return False

--- a/tests/wrong_type/while.jou
+++ b/tests/wrong_type/while.jou
@@ -1,4 +1,4 @@
 def main() -> int:
-    while 7:  # Error: 'while' condition must be a boolean, not int
+    while 7:  # Error: 'while' condition must be a bool, not int
         return 1
     return 0


### PR DESCRIPTION
Today @taahol ran into this. He tried converting a value to type `boolean`, which doesn't exist because it's `bool`, so let's just say `bool` in error messages.