### PR TITLE
Use "match ... with ..." statements in compiler and examples

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -59,7 +59,7 @@ for i in ${!commits[@]}; do
         unzip llvm_headers.zip
     fi
 
-    # Convince make that jou_bootstrap.exe is usable as is, and does not need
+    # Convince make that jou_bootstrap(.exe) is usable as is, and does not need
     # to be recompiled. We don't want bootstrap inside bootstrap.
     if [ $i != 0 ]; then
         touch jou_bootstrap$exe_suffix

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,6 +18,7 @@ set -e -o pipefail
 # produces a compiler that is too old.
 commits=(
     1c7ce74933aea8a8862fd1d4409735b9fb7a1d7e  # last commit on main that contains the compiler written in C
+    b339b1b300ba98a2245b493a58dd7fab4c465020  # "match ... with ..." syntax
 )
 
 if [[ "${OS:=$(uname)}" =~ Windows ]]; then
@@ -50,12 +51,20 @@ for i in ${!commits[@]}; do
     show_message "Checking out and compiling commit ${commit:0:10} ($((i+1))/${#commits[@]})"
 
     git checkout -q $commit
+
     if [[ "$OS" =~ "Windows" ]] && [ $i == 0 ]; then
         # The compiler written in C needed LLVM headers, and getting them on
         # Windows turned out to be more difficult than expected, so I included
         # them in the repository as a zip file.
         unzip llvm_headers.zip
     fi
+
+    # Convince make that jou_bootstrap.exe is usable as is, and does not need
+    # to be recompiled. We don't want bootstrap inside bootstrap.
+    if [ $i != 0 ]; then
+        touch jou_bootstrap$exe_suffix
+    fi
+
     $make jou$exe_suffix
     mv -v jou$exe_suffix jou_bootstrap$exe_suffix
     $make clean

--- a/compiler/command_line_args.jou
+++ b/compiler/command_line_args.jou
@@ -46,77 +46,72 @@ def parse_command_line_args(argc: int, argv: byte**) -> None:
     # Set default optimize to O1, user sets optimize will overwrite the default flag
     command_line_args.optlevel = 1
 
-    if argc == 2 and strcmp(argv[1], "--help") == 0:
-        print_help(argv[0])
-        exit(0)
-
-    if argc == 2 and strcmp(argv[1], "--update") == 0:
-        update_jou_compiler()
-        exit(0)
+    if argc == 2:
+        match argv[1] with strcmp:
+            case "--help":
+                print_help(argv[0])
+                exit(0)
+            case "--update":
+                update_jou_compiler()
+                exit(0)
 
     i = 1
     while i < argc:
-        if strcmp(argv[i], "--help") == 0 or strcmp(argv[i], "--update") == 0:
-            fprintf(stderr, "%s: \"%s\" cannot be used with other arguments (try \"%s --help\")\n", argv[0], argv[i], argv[0])
-            exit(2)
-        elif strcmp(argv[i], "--verbose") == 0:
-            command_line_args.verbosity++
-            i++
-        elif starts_with(argv[i], "-v") and strspn(&argv[i][1], "v") == strlen(argv[i])-1:
-            command_line_args.verbosity += (strlen(argv[i]) as int) - 1
-            i++
-        elif strcmp(argv[i], "--valgrind") == 0:
-            command_line_args.valgrind = True
-            i++
-        elif strcmp(argv[i], "--tokenize-only") == 0:
-            if argc > 3:
-                fprintf(stderr, "%s: --tokenize-only cannot be used together with other flags (try \"%s --help\")\n", argv[0], argv[0])
+        match argv[i] with strcmp:
+            case "--help" | "--update":
+                fprintf(stderr, "%s: \"%s\" cannot be used with other arguments (try \"%s --help\")\n", argv[0], argv[i], argv[0])
                 exit(2)
