### PR TITLE
Add retrying to link checker

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ jobs:
       - run: editorconfig-checker
 
   markdownlink-checker:
-    timeout-minutes: 1
+    timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,5 +32,4 @@ jobs:
         with:
             python-version: '3.13'
       - run: pip install requests
-      - name: "Check the links in the markdown files"
-        run: python check-markdown-links.py
+      - run: python check-markdown-links.py --retry=5

--- a/check-markdown-links.py
+++ b/check-markdown-links.py
@@ -6,6 +6,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from functools import cache
 from http.client import responses as status_code_names
 from pathlib import Path
@@ -22,7 +23,7 @@ def find_markdown_files():
     return [Path(line) for line in output.splitlines()]
 
 
-def find_links(markdown_file_path):
+def find_links_in_file(markdown_file_path):
     content = markdown_file_path.read_text(encoding="utf-8")
 
     for lineno, line in enumerate(content.splitlines(), start=1):
@@ -35,12 +36,12 @@ def find_links(markdown_file_path):
             r"^\[[^\[\]]+\]: (.+)$",
         ]
         for regex in link_regexes:
-            for link_target in re.findall(regex, line):
-                yield (lineno, link_target)
+            for target in re.findall(regex, line):
+                yield (markdown_file_path, lineno, target)
 
 
 @cache
-def check_https_url(url):
+def check_https_link(url):
     try:
         # Many sites redirect to front page for bad URLs. Let's not treat that as ok.
         response = requests.head(url, timeout=10, allow_redirects=False)
@@ -56,7 +57,7 @@ def check_https_url(url):
     if response.status_code != expected_status:
         return f"site returns {response.status_code} {status_code_names[response.status_code]}"
 
-    return None
+    return "ok"
 
 
 def get_all_refs(path):
@@ -67,25 +68,26 @@ def get_all_refs(path):
     return result
 
 
-def check_link(markdown_file_path, link_target, offline_mode=False):
-    if link_target.startswith("http://"):
+def check_link(markdown_file_path, target, offline_mode=False):
+    if target.startswith("http://"):
         return "this link should probably use https instead of http"
 
-    if link_target.startswith("https://"):
-        assert not offline_mode
-        return check_https_url(link_target)
+    if target.startswith("https://"):
+        if offline_mode:
+            return "assume ok (offline mode)"
+        return check_https_link(target)
 
-    if "//" in link_target:
+    if "//" in target:
         return "double slashes are allowed only in http:// and https:// links"
 
-    if "\\" in link_target:
+    if "\\" in target:
         return "use forward slashes instead of backslashes"
 
-    if link_target.startswith('#'):
+    if target.startswith('#'):
         # Link to within same file
         path = markdown_file_path
     else:
-        path = markdown_file_path.parent / link_target.split("#")[0]
+        path = markdown_file_path.parent / target.split("#")[0]
 
     if PROJECT_ROOT not in path.resolve().parents:
         return "link points outside of the Jou project folder"
@@ -93,18 +95,18 @@ def check_link(markdown_file_path, link_target, offline_mode=False):
     if not path.exists():
         return "link points to a file or folder that doesn't exist"
 
-    if "#" in link_target:
+    if "#" in target:
         # Reference to title within markdown file.
         # For example: architecture-and-design.md#loading-order
         if (not path.is_file()) or path.suffix != ".md":
             return "hashtag '#' can only be used with markdown files"
 
         refs = get_all_refs(path)
-        ref = "#" + link_target.split("#", 1)[1]
+        ref = "#" + target.split("#", 1)[1]
         if ref not in refs:
             return f"no heading in {path} matches {ref} (should be one of: {' '.join(refs)})"
 
-    return None
+    return "ok"
 
 
 def main():
@@ -114,33 +116,59 @@ def main():
         action="store_true",
         help="don't do HTTP requests, just assume that https:// links are fine",
     )
+    parser.add_argument(
+        "--retry",
+        type=int,
+        default=1,
+        metavar="n",
+        help="retry n times when https links don't work",
+    )
     args = parser.parse_args()
 
-    paths = find_markdown_files()
-    assert paths
+    remaining_links = []
+    for path in find_markdown_files():
+        for link in find_links_in_file(path):
+            remaining_links.append(link)
+
+    if not remaining_links:
+        print("Error: no links found")
+        sys.exit(1)
 
     good_links = 0
     bad_links = 0
 
-    for path in paths:
-        print("Checking", path)
-        for lineno, link_target in find_links(path):
-            if link_target.startswith("https://") and args.offline:
-                continue
+    assert args.retry >= 1
+    for i in reversed(range(args.retry)):
+        if i == 0:
+            # Do not retry anymore
+            retry = None
+        else:
+            retry = []
 
-            problem = check_link(path, link_target, offline_mode=args.offline)
-            if problem:
-                print(f"{path}:{lineno}: {problem}")
-                bad_links += 1
-            else:
+        for link in remaining_links:
+            path, lineno, target = link
+            result = check_link(path, target, offline_mode=args.offline)
+            print(f"{path}:{lineno}: {result}")
+            if result == "ok" or result == "assume ok (offline mode)":
                 good_links += 1
+            elif target.startswith("https://") and retry is not None:
+                retry.append(link)
+            else:
+                bad_links += 1
+
+        remaining_links.clear()
+        if retry:
+            print(f"Sleeping for 10 seconds before trying {len(retry)} bad links again.")
+            print()
+            time.sleep(10)
+            remaining_links = retry
+            check_https_link.cache_clear()
 
     assert good_links + bad_links > 0
-
+    print()
+    print(f"checked {good_links + bad_links} links: {good_links} good, {bad_links} bad")
     if bad_links > 0:
         sys.exit(1)
-    else:
-        print(f"checked {good_links} links, no errors :)")
 
 
 main()


### PR DESCRIPTION
Sometimes the CI fails because a link is temporarily down. To work around this, try each link 5 times if it doesn't work.