### PR TITLE
For loops: make all parts optional

### DIFF
--- a/bootstrap_compiler/build_llvm_ir.c
+++ b/bootstrap_compiler/build_llvm_ir.c
@@ -914,7 +914,10 @@ static void build_loop(
 
     // Evaluate condition and then jump to loop body or skip to after loop.
     LLVMPositionBuilderAtEnd(st->builder, condblock);
-    LLVMBuildCondBr(st->builder, build_expression(st, cond), bodyblock, doneblock);
+    if(cond)
+        LLVMBuildCondBr(st->builder, build_expression(st, cond), bodyblock, doneblock);
+    else
+        LLVMBuildBr(st->builder, bodyblock);
 
     // Within loop body, 'break' skips to after loop, 'continue' goes to incr.
     assert(st->nloops < sizeof(st->breaks)/sizeof(st->breaks[0]));
@@ -1029,7 +1032,7 @@ static void build_statement(struct State *st, const AstStatement *stmt)
         break;
     case AST_STMT_FOR:
         build_loop(
-            st, stmt->data.forloop.init, &stmt->data.forloop.cond, stmt->data.forloop.incr,
+            st, stmt->data.forloop.init, stmt->data.forloop.cond, stmt->data.forloop.incr,
             &stmt->data.forloop.body);
         break;
     case AST_STMT_MATCH:

--- a/bootstrap_compiler/free.c
+++ b/bootstrap_compiler/free.c
@@ -148,11 +148,18 @@ void free_ast_statement(const AstStatement *stmt)
         free_ast_body(&stmt->data.whileloop.body);
         break;
     case AST_STMT_FOR:
-        free_ast_statement(stmt->data.forloop.init);
-        free_expression(&stmt->data.forloop.cond);
-        free_ast_statement(stmt->data.forloop.incr);
-        free(stmt->data.forloop.init);
-        free(stmt->data.forloop.incr);
+        if (stmt->data.forloop.init) {
+            free_ast_statement(stmt->data.forloop.init);
+            free(stmt->data.forloop.init);
+        }
+        if (stmt->data.forloop.cond) {
+            free_expression(stmt->data.forloop.cond);
+            free(stmt->data.forloop.cond);
+        }
+        if (stmt->data.forloop.incr) {
+            free_ast_statement(stmt->data.forloop.incr);
+            free(stmt->data.forloop.incr);
+        }
         free_ast_body(&stmt->data.forloop.body);
         break;
     case AST_STMT_MATCH:

--- a/bootstrap_compiler/jou_compiler.h
+++ b/bootstrap_compiler/jou_compiler.h
@@ -254,11 +254,9 @@ struct AstForLoop {
     /*
     for init; cond; incr:
         ...body...
-
-    init and incr must be pointers because this struct goes inside AstStatement.
     */
     AstStatement *init;
-    AstExpression cond;
+    AstExpression *cond;
     AstStatement *incr;
     AstBody body;
 };

--- a/bootstrap_compiler/print.c
+++ b/bootstrap_compiler/print.c
@@ -354,15 +354,21 @@ static void print_ast_statement(const AstStatement *stmt, struct TreePrinter tp)
             break;
         case AST_STMT_FOR:
             printf("for loop\n");
-            sub = print_tree_prefix(tp, false);
-            printf("init: ");
-            print_ast_statement(stmt->data.forloop.init, sub);
-            sub = print_tree_prefix(tp, false);
-            printf("cond: ");
-            print_ast_expression(&stmt->data.forloop.cond, sub);
-            sub = print_tree_prefix(tp, false);
-            printf("incr: ");
-            print_ast_statement(stmt->data.forloop.incr, sub);
+            if (stmt->data.forloop.init) {
+                sub = print_tree_prefix(tp, false);
+                printf("init: ");
+                print_ast_statement(stmt->data.forloop.init, sub);
+            }
+            if (stmt->data.forloop.cond) {
+                sub = print_tree_prefix(tp, false);
+                printf("cond: ");
+                print_ast_expression(stmt->data.forloop.cond, sub);
+            }
+            if (stmt->data.forloop.incr) {
+                sub = print_tree_prefix(tp, false);
+                printf("incr: ");
+                print_ast_statement(stmt->data.forloop.incr, sub);
+            }
             sub = print_tree_prefix(tp, true);
             printf("body:\n");
             print_ast_body(&stmt->data.forloop.body, sub);

--- a/bootstrap_compiler/typecheck.c
+++ b/bootstrap_compiler/typecheck.c
@@ -1317,12 +1317,15 @@ static void typecheck_statement(FileTypes *ft, AstStatement *stmt)
         break;
 
     case AST_STMT_FOR:
-        typecheck_statement(ft, stmt->data.forloop.init);
-        typecheck_expression_with_implicit_cast(
-            ft, &stmt->data.forloop.cond, boolType,
-            "'for' condition must be a boolean, not FROM");
+        if (stmt->data.forloop.init)
+            typecheck_statement(ft, stmt->data.forloop.init);
+        if (stmt->data.forloop.cond)
+            typecheck_expression_with_implicit_cast(
+                ft, stmt->data.forloop.cond, boolType,
+                "'for' condition must be a boolean, not FROM");
         typecheck_body(ft, &stmt->data.forloop.body);
-        typecheck_statement(ft, stmt->data.forloop.incr);
+        if (stmt->data.forloop.incr)
+            typecheck_statement(ft, stmt->data.forloop.incr);
         break;
 
     case AST_STMT_MATCH:

--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -769,10 +769,9 @@ class AstCase:
 # for init; cond; incr:
 #     ...body...
 class AstForLoop:
-    # init and incr must be pointers because this goes inside AstStatement.
-    init: AstStatement*
-    cond: AstExpression
-    incr: AstStatement*
+    init: AstStatement*   # may be NULL
+    cond: AstExpression*  # may be NULL
+    incr: AstStatement*   # may be NULL
     body: AstBody
 
     def print(self) -> None:
@@ -781,28 +780,35 @@ class AstForLoop:
     def print_with_tree_printer(self, tp: TreePrinter) -> None:
         printf("for loop\n")
 
-        sub = tp.print_prefix(False)
-        printf("init: ")
-        self->init->print_with_tree_printer(sub)
+        if self->init != NULL:
+            sub = tp.print_prefix(False)
+            printf("init: ")
+            self->init->print_with_tree_printer(sub)
 
-        sub = tp.print_prefix(False)
-        printf("cond: ")
-        self->cond.print_with_tree_printer(sub)
+        if self->cond != NULL:
+            sub = tp.print_prefix(False)
+            printf("cond: ")
+            self->cond->print_with_tree_printer(sub)
 
-        sub = tp.print_prefix(False)
-        printf("incr: ")
-        self->incr->print_with_tree_printer(sub)
+        if self->incr != NULL:
+            sub = tp.print_prefix(False)
+            printf("incr: ")
+            self->incr->print_with_tree_printer(sub)
 
         sub = tp.print_prefix(True)
         printf("body:\n")
         self->body.print_with_tree_printer(sub)
 
     def free(self) -> None:
-        self->init->free()
-        free(self->init)
-        self->cond.free()
-        self->incr->free()
-        free(self->incr)
+        if self->init != NULL:
+            self->init->free()
+            free(self->init)
+        if self->cond != NULL:
+            self->cond->free()
+            free(self->cond)
+        if self->incr != NULL:
+            self->incr->free()
+            free(self->incr)
         self->body.free()
 
 

--- a/compiler/build_cf_graph.jou
+++ b/compiler/build_cf_graph.jou
@@ -902,6 +902,7 @@ class CfBuilder:
         cond: AstExpression*,
         incr: AstStatement*,
         body: AstBody*,
+        fallback_location: Location*
     ) -> None:
         condblock = self->add_block()  # evaluate condition and go to bodyblock or doneblock
         bodyblock = self->add_block()  # run loop body and go to incrblock