-            command_line_args.tokenize_only = True
-            i++
-        elif strcmp(argv[i], "--parse-only") == 0:
-            if argc > 3:
-                fprintf(stderr, "%s: --parse-only cannot be used together with other flags (try \"%s --help\")", argv[0], argv[0])
-                exit(2)
-            command_line_args.parse_only = True
-            i++
-        elif strcmp(argv[i], "--linker-flags") == 0:
-            if command_line_args.linker_flags != NULL:
-                fprintf(stderr, "%s: --linker-flags cannot be given multiple times (try \"%s --help\")\n", argv[0], argv[0])
-                exit(2)
+            case "--verbose":
+                command_line_args.verbosity++
+                i++
+            case "--valgrind":
+                command_line_args.valgrind = True
+                i++
+            case "--tokenize-only":
+                if argc > 3:
+                    fprintf(stderr, "%s: --tokenize-only cannot be used together with other flags (try \"%s --help\")\n", argv[0], argv[0])
+                    exit(2)
+                command_line_args.tokenize_only = True
+                i++
+            case "--parse-only":
+                if argc > 3:
+                    fprintf(stderr, "%s: --parse-only cannot be used together with other flags (try \"%s --help\")", argv[0], argv[0])
+                    exit(2)
+                command_line_args.parse_only = True
+                i++
+            case "--linker-flags":
+                if command_line_args.linker_flags != NULL:
+                    fprintf(stderr, "%s: --linker-flags cannot be given multiple times (try \"%s --help\")\n", argv[0], argv[0])
+                    exit(2)
+                if argc-i < 2:
+                    fprintf(stderr, "%s: there must be a string of flags after --linker-flags (try \"%s --help\")\n", argv[0], argv[0])
+                    exit(2)
+                command_line_args.linker_flags = argv[i+1]
+                i += 2
+            case "-O0" | "-O1" | "-O2" | "-O3":
+                command_line_args.optlevel = argv[i][2] - '0'
+                i++
+            case "-o":
+                if argc-i < 2:
+                    fprintf(stderr, "%s: there must be a file name after -o (try \"%s --help\")\n", argv[0], argv[0])
+                    exit(2)
 
-            if argc-i < 2:
-                fprintf(stderr, "%s: there must be a string of flags after --linker-flags (try \"%s --help\")\n", argv[0], argv[0])
-                exit(2)
-
-            command_line_args.linker_flags = argv[i+1]
-            i += 2
-        elif (
-            strlen(argv[i]) == 3
-            and starts_with(argv[i], "-O")
-            and argv[i][2] >= '0'
-            and argv[i][2] <= '3'
-        ):
-            command_line_args.optlevel = argv[i][2] - '0'
-            i++
-        elif strcmp(argv[i], "-o") == 0:
-            if argc-i < 2:
-                fprintf(stderr, "%s: there must be a file name after -o (try \"%s --help\")\n", argv[0], argv[0])
-                exit(2)
-
-            command_line_args.outfile = argv[i+1]
-            if strlen(command_line_args.outfile) > 4 and ends_with(command_line_args.outfile, ".jou"):
-                fprintf(stderr, "%s: the filename after -o should be an executable, not a Jou file (try \"%s --help\")\n", argv[0], argv[0])
-                exit(2)
-            i += 2
-        elif argv[i][0] == '-':
-            fprintf(stderr, "%s: unknown argument \"%s\" (try \"%s --help\")\n", argv[0], argv[i], argv[0])
-            exit(2)
-        elif command_line_args.infile != NULL:
-            fprintf(stderr, "%s: you can only pass one Jou file (try \"%s --help\")\n", argv[0], argv[0])
-            exit(2)
-        else:
-            command_line_args.infile = argv[i++]
+                command_line_args.outfile = argv[i+1]
+                if strlen(command_line_args.outfile) > 4 and ends_with(command_line_args.outfile, ".jou"):
+                    fprintf(stderr, "%s: the filename after -o should be an executable, not a Jou file (try \"%s --help\")\n", argv[0], argv[0])
+                    exit(2)
+                i += 2
+            case _:
+                if starts_with(argv[i], "-v") and strspn(&argv[i][1], "v") == strlen(argv[i])-1:
+                    command_line_args.verbosity += (strlen(argv[i++]) as int) - 1
+                elif argv[i][0] == '-':
+                    fprintf(stderr, "%s: unknown argument \"%s\" (try \"%s --help\")\n", argv[0], argv[i], argv[0])
+                    exit(2)
+                elif command_line_args.infile != NULL:
+                    fprintf(stderr, "%s: you can only pass one Jou file (try \"%s --help\")\n", argv[0], argv[0])
+                    exit(2)
+                else:
+                    command_line_args.infile = argv[i++]
 
     if command_line_args.infile == NULL:
         fprintf(stderr, "%s: missing Jou file name (try \"%s --help\")\n", argv[0], argv[0])

