### PR TITLE
Compiler refactor: store called function signature to AstCall

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -419,6 +419,7 @@ class AstCall:
     uses_arrow_operator: bool  # distinguishes foo->bar() and foo.bar()
     nargs: int
     args: AstExpression*
+    called_signature: Signature*  # populated in typecheck, NULL before typecheck runs, not owned
 
     def print(self) -> None:
         self->print_with_tree_printer(TreePrinter{})

--- a/compiler/build_cf_graph.jou
+++ b/compiler/build_cf_graph.jou
@@ -483,18 +483,7 @@ class CfBuilder:
         location: Location,
         call: AstCall*,
     ) -> LocalVariable*:
-        sig: Signature* = NULL
-
-        if call->method_call_self != NULL:
-            selfclass = call->method_call_self->types.orig_type
-            if call->uses_arrow_operator:
-                assert selfclass->kind == TypeKind.Pointer
-                selfclass = selfclass->value_type
-            assert selfclass->kind == TypeKind.Class
-            sig = selfclass->find_method(call->name)
-        else:
-            sig = self->filetypes->find_function(call->name)
-
+        sig = call->called_signature
         assert sig != NULL
 
         ins = CfInstruction{

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -596,6 +596,8 @@ def typecheck_function_or_method_call(state: State*, call: AstCall*, self_type: 
                 "class %s does not have a method named '%s'", self_type->name, call->name)
             fail(location, msg)
 
+    call->called_signature = sig
+
     if self_type == NULL:
         function_or_method = "function"
     else:


### PR DESCRIPTION
Much simpler than finding it again later.

The compiler is full of little refactor possibilities like this. CFG (Control Flow Graph) related things are the messiest, but fortunately I will soon replace them with a different approach to analyzing the code and building LLVM IR.