@@ -913,7 +914,12 @@ class CfBuilder:
 
         # Evaluate condition. Jump to loop body or skip to after loop.
         self->jump(NULL, condblock, condblock, condblock)
-        condvar = self->build_expression(cond)
+        if cond == NULL:
+            assert fallback_location != NULL
+            condvar = self->add_var(boolType)
+            self->constant(*fallback_location, Constant{kind = ConstantKind.Bool, boolean = True}, condvar)
+        else:
+            condvar = self->build_expression(cond)
         self->jump(condvar, bodyblock, doneblock, bodyblock)
 
         # 'break' skips to after loop, 'continue' goes to incr.
@@ -949,11 +955,11 @@ class CfBuilder:
             case AstStatementKind.WhileLoop:
                 self->build_loop(
                     NULL, &stmt->while_loop.condition, NULL,
-                    &stmt->while_loop.body)
+                    &stmt->while_loop.body, NULL)
             case AstStatementKind.ForLoop:
                 self->build_loop(
-                    stmt->for_loop.init, &stmt->for_loop.cond, stmt->for_loop.incr,
-                    &stmt->for_loop.body)
+                    stmt->for_loop.init, stmt->for_loop.cond, stmt->for_loop.incr,
+                    &stmt->for_loop.body, &stmt->location)
             case AstStatementKind.Match:
                 self->build_match_statement(&stmt->match_statement)
             case AstStatementKind.Break:

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -863,18 +863,34 @@ class Parser:
         ):
             fail(self->tokens[1].location, "Python-style for loops aren't supported. Use e.g. 'for i = 0; i < 10; i++'")
 
-        init: AstStatement* = malloc(sizeof *init)
-        incr: AstStatement* = malloc(sizeof *incr)
+        init: AstStatement*
+        if self->tokens->is_operator(";"):
+            init = NULL
+        else:
+            init = malloc(sizeof *init)
+            *init = self->parse_oneline_statement()
 
-        *init = self->parse_oneline_statement()
         if not self->tokens->is_operator(";"):
             self->tokens->fail_expected_got("a ';'")
         self->tokens++