--- a/compiler/evaluate.jou
+++ b/compiler/evaluate.jou
@@ -14,13 +14,15 @@ def evaluate_array_length(expr: AstExpression*) -> int:
 
 @public
 def get_special_constant(name: byte*) -> int:
-    if strcmp(name, "WINDOWS") == 0:
-        return WINDOWS as int
-    if strcmp(name, "MACOS") == 0:
-        return MACOS as int
-    if strcmp(name, "NETBSD") == 0:
-        return NETBSD as int
-    return -1
+    match name with strcmp:
+        case "WINDOWS":
+            return WINDOWS as int
+        case "MACOS":
+            return MACOS as int
+        case "NETBSD":
+            return NETBSD as int
+        case _:
+            return -1
 
 
 def evaluate_condition(expr: AstExpression*) -> bool:

--- a/compiler/tokenizer.jou
+++ b/compiler/tokenizer.jou
@@ -290,7 +290,9 @@ class Tokenizer:
         if c == '\\':
             after_backslash = self->read_byte()
             match after_backslash with bytecmp:
-                case '\0' | '\n':
+                case '\0':
+                    fail(self->location, "missing ' to end the byte literal")
+                case '\n':
                     self->location.lineno--
                     fail(self->location, "missing ' to end the byte literal")
                 case 'n':

--- a/compiler/tokenizer.jou
+++ b/compiler/tokenizer.jou
@@ -21,18 +21,17 @@ def is_operator_byte(c: byte) -> bool:
 
 def is_keyword(word: byte*) -> bool:
     # Please update the syntax documentation if you add keywords
-    keywords = [
-        "import", "def", "declare", "class", "union", "enum", "global",
-        "return", "if", "elif", "else", "while", "for", "pass", "break", "continue",
-        "True", "False", "None", "NULL", "void", "noreturn",
-        "and", "or", "not", "self", "as", "sizeof", "assert",
-        "bool", "byte", "short", "int", "long", "float", "double", "match", "with", "case",
-    ]
-
-    for i = 0; i < sizeof keywords / sizeof keywords[0]; i++:
-        if strcmp(keywords[i], word) == 0:
+    match word with strcmp:
+        case (
+            "import" | "def" | "declare" | "class" | "union" | "enum" | "global"
+            | "return" | "if" | "elif" | "else" | "while" | "for" | "pass" | "break" | "continue"
+            | "True" | "False" | "None" | "NULL" | "void" | "noreturn"
+            | "and" | "or" | "not" | "self" | "as" | "sizeof" | "assert"
+            | "bool" | "byte" | "short" | "int" | "long" | "float" | "double" | "match" | "with" | "case"
+        ):
             return True
-    return False
+        case _:
+            return False
 
 def hexdigit_value(c: byte) -> int:
     if 'A' <= c and c <= 'F':
@@ -139,20 +138,27 @@ def is_valid_float(str: byte[100]) -> bool:
     return is_valid_double(str) or strspn(str, "0123456789") == strlen(str)
 
 
+# TODO: should not be needed
+def bytecmp(a: byte, b: byte) -> int:
+    return (a as int) - (b as int)
+
+
 def flip_paren(c: byte) -> byte:
-    if c == '(':
-        return ')'
-    if c == ')':
-        return '('
-    if c == '[':
-        return ']'
-    if c == ']':
-        return '['
-    if c == '{':
-        return '}'
-    if c == '}':
-        return '{'
-    assert False
+    match c with bytecmp:
+        case '(':
+            return ')'
+        case ')':
+            return '('
+        case '[':
+            return ']'
+        case ']':
+            return '['
+        case '{':
+            return '}'
+        case '}':
+            return '{'
+        case _:
+            assert False
 
 
 class Tokenizer:
@@ -246,22 +252,23 @@ class Tokenizer:
         level = 0
         while True:
             c = self->read_byte()
-            if c == '\0':
-                # End of file. Do not validate that indentation is a
-                # multiple of 4 spaces. Add a trailing newline implicitly
-                # if needed.
-                #
-                # TODO: test this
-                return 0
-            elif c == '\n':
-                level = 0
-            elif c == '#':
-                self->consume_rest_of_line()
-            elif c == ' ':
-                level++
-            else:
-                self->unread_byte(c)
-                return level
+            match c with bytecmp:
+                case '\0':
+                    # End of file. Do not validate that indentation is a
+                    # multiple of 4 spaces. Add a trailing newline implicitly
+                    # if needed.
+                    #
+                    # TODO: test this
+                    return 0
+                case '\n':
+                    level = 0
+                case '#':
+                    self->consume_rest_of_line()
+                case ' ':
+                    level++
+                case _:
+                    self->unread_byte(c)
+                    return level
 
     def read_hex_escape_byte(self) -> byte:
         n1 = hexdigit_value(self->read_byte())
