### PR TITLE
Changes to how match statements interact with enums

### DIFF
--- a/compiler/builders/ast_to_builder.jou
+++ b/compiler/builders/ast_to_builder.jou
@@ -508,7 +508,22 @@ class AstToBuilder:
 
         if match_stmt->case_underscore != NULL:
             self->build_body(match_stmt->case_underscore)
-        self->builder->jump(done)
+
+        if (
+            match_stmt->case_underscore == NULL
+            and match_stmt->match_obj.types.implicit_cast_type->kind == TypeKind.Enum
+        ):
+            # The one corner case where match statement invokes UB:
+            #   - User is matching over an enum
+            #   - All enum members are handled (otherwise error in typecheck)
+            #   - The value stored in the enum is not a valid value of the enum
+            #   - There is no "case _" to catch the invalid value
+            #
+            # See also: doc/match.md
+            self->builder->unreachable()
+        else:
+            self->builder->jump(done)
+
         self->builder->set_current_block(done)
 
     def build_assert(self, assert_location: Location, assertion: AstAssertion*) -> None:

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -1146,11 +1146,11 @@ def typecheck_match_statement(state: State*, match_stmt: AstMatchStatement*) -> 
                 snprintf(msg, sizeof(msg), "case value cannot be <from> when matching with %s", sig_string)
             typecheck_expression_with_implicit_cast(state, case_obj, case_type, msg)
 
-            # The special casing only applies to simple enum member lookups (TheEnum.TheMember syntax)
-            if case_obj->kind != AstExpressionKind.GetEnumMember:
-                nremaining = -1
-
             if nremaining != -1:
+                if case_obj->kind != AstExpressionKind.GetEnumMember:
+                    # Matching an enum but it's too dynamic, not simply TheEnum.Member
+                    snprintf(msg, sizeof(msg), "'case' value must be %s.something when matching a value of enum %s", case_type->name, case_type->name)
+                    fail(case_obj->location, msg)
                 # We are matching against TheEnum.member. Try to find and remove it from remaining members.
                 member = case_obj->enum_member.member_name
                 found = False

--- a/doc/enums.md
+++ b/doc/enums.md
@@ -108,60 +108,7 @@ This is useful especially when adding a new feature to a large existing program.
 Instead of a `match` statement, you can also use `if` and `elif` with enums,
 but then the compiler won't complain if you don't handle all enum members.
 
-Sometimes you don't want to list all enum members in a `match` statement.
-You can use `case _:` to catch all remaining enum members:
-
-```python
-import "stdlib/io.jou"
-
-enum Operation:
-    Add
-    Subtract
-    Multiply
-    Divide
-    FloorDivide
-
-def main() -> int:
-    op = Operation.Divide
-
-    match op:
-        case Operation.Add:
-            printf("It's adding\n")
-        case Operation.Subtract:
-            printf("It's subtracting\n")
-        case _:
-            printf("Not adding or subtracting\n")  # Output: Not adding or subtracting
-
-    return 0
-```
-
-You can also combine multiple cases with `|`.
-Read the `|` operator as "or" when it's used in match statements.
-
-```python
-import "stdlib/io.jou"
-
-enum Operation:
-    Add
-    Subtract
-    Multiply
-    Divide
-    FloorDivide
-
-def main() -> int:
-    op = Operation.FloorDivide
-
-    match op:
-        case Operation.Divide | Operation.FloorDivide:
-            printf("It's dividing\n")  # Output: It's dividing
-        case _:
-            pass
-
-    return 0
-```
-
-Here `case _: pass` is needed to ignore the enum members that were not mentioned,
-because without it, you will get a compiler error saying that you didn't handle all possible values.
+See also [the `match` statement documentation](match.md).
 
 
 ## Integer conversions
@@ -203,7 +150,7 @@ def main() -> int:
 
 You can also convert integers to enums,
 but note that the result might not correspond with any member of the enum.
-In a `match` statements, only `case _:` matches these values.
+For example:
 
 ```python
 import "stdlib/io.jou"
@@ -229,6 +176,8 @@ def main() -> int:
 
     return 0
 ```
