### PR TITLE
Tweak error message for using `@public` with the main() function

### DIFF
--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -143,8 +143,7 @@ def decorate(stmt: AstStatement*, decor: byte*, location: Location) -> None:
         match stmt->kind:
             case AstStatementKind.FunctionDeclare | AstStatementKind.FunctionDef:
                 if strcmp(stmt->function.ast_signature.name, "main") == 0:
-                    # TODO: test this
-                    fail(location, "do not decorate the main() function with @public")
+                    fail(location, "the main() function cannot be @public")
                 stmt->function.public = True
                 return
             case _:

--- a/tests/other_errors/main_public.jou
+++ b/tests/other_errors/main_public.jou
@@ -1,5 +1,5 @@
 # The main() function is special and does not need to be marked public.
 
-@public  # Error: do not decorate the main() function with @public
+@public  # Error: the main() function cannot be @public
 def main() -> int:
     return 0


### PR DESCRIPTION
Closes #648 

I have decided that `@public` shouldn't be used with `main()`, for a few reasons:
- Moosems said "Being able to do an if name equals main equivalent with the main function by making it private sounds really awesome"
- Simple Jou programs should look simple
- Main function needs some special casing anyway, IMO it's not too bad

This can be changed later if someone convinces me otherwise.