@@ -282,43 +289,45 @@ class Tokenizer:
 
         if c == '\\':
             after_backslash = self->read_byte()
-            if after_backslash == '\0' or after_backslash == '\n':
-                self->location.lineno--
-                fail(self->location, "missing ' to end the byte literal")
-            elif after_backslash == 'n':
-                c = '\n'
-            elif after_backslash == 'r':
-                c = '\r'
-            elif after_backslash == 't':
-                c = '\t'
-            elif after_backslash == '\\':
-                c = '\\'
-            elif after_backslash == '\'':
-                c = '\''
-            elif after_backslash == '"':
-                fail(self->location, "double quotes shouldn't be escaped in byte literals")
-            elif after_backslash == '0':
-                c = '\0'
-            elif after_backslash == 'x':
-                c = self->read_hex_escape_byte()
-            elif after_backslash < 0x80 and isprint(after_backslash) != 0:
-                message: byte* = malloc(100)
-                sprintf(message, "unknown escape: '\\%c'", after_backslash)
-                fail(self->location, message)
-            else:
-                fail(self->location, "unknown '\\' escape")
+            match after_backslash with bytecmp:
+                case '\0' | '\n':
+                    self->location.lineno--
+                    fail(self->location, "missing ' to end the byte literal")
+                case 'n':
+                    c = '\n'
+                case 'r':
+                    c = '\r'
+                case 't':
+                    c = '\t'
+                case '\\':
+                    c = '\\'
+                case '\'':
+                    c = '\''
+                case '"':
+                    fail(self->location, "double quotes shouldn't be escaped in byte literals")
+                case '0':
+                    c = '\0'
+                case 'x':
+                    c = self->read_hex_escape_byte()
+                case _:
+                    # TODO: add is_ascii_printable() function to stdlib/ascii.jou
+                    if after_backslash < 0x80 and isprint(after_backslash) != 0:
+                        message: byte* = malloc(100)
+                        sprintf(message, "unknown escape: '\\%c'", after_backslash)
+                        fail(self->location, message)
+                    else:
+                        fail(self->location, "unknown '\\' escape")
 
         end = self->read_byte()
         if end != '\'':
             # If there's another single quote later on the same line, suggest using double quotes.
             location = self->location
             while True:
-                c = self->read_byte()
-                if c == '\0' or c == '\n':
-                    break
-                if c == '\'':
-                    fail(location, "single quotes are for specifying a byte, maybe use double quotes to instead make a string?")
-            fail(location, "missing ' to end the byte literal")
+                match self->read_byte() with bytecmp:
+                    case '\0' | '\n':
+                        fail(location, "missing ' to end the byte literal")
+                    case '\'':
+                        fail(location, "single quotes are for specifying a byte, maybe use double quotes to instead make a string?")
 
         return c
 
@@ -326,61 +335,70 @@ class Tokenizer:
     def read_string(self) -> byte*:
         result: byte* = NULL
         len = 0
+        msg: byte[100]
 
         while True:
             c = self->read_byte()
-            if c == '"':
-                break
-            elif c == '\n' or c == '\0':
-                if c == '\n':
+            match c with bytecmp:
+                case '"':
+                    break
+                case '\n':
                     self->location.lineno--
-                fail(self->location, "missing \" to end the string")
-            elif c == '\\':
-                # \n means newline, for example
-                after_backslash = self->read_byte()
-                if after_backslash == '\0':
                     fail(self->location, "missing \" to end the string")
