### PR TITLE
bootstrap.sh: Add commit hash sanity check

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,6 @@ commits=(
     1c7ce74933aea8a8862fd1d4409735b9fb7a1d7e  # last commit on main that contains the compiler written in C
     b339b1b300ba98a2245b493a58dd7fab4c465020  # "match ... with ..." syntax
     874d1978044a080173fcdcc4e92736136c97dd61  # "match some_integer:" support
-    8cbccffe7e9f6a919035fc87b8684c74b3afcd8f  # TEMPORARY TEST
 )
 
 for commit in ${commits[@]}; do

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -50,7 +50,7 @@ for i in ${!commits[@]}; do
     commit=${commits[$i]}
 
     # Sanity check: commit must exists on main branch
-    if ! (git log main --format='%H' || true) | grep -qx $commit; then
+    if ! (git log origin/main --format='%H' || true) | grep -qx $commit; then
         echo "Error: commit $commit is not on main branch"
         exit 1
     fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -46,16 +46,17 @@ if [[ "$OS" =~ Windows ]]; then
 fi
 cd tmp/bootstrap
 
-for i in ${!commits[@]}; do
-    commit=${commits[$i]}
-
-    # Sanity check: commit must exists on main branch
-    if ! (git log origin/main --format='%H' || true) | grep -qx $commit; then
-        echo "Error: commit $commit is not on main branch"
+for commit in ${commits[@]}; do
+    if ! (git log --format='%H' || true) | grep -qx $commit; then
+        echo "Error: commit $commit not found on main branch"
         exit 1
     fi
+done
 
+for i in ${!commits[@]}; do
+    commit=${commits[$i]}
     show_message "Checking out and compiling commit ${commit:0:10} ($((i+1))/${#commits[@]})"
+
     git checkout -q $commit
 
     if [[ "$OS" =~ "Windows" ]] && [ $i == 0 ]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,6 +20,7 @@ commits=(
     1c7ce74933aea8a8862fd1d4409735b9fb7a1d7e  # last commit on main that contains the compiler written in C
     b339b1b300ba98a2245b493a58dd7fab4c465020  # "match ... with ..." syntax
     874d1978044a080173fcdcc4e92736136c97dd61  # "match some_integer:" support
+    8cbccffe7e9f6a919035fc87b8684c74b3afcd8f  # TEMPORARY TEST
 )
 
 for commit in ${commits[@]}; do

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,7 +25,7 @@ commits=(
 
 for commit in ${commits[@]}; do
     if ! (git log --format='%H' || true) | grep -qx $commit; then
-        echo "Error: commit $commit not found on main branch"
+        echo "Error: commit $commit not in history of current branch"
         exit 1
     fi
 done

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,6 +21,13 @@ commits=(
     b339b1b300ba98a2245b493a58dd7fab4c465020  # "match ... with ..." syntax
 )
 
+for commit in ${commits[@]}; do
+    if ! (git log --format='%H' || true) | grep -qx $commit; then
+        echo "Error: commit $commit not found on main branch"
+        exit 1
+    fi
+done
+
 if [[ "${OS:=$(uname)}" =~ Windows ]]; then
     source activate
     make="mingw32-make"
@@ -45,13 +52,6 @@ if [[ "$OS" =~ Windows ]]; then
     cp -r libs mingw64 tmp/bootstrap
 fi
 cd tmp/bootstrap
-
-for commit in ${commits[@]}; do
-    if ! (git log --format='%H' || true) | grep -qx $commit; then
-        echo "Error: commit $commit not found on main branch"
-        exit 1
-    fi
-done
 
 for i in ${!commits[@]}; do
     commit=${commits[$i]}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,8 +48,14 @@ cd tmp/bootstrap
 
 for i in ${!commits[@]}; do
     commit=${commits[$i]}
-    show_message "Checking out and compiling commit ${commit:0:10} ($((i+1))/${#commits[@]})"
 
+    # Sanity check: commit must exists on main branch
+    if ! (git log main --format='%H' || true) | grep -qx $commit; then
+        echo "Error: commit $commit is not on main branch"
+        exit 1
+    fi
+
+    show_message "Checking out and compiling commit ${commit:0:10} ($((i+1))/${#commits[@]})"
     git checkout -q $commit
 
     if [[ "$OS" =~ "Windows" ]] && [ $i == 0 ]; then


### PR DESCRIPTION
This is good from a security point of view. It prevents the following attack:
- Attacker can somehow push malicious code into my repository `Akuli/jou`, but not onto the main branch
- Attacker pretends to be a contributor who needs to add another Git revision to the bootstrap script
- Attacker adds malicious commit hash to bootstrap script

Without this PR, bootstrap script would happily compile with the malicious commit hash. With this PR, the bootstrap script will notice that the commit hash is not on the `main` branch and stop.

The attack is very unlikely, but this sanity check cannot be a bad thing, so might as well add it.