-        cond = self->parse_expression()
+
+        cond: AstExpression*
+        if self->tokens->is_operator(";"):
+            cond = NULL
+        else:
+            cond = malloc(sizeof *cond)
+            *cond = self->parse_expression()
+
         if not self->tokens->is_operator(";"):
             self->tokens->fail_expected_got("a ';'")
         self->tokens++
-        *incr = self->parse_oneline_statement()
+
+        incr: AstStatement*
+        if self->tokens->is_operator(":"):
+            incr = NULL
+        else:
+            incr = malloc(sizeof *incr)
+            *incr = self->parse_oneline_statement()
 
         self->loop_counter++
         body = self->parse_body()

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -1144,12 +1144,15 @@ def typecheck_statement(ft: FileTypes*, stmt: AstStatement*) -> None:
             typecheck_body(ft, &stmt->while_loop.body)
 
         case AstStatementKind.ForLoop:
-            typecheck_statement(ft, stmt->for_loop.init)
-            typecheck_expression_with_implicit_cast(
-                ft, &stmt->for_loop.cond, boolType,
-                "'for' condition must be a boolean, not <from>")
+            if stmt->for_loop.init != NULL:
+                typecheck_statement(ft, stmt->for_loop.init)
+            if stmt->for_loop.cond != NULL:
+                typecheck_expression_with_implicit_cast(
+                    ft, stmt->for_loop.cond, boolType,
+                    "'for' condition must be a boolean, not <from>")
             typecheck_body(ft, &stmt->for_loop.body)
-            typecheck_statement(ft, stmt->for_loop.incr)
+            if stmt->for_loop.incr != NULL:
+                typecheck_statement(ft, stmt->for_loop.incr)
 
         case AstStatementKind.Match:
             typecheck_match_statement(ft, &stmt->match_statement)

--- a/tests/should_succeed/loops.jou
+++ b/tests/should_succeed/loops.jou
@@ -1,0 +1,47 @@
+def main() -> int:
+    # Output: 1
+    # Output: 2
+    # Output: 3
+    i = 0
+    while i < 3:
+        printf("%d\n", ++i)
+
+    # Output: 1
+    # Output: 3
+    i = 0
+    while True:
+        printf("%d\n", ++i)
+        if i == 3:
+            break
+
+    # Output: 1
+    # Output: 2
+    # Output: 3
+    for i = 1; i <= 3; i++:
+        printf("%d\n", i)
+
+    # Output: 1
+    # Output: 3
+    for i = 1; i <= 3; i++:
+        if i == 2:
+            continue
+        printf("%d\n", i)
+
+    # Output: 1
+    # Output: 3
+    i = 1
+    for ;; i++:
+        if i == 2:
+            continue
+        if i == 4:
+            break
+        printf("%d\n", i)
+
+    # Output: 1
+    # Output: 2
+    # Output: 3
+    i = 1
+    for ;;:
+        printf("%d\n", i++)
+        if i == 4:
+            break

--- a/tests/should_succeed/loops.jou
+++ b/tests/should_succeed/loops.jou
@@ -1,47 +1,55 @@
+import "stdlib/io.jou"
+
+
 def main() -> int:
-    # Output: 1
-    # Output: 2
-    # Output: 3
+    # Output: while 1
+    # Output: while 2
+    # Output: while 3
     i = 0
     while i < 3:
-        printf("%d\n", ++i)
+        printf("while %d\n", ++i)
 
-    # Output: 1
-    # Output: 3
+    # Output: while 1
+    # Output: while 3
     i = 0
     while True:
-        printf("%d\n", ++i)
+        if i == 1:
+            i++
+            continue
+        printf("while %d\n", ++i)
         if i == 3:
             break
 
-    # Output: 1
-    # Output: 2
-    # Output: 3
+    # Output: for 1
+    # Output: for 2
+    # Output: for 3
     for i = 1; i <= 3; i++:
-        printf("%d\n", i)
+        printf("for %d\n", i)
 
-    # Output: 1
-    # Output: 3
+    # Output: for 1
+    # Output: for 3
     for i = 1; i <= 3; i++:
         if i == 2:
             continue
-        printf("%d\n", i)
+        printf("for %d\n", i)
 
-    # Output: 1
-    # Output: 3
+    # Output: forever 1
+    # Output: forever 3
     i = 1
     for ;; i++:
         if i == 2:
             continue
         if i == 4:
             break
-        printf("%d\n", i)
+        printf("forever %d\n", i)
 
-    # Output: 1
-    # Output: 2
-    # Output: 3
+    # Output: forever 1
+    # Output: forever 2
+    # Output: forever 3
     i = 1
     for ;;:
-        printf("%d\n", i++)
+        printf("forever %d\n", i++)
         if i == 4:
             break
+
+    return 0


### PR DESCRIPTION
Now all three parts of the `for a; b; c:` are optional. Here are some examples.

```
# initialization is optional
i = 0
for ; i < 10; i++:
    printf("%d\n", i)

# condition is optional (defaults to True)
for i = 0;; i++:
    if i == 10:
        break
    printf("%d\n", i)

# increment is optional
for i = 0; i < 10;:
    printf("%d\n", i++)

# all fields are optional
i = 0
for ;;:
    if i == 10:
        break
    printf("%d\n", i++)
```