-                elif after_backslash == 'n':
+                case '\0':
+                    fail(self->location, "missing \" to end the string")
+                case '\\':
+                    # \n means newline, for example
+                    after_backslash = self->read_byte()
+                    match after_backslash with bytecmp:
+                        case '\0':
+                            fail(self->location, "missing \" to end the string")
+                        case 'n':
+                            result = realloc(result, len+1)
+                            result[len++] = '\n'
+                        case 'r':
+                            result = realloc(result, len+1)
+                            result[len++] = '\r'
+                        case 't':
+                            result = realloc(result, len+1)
+                            result[len++] = '\t'
+                        case '\\':
+                            result = realloc(result, len+1)
+                            result[len++] = '\\'
+                        case '"':
+                            result = realloc(result, len+1)
+                            result[len++] = '"'
+                        case '\'':
+                            fail(self->location, "single quotes shouldn't be escaped in strings")
+                        case '0':
+                            fail(self->location, "strings cannot contain zero bytes (\\0), because that is the special end marker byte")
+                        case 'x':
+                            b = self->read_hex_escape_byte()
+                            if b == '\0':
+                                fail(self->location, "strings cannot contain zero bytes (\\x00), because that is the special end marker byte")
+                            result = realloc(result, len+1)
+                            result[len++] = b
+                        case '\n':
+                            # \ at end of line, string continues on next line
+                            pass
+                        case _:
+                            # TODO: add is_ascii_printable() function to stdlib/ascii.jou
+                            if after_backslash < 0x80 and isprint(after_backslash) != 0:
+                                snprintf(msg, sizeof(msg), "unknown escape: '\\%c'", after_backslash)
+                            else:
+                                msg = "unknown '\\' escape"
+                            fail(self->location, msg)
+                case _:
                     result = realloc(result, len+1)
-                    result[len++] = '\n'
-                elif after_backslash == 'r':
-                    result = realloc(result, len+1)
-                    result[len++] = '\r'
-                elif after_backslash == 't':
-                    result = realloc(result, len+1)
-                    result[len++] = '\t'
-                elif after_backslash == '\\' or after_backslash == '"':
-                    result = realloc(result, len+1)
-                    result[len++] = after_backslash
-                elif after_backslash == '\'':
-                    fail(self->location, "single quotes shouldn't be escaped in strings")
-                elif after_backslash == '0':
-                    fail(self->location, "strings cannot contain zero bytes (\\0), because that is the special end marker byte")
-                elif after_backslash == 'x':
-                    b = self->read_hex_escape_byte()
-                    if b == '\0':
-                        fail(self->location, "strings cannot contain zero bytes (\\x00), because that is the special end marker byte")
-                    result = realloc(result, len+1)
-                    result[len++] = b
-                elif after_backslash == '\n':
-                    # \ at end of line, string continues on next line
-                    pass
-                else:
-                    if after_backslash < 0x80 and isprint(after_backslash) != 0:
-                        message: byte* = malloc(100)
-                        sprintf(message, "unknown escape: '\\%c'", after_backslash)
-                        fail(self->location, message)
-                    else:
-                        fail(self->location, "unknown '\\' escape")
-            else:
-                result = realloc(result, len+1)
-                result[len++] = c
+                    result[len++] = c
 
         result = realloc(result, len+1)
         result[len] = '\0'
         return result
 
     def read_operator(self) -> byte[100]:
+        msg: byte[100]
+
         operators = [
             # Please update the syntax documentation if you add new operators.
             # Longer operators are first, so that '==' does not tokenize as '=' '='
@@ -388,9 +406,7 @@ class Tokenizer:
             "==", "!=", "->", "<=", ">=", "++", "--", "+=", "-=", "*=", "/=", "%=", "&&", "||",
             ".", ",", ":", ";", "=", "(", ")", "{", "}", "[", "]", "&", "%", "*", "/", "+", "-", "<", ">", "!", "|",
         ]
-
-        operator: byte[100]
-        memset(&operator, 0, sizeof operator)
+        operator: byte[100] = ""
 
         # Read as many operator characters as we may need.
         while strlen(operator) < 3:
@@ -410,32 +426,32 @@ class Tokenizer:
 
                 # These operators are here only to give a better error message when you
                 # accidentally use syntax of another programming language.
-                if strcmp(operator, "===") == 0:
-                    fail(self->location, "use '==' instead of '==='")
-                if strcmp(operator, "!==") == 0:
-                    fail(self->location, "use '!=' instead of '!=='")
-                if strcmp(operator, "&&") == 0:
-                    fail(self->location, "use 'and' instead of '&&'")
-                if strcmp(operator, "||") == 0:
-                    fail(self->location, "use 'or' instead of '||'")
-                if strcmp(operator, "!") == 0:
-                    fail(self->location, "use 'not' instead of '!'")
+                match operator with strcmp:
+                    case "===":
+                        fail(self->location, "use '==' instead of '==='")
+                    case "!==":
+                        fail(self->location, "use '!=' instead of '!=='")
+                    case "&&":
+                        fail(self->location, "use 'and' instead of '&&'")
+                    case "||":
+                        fail(self->location, "use 'or' instead of '||'")
+                    case "!":
+                        fail(self->location, "use 'not' instead of '!'")
+                    case _:
+                        return operator
 
