### PR TITLE
Bootstrap script improvements

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -93,14 +93,15 @@ for i in ${!commits[@]}; do
         (cd $folder && unzip -q llvm_headers.zip)
     fi
 
-    if [ $i != 0 ]; then
+    if [ $i == 0 ]; then
+        # Only build the compiler written in C (jou_stage1.exe)
+        (cd $folder && make jou$exe_suffix)
+    else
         cp $(folder_of_commit $((i-1)))/jou$exe_suffix $folder/jou_bootstrap$exe_suffix
-        # Convince make that jou_bootstrap(.exe) is usable as is, and does not
-        # need to be recompiled. We don't want bootstrap inside bootstrap.
-        touch $folder/jou_bootstrap$exe_suffix
+        # 'touch' convinces make that jou_bootstrap(.exe) is usable as is, and does
+        # not need to be recompiled. We don't want bootstrap inside bootstrap.
+        (cd $folder && touch jou_bootstrap$exe_suffix && $make jou$exe_suffix)
     fi
-
-    (cd $folder && make jou$exe_suffix)
 done
 
 show_message "Copying the bootstrapped executable"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -93,15 +93,14 @@ for i in ${!commits[@]}; do
         (cd $folder && unzip -q llvm_headers.zip)
     fi
 
-    if [ $i == 0 ]; then
-        # Only build the compiler written in C (jou_stage1.exe)
-        (cd $folder && make jou$exe_suffix)
-    else
+    if [ $i != 0 ]; then
         cp $(folder_of_commit $((i-1)))/jou$exe_suffix $folder/jou_bootstrap$exe_suffix
-        # 'touch' convinces make that jou_bootstrap(.exe) is usable as is, and does
-        # not need to be recompiled. We don't want bootstrap inside bootstrap.
-        (cd $folder && touch jou_bootstrap$exe_suffix && $make jou$exe_suffix)
+        # Convince make that jou_bootstrap(.exe) is usable as is, and does not
+        # need to be recompiled. We don't want bootstrap inside bootstrap.
+        touch $folder/jou_bootstrap$exe_suffix
     fi
+
+    (cd $folder && make jou$exe_suffix)
 done
 
 show_message "Copying the bootstrapped executable"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -95,7 +95,7 @@ for i in ${!commits[@]}; do
 
     if [ $i == 0 ]; then
         # Only build the compiler written in C (jou_stage1.exe)
-        (cd $folder && make jou_stage1$exe_suffix && mv -v jou_stage1$exe_suffix jou$exe_suffix)
+        (cd $folder && make jou$exe_suffix)
     else
         cp $(folder_of_commit $((i-1)))/jou$exe_suffix $folder/jou_bootstrap$exe_suffix
         # 'touch' convinces make that jou_bootstrap(.exe) is usable as is, and does

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,12 +74,11 @@ for i in ${!commits[@]}; do
     show_message "Checking out and compiling commit ${commit:0:10} ($((i+1))/${#commits[@]})"
 
     folder=$(folder_of_commit $i)
-    rm -rf $folder >/dev/null
+    rm -rf $folder
     mkdir -vp $folder
 
-    # If you know a better way to checkout a commit into a folder, let me know.
-    git archive --format=zip --output $folder/repo.zip $commit
-    (cd $folder && unzip -q repo.zip && rm repo.zip)
+    # This seems to be the best way to checkout a commit into a folder.
+    git archive --format=tar $commit | (cd $folder && tar xf -)
 
     if [[ "$OS" =~ Windows ]]; then
         cp -r libs mingw64 $folder

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -95,7 +95,7 @@ for i in ${!commits[@]}; do
 
     if [ $i == 0 ]; then
         # Only build the compiler written in C (jou_stage1.exe)
-        (cd $folder && make jou_stage1$exe_suffix && mv -v jou_stage1$exe_suffix jou$exe_suffix)
+        (cd $folder && $make jou_stage1$exe_suffix && mv -v jou_stage1$exe_suffix jou$exe_suffix)
     else
         cp $(folder_of_commit $((i-1)))/jou$exe_suffix $folder/jou_bootstrap$exe_suffix
         # 'touch' convinces make that jou_bootstrap(.exe) is usable as is, and does

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -93,15 +93,14 @@ for i in ${!commits[@]}; do
         (cd $folder && unzip -q llvm_headers.zip)
     fi
 
-    if [ $i == 0 ]; then
-        # Only build the compiler written in C (jou_stage1.exe)
-        (cd $folder && $make jou_stage1$exe_suffix && mv -v jou_stage1$exe_suffix jou$exe_suffix)
-    else
+    if [ $i != 0 ]; then
         cp $(folder_of_commit $((i-1)))/jou$exe_suffix $folder/jou_bootstrap$exe_suffix
-        # 'touch' convinces make that jou_bootstrap(.exe) is usable as is, and does
+        # Convince make that jou_bootstrap(.exe) is usable as is, and does
         # not need to be recompiled. We don't want bootstrap inside bootstrap.
-        (cd $folder && touch jou_bootstrap$exe_suffix && $make jou$exe_suffix)
+        touch $folder/jou_bootstrap$exe_suffix
     fi
+
+    (cd $folder && $make jou$exe_suffix)
 done
 
 show_message "Copying the bootstrapped executable"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -95,7 +95,7 @@ for i in ${!commits[@]}; do
 
     if [ $i == 0 ]; then
         # Only build the compiler written in C (jou_stage1.exe)
-        (cd $folder && make jou$exe_suffix)
+        (cd $folder && make jou_stage1$exe_suffix && mv -v jou_stage1$exe_suffix jou$exe_suffix)
     else
         cp $(folder_of_commit $((i-1)))/jou$exe_suffix $folder/jou_bootstrap$exe_suffix
         # 'touch' convinces make that jou_bootstrap(.exe) is usable as is, and does


### PR DESCRIPTION
- Save all bootstrapped compilers. Commit hash is included in folder name, so that this will work even if commits are removed from the list (unlikely).
- When a new commit is added to the bootstrap process, don't recompile everything from scratch.
- ~~For the first commit, use the compiler written in C directly instead of compiling a compiler written in Jou with it.~~ (failed on Windows for some reason)

Fixes #711 