+
+Make sure to include `case _` if you do this, [so that you don't get Undefined Behavior](match.md#the-weird-corner-case-where-a-match-statement-produces-ub).
 
 
 ## Debugging

--- a/doc/enums.md
+++ b/doc/enums.md
@@ -108,7 +108,60 @@ This is useful especially when adding a new feature to a large existing program.
 Instead of a `match` statement, you can also use `if` and `elif` with enums,
 but then the compiler won't complain if you don't handle all enum members.
 
-See also [the `match` statement documentation](match.md).
+Sometimes you don't want to list all enum members in a `match` statement.
+You can use `case _:` to catch all remaining enum members:
+
+```python
+import "stdlib/io.jou"
+
+enum Operation:
+    Add
+    Subtract
+    Multiply
+    Divide
+    FloorDivide
+
+def main() -> int:
+    op = Operation.Divide
+
+    match op:
+        case Operation.Add:
+            printf("It's adding\n")
+        case Operation.Subtract:
+            printf("It's subtracting\n")
+        case _:
+            printf("Not adding or subtracting\n")  # Output: Not adding or subtracting
+
+    return 0
+```
+
+You can also combine multiple cases with `|`.
+Read the `|` operator as "or" when it's used in match statements.
+
+```python
+import "stdlib/io.jou"
+
+enum Operation:
+    Add
+    Subtract
+    Multiply
+    Divide
+    FloorDivide
+
+def main() -> int:
+    op = Operation.FloorDivide
+
+    match op:
+        case Operation.Divide | Operation.FloorDivide:
+            printf("It's dividing\n")  # Output: It's dividing
+        case _:
+            pass
+
+    return 0
+```
+
+Here `case _: pass` is needed to ignore the enum members that were not mentioned,
+because without it, you will get a compiler error saying that you didn't handle all possible values.
 
 
 ## Integer conversions
@@ -150,7 +203,7 @@ def main() -> int:
 
 You can also convert integers to enums,
 but note that the result might not correspond with any member of the enum.
-For example:
+In a `match` statements, only `case _:` matches these values.
 
 ```python
 import "stdlib/io.jou"
@@ -176,8 +229,6 @@ def main() -> int:
 
     return 0
 ```
-
-Make sure to include `case _` if you do this, [so that you don't get Undefined Behavior](match.md#the-weird-corner-case-where-a-match-statement-produces-ub).
 
 
 ## Debugging

--- a/tests/other_errors/match_enum_too_dynamic.jou
+++ b/tests/other_errors/match_enum_too_dynamic.jou
@@ -1,0 +1,11 @@
+enum Thing:
+    Foo
+    Bar
+    Baz
+
+def do_stuff(t1: Thing, t2: Thing) -> None:
+    match t1:
+        # This is forbidden because it would be hard for the compiler to know
+        # which values have been handled and which haven't
+        case t2:  # Error: 'case' value must be Thing.something when matching a value of enum Thing
+            pass

--- a/tests/should_succeed/match.jou
+++ b/tests/should_succeed/match.jou
@@ -9,9 +9,9 @@ enum Foo:
     Wut
 
 
-def show_evaluation(foo: Foo, msg: byte*) -> Foo:
+def show_evaluation(value: int, msg: byte*) -> int:
     puts(msg)
-    return foo
+    return value
 
 
 def main() -> int:
@@ -80,6 +80,8 @@ def main() -> int:
             printf("Hey! :)\n")  # Output: Hey! :)
         case Foo.Wut:
             printf("nope\n")
+        case _:
+            printf("Other!!!\n")
 
     f = 12345 as Foo
     match f:
@@ -91,6 +93,8 @@ def main() -> int:
             printf("nope\n")
         case Foo.Wut:
             printf("nope\n")
+        case _:
+            printf("Other!!!\n")  # Output: Other!!!
 
     # Test evaluation order.
     #
@@ -99,14 +103,14 @@ def main() -> int:
     # Output: case 2
     # Output: case 3
     # Output: ye
-    match show_evaluation(Foo.Lol, "match obj"):
-        case show_evaluation(Foo.Bar, "case 1"):
+    match show_evaluation(3, "match obj"):
+        case show_evaluation(1, "case 1"):
             printf("nope\n")
-        case show_evaluation(Foo.Baz, "case 2"):
+        case show_evaluation(2, "case 2"):
             printf("nope\n")
-        case show_evaluation(Foo.Lol, "case 3"):
+        case show_evaluation(3, "case 3"):
             printf("ye\n")
-        case show_evaluation(Foo.Wut, "case 4"):
+        case show_evaluation(4, "case 4"):
             printf("nope\n")
 
     # Output: match obj
@@ -114,10 +118,10 @@ def main() -> int:
     # Output: case 2
     # Output: case 3
     # Output: ye
-    match show_evaluation(Foo.Lol, "match obj"):
-        case show_evaluation(Foo.Bar, "case 1") | show_evaluation(Foo.Baz, "case 2"):
+    match show_evaluation(3, "match obj"):
+        case show_evaluation(1, "case 1") | show_evaluation(2, "case 2"):
             printf("nope\n")
-        case show_evaluation(Foo.Lol, "case 3") | show_evaluation(Foo.Wut, "case 4"):
+        case show_evaluation(3, "case 3") | show_evaluation(4, "case 4"):
             printf("ye\n")
 
     # Make a string that is surely not == "Hello", to make sure strcmp() is called below


### PR DESCRIPTION
Two things.


## Compiler must know what enum values are matched

This is no longer valid:

```python
enum Thingy:
    Foo
    Bar
    Baz

def get_bar() -> Thingy:
    return Thingy.Bar

def do_stuff(t: Thingy) -> None:
    match t:
        case get_bar():  # error on this line
            ...
```

When matching over enums, cases must be simple `EnumName.MemberName`, nothing more complicated is allowed.


## New UB

After this PR, the following function will invoke UB if you do `thingy_to_string(7 as Thingy)`:

```python
enum Thingy:
    Foo
    Bar
    Baz

def thingy_to_string(t: Thingy) -> byte*:
    match t:
        case Thingy.Foo:
            return "It's a foo"
        case Thingy.Bar:
            return "Barbar"
        case Thingy.Baz:
            return "Bazzz"
    # We never get here, because we return in all cases
```

Currently the match statement does nothing, which means that the compiler should complain about how the function might not return a value. It doesn't because undefined value checks are currently missing. After this PR, the match statement invokes UB.

UB happens only in a very specific scenario:
- Matching over an enum
- All enum members are handled one by one (otherwise, there is a compiler error)
- No `case _`
- Value passed to `match` statement is not one of the enum members

I will document this (and other match statement things) in next PR.