-                return operator
-
-        message: byte[100]
-        sprintf(message, "there is no '%s' operator", operator)
-        fail(self->location, message)
+        snprintf(msg, sizeof(msg), "there is no '%s' operator", operator)
+        fail(self->location, msg)
 
     def handle_parentheses(self, token: Token*) -> None:
+        msg: byte[100]
+
         if token->kind == TokenKind.EndOfFile and self->open_parens_len > 0:
             open_token = self->open_parens[0]
             actual_open = open_token.short_string[0]
             expected_close = flip_paren(actual_open)
-
-            message = malloc(100)
-            sprintf(message, "'%c' without a matching '%c'", actual_open, expected_close)
-            fail(open_token.location, message)
+            snprintf(msg, sizeof(msg), "'%c' without a matching '%c'", actual_open, expected_close)
+            fail(open_token.location, msg)
 
         if token->is_open_paren():
             if self->open_parens_len == sizeof self->open_parens / sizeof self->open_parens[0]:
@@ -446,73 +462,72 @@ class Tokenizer:
             actual_close = token->short_string[0]
             expected_open = flip_paren(actual_close)
             if self->open_parens_len == 0 or self->open_parens[--self->open_parens_len].short_string[0] != expected_open:
-                message = malloc(100)
-                sprintf(message, "'%c' without a matching '%c'", actual_close, expected_open)
-                fail(token->location, message)
+                snprintf(msg, sizeof(msg), "'%c' without a matching '%c'", actual_close, expected_open)
+                fail(token->location, msg)
 
     def read_token(self) -> Token:
         while True:
             token = Token{location = self->location}
             b = self->read_byte()
-
-            if b == ' ':
-                continue
-            if b == '#':
-                self->consume_rest_of_line()
-                continue
-
-            if b == '\n':
-                if self->open_parens_len > 0:
+            match b with bytecmp:
+                case ' ':
                     continue
-                token.kind = TokenKind.Newline
-                token.indentation_level = self->read_newline_token()
-            elif b == '"':
-                token.kind = TokenKind.String
-                token.long_string = self->read_string()
-            elif b == '\'':
-                token.kind = TokenKind.Byte
-                token.byte_value = self->read_byte_literal()
-            elif b == '@':
-                token.kind = TokenKind.Decorator
-                token.short_string = self->read_identifier_or_number(b)
-            elif is_identifier_or_number_byte(b):
-                token.short_string = self->read_identifier_or_number(b)
-                if is_keyword(token.short_string):
-                    token.kind = TokenKind.Keyword
-                elif '0' <= token.short_string[0] and token.short_string[0] <= '9':
-                    if is_valid_double(token.short_string):
-                        token.kind = TokenKind.Double
-                    elif is_valid_float(token.short_string):
-                        token.short_string[strlen(token.short_string) - 1] = '\0'  # delete trailing 'f' or 'F'
-                        token.kind = TokenKind.Float
-                    elif token.short_string[strlen(token.short_string) - 1] == 'L':
-                        token.short_string[strlen(token.short_string) - 1] = '\0'
-                        token.kind = TokenKind.Long
-                        token.long_value = parse_integer(token.short_string, token.location, 64)
-                    elif token.short_string[strlen(token.short_string) - 1] == 'S':
-                        token.short_string[strlen(token.short_string) - 1] = '\0'
-                        token.kind = TokenKind.Short
-                        token.short_value = parse_integer(token.short_string, token.location, 16) as short
+                case '#':
+                    self->consume_rest_of_line()
+                    continue
+                case '\n':
+                    if self->open_parens_len > 0:
+                        continue
+                    token.kind = TokenKind.Newline
+                    token.indentation_level = self->read_newline_token()
+                case '"':
+                    token.kind = TokenKind.String
+                    token.long_string = self->read_string()
+                case '\'':
+                    token.kind = TokenKind.Byte
+                    token.byte_value = self->read_byte_literal()
+                case '@':
+                    token.kind = TokenKind.Decorator
+                    token.short_string = self->read_identifier_or_number(b)
+                case '\t':
+                    fail(self->location, "Jou files cannot contain tab characters (use 4 spaces for indentation)")
+                case '\0':
+                    token.kind = TokenKind.EndOfFile
+                case _:
+                    if is_identifier_or_number_byte(b):
+                        token.short_string = self->read_identifier_or_number(b)
+                        if is_keyword(token.short_string):
+                            token.kind = TokenKind.Keyword
+                        elif '0' <= token.short_string[0] and token.short_string[0] <= '9':
+                            if is_valid_double(token.short_string):
+                                token.kind = TokenKind.Double
+                            elif is_valid_float(token.short_string):
+                                token.short_string[strlen(token.short_string) - 1] = '\0'  # delete trailing 'f' or 'F'
+                                token.kind = TokenKind.Float
+                            elif token.short_string[strlen(token.short_string) - 1] == 'L':
+                                token.short_string[strlen(token.short_string) - 1] = '\0'
+                                token.kind = TokenKind.Long
+                                token.long_value = parse_integer(token.short_string, token.location, 64)
+                            elif token.short_string[strlen(token.short_string) - 1] == 'S':
+                                token.short_string[strlen(token.short_string) - 1] = '\0'
+                                token.kind = TokenKind.Short
+                                token.short_value = parse_integer(token.short_string, token.location, 16) as short
+                            else:
+                                token.kind = TokenKind.Int
+                                token.int_value = parse_integer(token.short_string, token.location, 32) as int
+                        else:
+                            token.kind = TokenKind.Name
+                    elif is_operator_byte(b):
+                        self->unread_byte(b)
+                        token.kind = TokenKind.Operator
+                        token.short_string = self->read_operator()
                     else:
