### PR TITLE
Compiler code cleanup: simplify array of strings

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,6 +21,7 @@ commits=(
     b339b1b300ba98a2245b493a58dd7fab4c465020  # "match ... with ..." syntax
     874d1978044a080173fcdcc4e92736136c97dd61  # "match some_integer:" support
     8a0bb4b50ef77932243f4f65ae90be84e763ec45  # evaluating "if WINDOWS:" and such inside functions
+    2b33658b17239c68c84b034c33c2a7c145da43dd  # bidirectional type inference for arrays of strings
 )
 
 for commit in ${commits[@]}; do

--- a/compiler/builders/ast_to_builder.jou
+++ b/compiler/builders/ast_to_builder.jou
@@ -497,12 +497,7 @@ class AstToBuilder:
 
         self->builder->set_current_block(error_block)
 
-        # TODO: https://github.com/Akuli/jou/issues/683
-        argnames: byte[100][3]
-        strcpy(argnames[0], "assertion")
-        strcpy(argnames[1], "path")
-        strcpy(argnames[2], "lineno")
-
+        argnames: byte[100][3] = ["assertion", "path", "lineno"]
         argtypes: Type*[3] = [byteType->pointer_type(), byteType->pointer_type(), intType]
         sig = Signature{
             name = "_jou_assert_fail",


### PR DESCRIPTION
Uses the stuff implemented in #714. Must be separate PR because #714 must be added to bootstrap script.