### PR TITLE
Handle `-> noreturn` functions properly

### DIFF
--- a/compiler/builders/ast_to_builder.jou
+++ b/compiler/builders/ast_to_builder.jou
@@ -91,7 +91,14 @@ class AstToBuilder:
         args: EitherBuilderValue[100]
         for i = 0; i < call->nargs; i++:
             args[i] = self->build_expression(&call->args[i])
-        return self->builder->call(call->called_signature, args, call->nargs)
+        result = self->builder->call(call->called_signature, args, call->nargs)
+
+        if call->called_signature->is_noreturn:
+            # Code after the function call will not run. Place it to a new block.
+            self->builder->unreachable()
+            self->builder->set_current_block(self->builder->add_block())
+
+        return result
 
     def build_method_call(self, call: AstCall*) -> EitherBuilderValue:
         assert call->method_call_self != NULL


### PR DESCRIPTION
Now the compiler knows that code after calling a `noreturn` function will not run.

For example, consider this:

```python
import "stdlib/io.jou"
import "stdlib/process.jou"

def foo(x: int) -> byte*:
    if x == 1:
        return "one"
    elif x == 2:
        return "two"
    else:
        printf("Error: bad number\n")
        exit(1)
```

Before this PR, this gave a warning: `function 'foo' does not seem to return a value in all cases`. Now there are no warnings.