-                        token.kind = TokenKind.Int
-                        token.int_value = parse_integer(token.short_string, token.location, 32) as int
-                else:
-                    token.kind = TokenKind.Name
-            elif is_operator_byte(b):
-                self->unread_byte(b)
-                token.kind = TokenKind.Operator
-                token.short_string = self->read_operator()
-            elif b == '\t':
-                fail(self->location, "Jou files cannot contain tab characters (use 4 spaces for indentation)")
-            elif b == '\0':
-                token.kind = TokenKind.EndOfFile
-            else:
-                message: byte[100]
-                if b < 0x80 and isprint(b) != 0:
-                    sprintf(message, "unexpected byte '%c' (%#02x)", b, b)
-                else:
-                    sprintf(message, "unexpected byte %#02x", b)
-                fail(self->location, message)
+                        message: byte[100]
+                        if b < 0x80 and isprint(b) != 0:
+                            sprintf(message, "unexpected byte '%c' (%#02x)", b, b)
+                        else:
+                            sprintf(message, "unexpected byte %#02x", b)
+                        fail(self->location, message)
 
             self->handle_parentheses(&token)
             return token

--- a/compiler/typecheck/common.jou
+++ b/compiler/typecheck/common.jou
@@ -39,27 +39,27 @@ def type_from_ast(ft: FileTypes*, asttype: AstType*) -> Type*:
 
     match asttype->kind:
         case AstTypeKind.Named:
-            if strcmp(asttype->name, "short") == 0:
-                return shortType
-            if strcmp(asttype->name, "int") == 0:
-                return intType
-            if strcmp(asttype->name, "long") == 0:
-                return longType
-            if strcmp(asttype->name, "byte") == 0:
-                return byteType
-            if strcmp(asttype->name, "bool") == 0:
-                return boolType
-            if strcmp(asttype->name, "float") == 0:
-                return floatType
-            if strcmp(asttype->name, "double") == 0:
-                return doubleType
-
-            found = ft->find_type(asttype->name)
-            if found != NULL:
-                return found
-
-            snprintf(msg, sizeof(msg), "there is no type named '%s'", asttype->name)
-            fail(asttype->location, msg)
+            match asttype->name with strcmp:
+                case "short":
+                    return shortType
+                case "int":
+                    return intType
+                case "long":
+                    return longType
+                case "byte":
+                    return byteType
+                case "bool":
+                    return boolType
+                case "float":
+                    return floatType
+                case "double":
+                    return doubleType
+                case _:
+                    found = ft->find_type(asttype->name)
+                    if found != NULL:
+                        return found
+                    snprintf(msg, sizeof(msg), "there is no type named '%s'", asttype->name)
+                    fail(asttype->location, msg)
 
         case AstTypeKind.Pointer:
             if asttype->value_type->is_void():

