### PR TITLE
Temporarily allow `@public` in all places where it will be added

### DIFF
--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -145,7 +145,10 @@ def decorate(stmt: AstStatement*, decor: byte*, location: Location) -> None:
                 if strcmp(stmt->function.ast_signature.name, "main") == 0:
                     fail(location, "the main() function cannot be @public")
                 stmt->function.public = True
-                return
+            # Temporarily allow and ignore using @public on enums, classes and global variables.
+            # This is needed for the bootstrap compiler to accept new syntax.
+            case AstStatementKind.Enum | AstStatementKind.Class | AstStatementKind.GlobalVariableDeclare | AstStatementKind.GlobalVariableDef:
+                pass  # TODO: handle these cases properly
             case _:
                 fail(location, "the @public decorator cannot be used here")
     else:


### PR DESCRIPTION
Once this commit is in the bootstrap compiler, I will be able to use `@public` in the Jou compiler right away. The compiler will temporarily accept and ignore `@public` decorators, but it doesn't really matter.