### PR TITLE
Fix 'make clean'

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,7 +62,7 @@ jobs:
       - run: sudo apt update
       - run: sudo apt install -y llvm-{14,15,16}-dev clang-{14,15,16} make
       - run: LLVM_CONFIG=llvm-config-14 ./doctest.sh
-      - run: make clean
+      - run: mv jou_bootstrap x; make clean; mv x jou_bootstrap
       - run: LLVM_CONFIG=llvm-config-15 ./doctest.sh
-      - run: make clean
+      - run: mv jou_bootstrap x; make clean; mv x jou_bootstrap
       - run: LLVM_CONFIG=llvm-config-16 ./doctest.sh

--- a/Makefile.posix
+++ b/Makefile.posix
@@ -29,9 +29,9 @@ jou_bootstrap: bootstrap.sh
 jou: jou_bootstrap config.jou $(wildcard compiler/*.jou compiler/*/*.jou)
 	rm -rf compiler/jou_compiled && ./jou_bootstrap -o jou --linker-flags "$(shell $(LLVM_CONFIG) --ldflags --libs)" compiler/main.jou
 
-# Does not delete jou_bootstrap executable because bootstrapping is slow.
-# Bootstrap folder is deleted without -v (verbose) because it contains many files.
+# Does not delete tmp/bootstrap_cache because bootstrapping is slow.
 .PHONY: clean
 clean:
-	rm -rf tmp/bootstrap_cache && rm -rvf jou jou.exe tmp config.jou
+	bash -O extglob -c "rm -rvf tmp/!(bootstrap_cache)"
+	rm -vf *.exe config.jou jou jou_bootstrap
 	find . -name jou_compiled -print -exec rm -rf '{}' +

--- a/Makefile.posix
+++ b/Makefile.posix
@@ -33,5 +33,5 @@ jou: jou_bootstrap config.jou $(wildcard compiler/*.jou compiler/*/*.jou)
 # Bootstrap folder is deleted without -v (verbose) because it contains many files.
 .PHONY: clean
 clean:
-	rm -rf tmp/bootstrap && rm -rvf jou jou.exe tmp config.jou
+	rm -rf tmp/bootstrap_cache && rm -rvf jou jou.exe tmp config.jou
 	find . -name jou_compiled -print -exec rm -rf '{}' +

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -12,9 +12,9 @@ jou_bootstrap.exe: bootstrap.sh
 jou.exe: jou_bootstrap.exe config.jou $(wildcard compiler/*.jou compiler/*/*.jou)
 	rm -rf compiler/jou_compiled && ./jou_bootstrap.exe -o jou.exe --linker-flags "$(wildcard libs/lib*.a)" compiler/main.jou
 
-# Does not delete jou_bootstrap executable because bootstrapping is slow.
-# Bootstrap folder is deleted without -v (verbose) because it contains many files.
+# Does not delete tmp/bootstrap_cache because bootstrapping is slow.
 .PHONY: clean
 clean:
-	rm -rf tmp/bootstrap_cache && rm -rvf jou.exe tmp config.jou
-	find -name jou_compiled -print -exec rm -rf '{}' +
+	bash -O extglob -c "rm -rvf tmp/!(bootstrap_cache)"
+	rm -vf *.exe config.jou
+	find . -name jou_compiled -print -exec rm -rf '{}' +

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -16,5 +16,5 @@ jou.exe: jou_bootstrap.exe config.jou $(wildcard compiler/*.jou compiler/*/*.jou
 # Bootstrap folder is deleted without -v (verbose) because it contains many files.
 .PHONY: clean
 clean:
-	rm -rf tmp/bootstrap && rm -rvf jou.exe tmp config.jou
+	rm -rf tmp/bootstrap_cache && rm -rvf jou.exe tmp config.jou
 	find -name jou_compiled -print -exec rm -rf '{}' +


### PR DESCRIPTION
Currently folder paths in `Makefile.*` and `bootstrap.sh` are not the same like they should be, which causes `make clean` to print a lot of unnecessary output.