--- a/examples/aoc2023/day02/part2.jou
+++ b/examples/aoc2023/day02/part2.jou
@@ -14,12 +14,13 @@ class Game:
         color: byte[10]
         assert sscanf(text, "%d %9s", &n, color) == 2
 
-        if strcmp(color, "red") == 0:
-            self->red = max(self->red, n)
-        if strcmp(color, "green") == 0:
-            self->green = max(self->green, n)
-        if strcmp(color, "blue") == 0:
-            self->blue = max(self->blue, n)
+        match color with strcmp:
+            case "red":
+                self->red = max(self->red, n)
+            case "green":
+                self->green = max(self->green, n)
+            case "blue":
+                self->blue = max(self->blue, n)
 
     def get_power(self) -> int:
         return self->red * self->green * self->blue

--- a/examples/aoc2023/day19/part1.jou
+++ b/examples/aoc2023/day19/part1.jou
@@ -109,10 +109,11 @@ def run(workflows: Workflow*, nworkflows: int, xmas: XMAS) -> bool:
 
     while True:
         result = find_workflow(workflows, nworkflows, result)->run(xmas)
-        if strcmp(result, "A") == 0:
-            return True
-        if strcmp(result, "R") == 0:
-            return False
+        match result with strcmp:
+            case "A":
+                return True
+            case "R":
+                return False
 
 
 def main() -> int:

--- a/examples/aoc2024/day24/part1.jou
+++ b/examples/aoc2024/day24/part1.jou
@@ -103,14 +103,15 @@ def main() -> int:
 
     input1, op, input2, output: byte[4]
     while fscanf(f, "%3s %3s %3s -> %3s\n", input1, op, input2, output) == 4:
-        if strcmp(op, "AND") == 0:
-            op_enum = LogicOp.And
-        elif strcmp(op, "OR") == 0:
-            op_enum = LogicOp.Or
-        elif strcmp(op, "XOR") == 0:
-            op_enum = LogicOp.Xor
-        else:
-            assert False
+        match op with strcmp:
+            case "AND":
+                op_enum = LogicOp.And
+            case "OR":
+                op_enum = LogicOp.Or
+            case "XOR":
+                op_enum = LogicOp.Xor
+            case _:
+                assert False
 
         assert ngates < sizeof(gates)/sizeof(gates[0])
         gates[ngates++] = LogicGate{

--- a/examples/aoc2024/day24/part2.jou
+++ b/examples/aoc2024/day24/part2.jou
@@ -256,21 +256,23 @@ def read_gates(filename: byte*, ngates: int*) -> Gate[250]:
             or (g.inputs[0][0] == 'y' and g.inputs[1][0] == 'x')
         ):
             # Handles input directly, so it must be InputXor or InputAnd
-            if strcmp(op, "XOR") == 0:
-                g.gtype = GateType.InputXor
-            elif strcmp(op, "AND") == 0:
-                g.gtype = GateType.InputAnd
-            else:
-                assert False
+            match op with strcmp:
+                case "XOR":
+                    g.gtype = GateType.InputXor
+                case "AND":
+                    g.gtype = GateType.InputAnd
+                case _:
+                    assert False
         else:
-            if strcmp(op, "XOR") == 0:
-                g.gtype = GateType.OutputXor
-            elif strcmp(op, "AND") == 0:
-                g.gtype = GateType.OverflowAnd
-            elif strcmp(op, "OR") == 0:
-                g.gtype = GateType.OverflowOr
-            else:
-                assert False
+            match op with strcmp:
+                case "XOR":
+                    g.gtype = GateType.OutputXor
+                case "AND":
+                    g.gtype = GateType.OverflowAnd
+                case "OR":
+                    g.gtype = GateType.OverflowOr
+                case _:
+                    assert False
 
         assert *ngates < sizeof(gates)/sizeof(gates[0])
         gates[(*ngates)++] = g


### PR DESCRIPTION
The code is slightly longer, but much more readable.

Currently `match some_byte:` doesn't work, but `match some_byte with bytecmp` does, where `bytecmp` is the following function:

```python
# TODO: should not be needed
def bytecmp(a: byte, b: byte) -> int:
    return (a as int) - (b as int)
```