### PR TITLE
Make global variable definitions private by default

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -509,7 +509,9 @@ class AstStatement:
         for_loop: AstForLoop
         return_value: AstExpression*        # can be NULL
         assignment: AstAssignment           # also used for +=, -= etc
-        var_declaration: AstNameTypeValue   # DeclareLocalVar
+        local_var_declare: AstNameTypeValue # DeclareLocalVar
+        global_var_declare: AstNameTypeValue  # GlobalVariableDeclare
+        global_var_def: AstGlobalVarDef     # GlobalVariableDef
         class_field: AstNameTypeValue       # ClassField
         union_fields: AstUnionFields        # ClassUnion
         function: AstFunctionOrMethod
@@ -553,7 +555,7 @@ class AstStatement:
                 printf("continue\n")
             case AstStatementKind.DeclareLocalVar:
                 printf("declare local var ")
-                self->var_declaration.print_with_tree_printer(&tp)
+                self->local_var_declare.print_with_tree_printer(&tp)
             case AstStatementKind.Assign:
                 printf("assign\n")
                 self->assignment.print_with_tree_printer(tp)
@@ -587,11 +589,11 @@ class AstStatement:
                 self->enumdef.print_with_tree_printer(tp)
             case AstStatementKind.GlobalVariableDeclare:
                 printf("declare global var ")
-                self->var_declaration.print_with_tree_printer(NULL)
+                self->global_var_declare.print_with_tree_printer(NULL)
                 printf("\n")
             case AstStatementKind.GlobalVariableDef:
                 printf("define global var ")
-                self->var_declaration.print_with_tree_printer(NULL)
+                self->global_var_def.print()
                 printf("\n")
             case AstStatementKind.Import:
                 self->import_statement.print()
@@ -621,12 +623,12 @@ class AstStatement:
                 self->for_loop.free()
             case AstStatementKind.Match:
                 self->match_statement.free()
-            case (
-                AstStatementKind.DeclareLocalVar
-                | AstStatementKind.GlobalVariableDeclare
-                | AstStatementKind.GlobalVariableDef
-            ):
-                self->var_declaration.free()
+            case AstStatementKind.DeclareLocalVar:
+                self->local_var_declare.free()
+            case AstStatementKind.GlobalVariableDeclare:
+                self->global_var_declare.free()
+            case AstStatementKind.GlobalVariableDef:
+                self->global_var_def.free()
             case AstStatementKind.ClassField:
                 self->class_field.free()
             case (
@@ -861,6 +863,22 @@ class AstNameTypeValue:
         if self->value != NULL:
             self->value->free()
             free(self->value)
+
+
+# global foo: int
+class AstGlobalVarDef:
+    name: byte[100]
+    type: AstType
+    public: bool  # is it decorated with @public
+    used: bool  # used to detect unused global variables
+
+    def print(self) -> None:
+        printf("%s: ", self->name)
+        self->type.print(True)
+        printf("\n")
+
+    def free(self) -> None:
+        self->type.free()
 
 
 # typically multiple indented lines after a ":" at end of line

--- a/compiler/builders/ast_to_builder.jou
+++ b/compiler/builders/ast_to_builder.jou
@@ -608,9 +608,9 @@ class AstToBuilder:
                     self->builder->ret(NULL)
                 self->builder->set_current_block(self->builder->add_block())  # for code after 'return', if any
             case AstStatementKind.DeclareLocalVar:
-                if stmt->var_declaration.value != NULL:
-                    var_ptr = self->local_var_ptr(stmt->var_declaration.name)
-                    value = self->build_expression(stmt->var_declaration.value)
+                if stmt->local_var_declare.value != NULL:
+                    var_ptr = self->local_var_ptr(stmt->local_var_declare.name)
+                    value = self->build_expression(stmt->local_var_declare.value)
                     self->builder->set_ptr(var_ptr, value)
             case AstStatementKind.ExpressionStatement:
                 self->build_expression(&stmt->expression)

--- a/compiler/builders/llvm_builder.jou
+++ b/compiler/builders/llvm_builder.jou
@@ -570,13 +570,23 @@ def build_llvm_ir(ast: AstFile*) -> LLVMModule*:
     builder_wrapper = EitherBuilder{lbuilder = &builder}
 
     for g = ast->types.globals; g < &ast->types.globals[ast->types.nglobals]; g++:
-        t = type_to_llvm(g->type)
-        globalptr = LLVMAddGlobal(module, t, g->name)
-        if g->defined_in_current_file:
-            LLVMSetInitializer(globalptr, LLVMConstNull(t))
+        LLVMAddGlobal(module, type_to_llvm(g->type), g->name)
 
     for stmt = ast->body.statements; stmt < &ast->body.statements[ast->body.nstatements]; stmt++:
         match stmt->kind:
+            case AstStatementKind.GlobalVariableDef:
+                globalptr = LLVMGetNamedGlobal(module, stmt->global_var_def.name)
+                assert globalptr != NULL
+                # TODO: better way to get the type
+                vartype: Type* = NULL
+                for g = ast->types.globals; g < &ast->types.globals[ast->types.nglobals]; g++:
+                    if strcmp(g->name, stmt->global_var_def.name) == 0:
+                        vartype = g->type
+                        break
+                assert vartype != NULL
+                LLVMSetInitializer(globalptr, LLVMConstNull(type_to_llvm(vartype)))
+                if not stmt->global_var_def.public:
+                    LLVMSetLinkage(globalptr, LLVMLinkage.Private)  # This makes it a static global variable
             case AstStatementKind.FunctionDef:
                 feed_ast_to_builder(&stmt->function, stmt->location, ast->is_main_file, &builder_wrapper)
             case AstStatementKind.Class:

--- a/compiler/builders/llvm_builder.jou
+++ b/compiler/builders/llvm_builder.jou
@@ -577,7 +577,6 @@ def build_llvm_ir(ast: AstFile*) -> LLVMModule*:
             case AstStatementKind.GlobalVariableDef:
                 globalptr = LLVMGetNamedGlobal(module, stmt->global_var_def.name)
                 assert globalptr != NULL
-                # TODO: better way to get the type
                 vartype: Type* = NULL
                 for g = ast->types.globals; g < &ast->types.globals[ast->types.nglobals]; g++:
                     if strcmp(g->name, stmt->global_var_def.name) == 0:

--- a/compiler/builders/llvm_builder.jou
+++ b/compiler/builders/llvm_builder.jou
@@ -577,7 +577,12 @@ def build_llvm_ir(ast: AstFile*) -> LLVMModule*:
             case AstStatementKind.GlobalVariableDef:
                 globalptr = LLVMGetNamedGlobal(module, stmt->global_var_def.name)
                 assert globalptr != NULL
-                vartype = ast->types.find_global_var(stmt->global_var_def.name)
+                # TODO: better way to get the type
+                vartype: Type* = NULL
+                for g = ast->types.globals; g < &ast->types.globals[ast->types.nglobals]; g++:
+                    if strcmp(g->name, stmt->global_var_def.name) == 0:
+                        vartype = g->type
+                        break
                 assert vartype != NULL
                 LLVMSetInitializer(globalptr, LLVMConstNull(type_to_llvm(vartype)))
                 if not stmt->global_var_def.public:

--- a/compiler/command_line_args.jou
+++ b/compiler/command_line_args.jou
@@ -20,6 +20,7 @@ class CommandLineArgs:
 
 # Command-line arguments are a global variable because I like it.
 # This variable is also accessed from other files because I like it.
+@public
 global command_line_args: CommandLineArgs
 
 

--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -38,10 +38,15 @@ def statement_conflicts_with_an_import(stmt: AstStatement*, importsym: ExportSym
                 importsym->kind == ExportSymbolKind.Function
                 and strcmp(importsym->name, stmt->function.ast_signature.name) == 0
             )
-        case AstStatementKind.GlobalVariableDeclare | AstStatementKind.GlobalVariableDef:
+        case AstStatementKind.GlobalVariableDeclare:
             return (
                 importsym->kind == ExportSymbolKind.GlobalVar
-                and strcmp(importsym->name, stmt->var_declaration.name) == 0
+                and strcmp(importsym->name, stmt->global_var_declare.name) == 0
+            )
+        case AstStatementKind.GlobalVariableDef:
+            return (
+                importsym->kind == ExportSymbolKind.GlobalVar
+                and strcmp(importsym->name, stmt->global_var_def.name) == 0
             )
         case AstStatementKind.Class:
             return (

--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -138,6 +138,10 @@ class FileState:
                     if not stmt->enumdef.public and not stmt->enumdef.used:
                         snprintf(msg, sizeof msg, "enum %s defined but not used", stmt->enumdef.name)
                         show_warning(stmt->location, msg)
+                case AstStatementKind.GlobalVariableDef:
+                    if not stmt->global_var_def.public and not stmt->global_var_def.used:
+                        snprintf(msg, sizeof msg, "global variable '%s' defined but not used", stmt->global_var_def.name)
+                        show_warning(stmt->location, msg)
                 case _:
                     pass
 

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -147,9 +147,11 @@ def decorate(stmt: AstStatement*, decor: byte*, location: Location) -> None:
                 stmt->function.public = True
             case AstStatementKind.Enum:
                 stmt->enumdef.public = True
+            case AstStatementKind.GlobalVariableDef:
+                stmt->global_var_def.public = True
             # Temporarily allow and ignore using @public on enums, classes and global variables.
             # This is needed for the bootstrap compiler to accept new syntax.
-            case AstStatementKind.Class | AstStatementKind.GlobalVariableDeclare | AstStatementKind.GlobalVariableDef:
+            case AstStatementKind.Class | AstStatementKind.GlobalVariableDeclare:
                 pass  # TODO: handle these cases properly
             case _:
                 fail(location, "the @public decorator cannot be used here")
@@ -818,7 +820,7 @@ class Parser:
                         fail(result.class_field.value->location, "class fields cannot have default values")
                 case WhatAreWeParsing.FunctionBody | WhatAreWeParsing.MethodBody:
                     result.kind = AstStatementKind.DeclareLocalVar
-                    result.var_declaration = self->parse_name_type_value(NULL)
+                    result.local_var_declare = self->parse_name_type_value(NULL)
         else:
             expr = self->parse_expression()
             result.kind = determine_the_kind_of_a_statement_that_starts_with_an_expression(self->tokens)
@@ -1039,9 +1041,6 @@ class Parser:
         if self->tokens->is_operator("="):
             fail(self->tokens->location, "only one variable can be assigned at a time")
 
-        if self->tokens->is_operator("="):
-            fail(self->tokens->location, "only one variable can be assigned at a time")
-
         if not self->tokens->is_operator(":"):
             self->tokens->fail_expected_got("':' and a type after it (example: \"foo, bar: int\")")
         self->tokens++
@@ -1089,16 +1088,17 @@ class Parser:
             location = (self->tokens++)->location
             if self->tokens->is_keyword("global"):
                 self->tokens++
+                ntv = self->parse_name_type_value("a variable name")
+                if ntv.value != NULL:
+                    fail(
+                        ntv.value->location,
+                        "a value cannot be given when declaring a global variable",
+                    )
                 result = AstStatement{
                     location = location,
                     kind = AstStatementKind.GlobalVariableDeclare,
-                    var_declaration = self->parse_name_type_value("a variable name"),
+                    global_var_declare = ntv,
                 }
-                if result.var_declaration.value != NULL:
-                    fail(
-                        result.var_declaration.value->location,
-                        "a value cannot be given when declaring a global variable",
-                    )
             else:
                 result = AstStatement{
                     location = location,
@@ -1108,16 +1108,18 @@ class Parser:
             self->eat_newline()
         elif self->tokens->is_keyword("global"):
             self->check_top_level("global variables")
-            result = AstStatement{
-                location = (self->tokens++)->location,
-                kind = AstStatementKind.GlobalVariableDef,
-                var_declaration = self->parse_name_type_value("a variable name"),
-            }
-            if result.var_declaration.value != NULL:
+            location = (self->tokens++)->location
+            ntv = self->parse_name_type_value("a variable name")
+            if ntv.value != NULL:
                 fail(
-                    result.var_declaration.value->location,
+                    ntv.value->location,
                     "specifying a value for a global variable is not supported yet",
                 )
+            result = AstStatement{
+                location = location,
+                kind = AstStatementKind.GlobalVariableDef,
+                global_var_def = AstGlobalVarDef{name = ntv.name, type = ntv.type},
+            }
             self->eat_newline()
         elif self->tokens->is_keyword("class"):
             result = AstStatement{
@@ -1169,7 +1171,7 @@ class Parser:
             result = AstStatement{
                 location = self->tokens->location,
                 kind = AstStatementKind.DeclareLocalVar,
-                var_declaration = self->parse_first_of_multiple_local_var_declares(),
+                local_var_declare = self->parse_first_of_multiple_local_var_declares(),
             }
         else:
             result = self->parse_oneline_statement()

--- a/compiler/target.jou
+++ b/compiler/target.jou
@@ -19,6 +19,7 @@ class Target:
     target_machine: LLVMTargetMachine*
     target_data: LLVMTargetData*
 
+@public
 global target: Target
 
 

--- a/compiler/typecheck/step2_populate_types.jou
+++ b/compiler/typecheck/step2_populate_types.jou
@@ -18,13 +18,13 @@ import "../errors_and_warnings.jou"
 import "./common.jou"
 
 
-def handle_global_var(ft: FileTypes*, location: Location, name: byte*, type: AstType*) -> ExportSymbol:
+def handle_global_var(ft: FileTypes*, location: Location, name: byte*, type: AstType*, usedptr: bool*) -> ExportSymbol:
     if ft->find_global_var(name) != NULL:
         msg: byte[500]
         snprintf(msg, sizeof(msg), "a global variable named '%s' already exists", name)
         fail(location, msg)
 
-    g = ft->add_global_var(name, type_from_ast(ft, type), NULL)
+    g = ft->add_global_var(name, type_from_ast(ft, type), usedptr)
     return ExportSymbol{kind = ExportSymbolKind.GlobalVar, type = g->type, name = g->name}
 
 
@@ -204,9 +204,9 @@ def typecheck_step2_populate_types(ast: AstFile*) -> ExportSymbol*:
                 pass
             case AstStatementKind.GlobalVariableDeclare:
                 assert stmt->global_var_declare.value == NULL
-                exports[nexports++] = handle_global_var(&ast->types, stmt->location, stmt->global_var_declare.name, &stmt->global_var_declare.type)
+                exports[nexports++] = handle_global_var(&ast->types, stmt->location, stmt->global_var_declare.name, &stmt->global_var_declare.type, NULL)
             case AstStatementKind.GlobalVariableDef:
-                exp = handle_global_var(&ast->types, stmt->location, stmt->global_var_def.name, &stmt->global_var_def.type)
+                exp = handle_global_var(&ast->types, stmt->location, stmt->global_var_def.name, &stmt->global_var_def.type, &stmt->global_var_def.used)
                 if stmt->global_var_def.public:
                     exports[nexports++] = exp
             case AstStatementKind.FunctionDeclare | AstStatementKind.FunctionDef:

--- a/compiler/typecheck/step2_populate_types.jou
+++ b/compiler/typecheck/step2_populate_types.jou
@@ -18,15 +18,13 @@ import "../errors_and_warnings.jou"
 import "./common.jou"
 
 
-def handle_global_var(ft: FileTypes*, vardecl: AstNameTypeValue*, defined_here: bool) -> ExportSymbol:
-    if ft->find_global_var(vardecl->name) != NULL:
+def handle_global_var(ft: FileTypes*, location: Location, name: byte*, type: AstType*) -> ExportSymbol:
+    if ft->find_global_var(name) != NULL:
         msg: byte[500]
-        snprintf(msg, sizeof(msg), "a global variable named '%s' already exists", vardecl->name)
-        fail(vardecl->name_location, msg)
+        snprintf(msg, sizeof(msg), "a global variable named '%s' already exists", name)
+        fail(location, msg)
 
-    assert vardecl->value == NULL
-    g = ft->add_global_var(vardecl->name, type_from_ast(ft, &vardecl->type), NULL)
-    g->defined_in_current_file = defined_here
+    g = ft->add_global_var(name, type_from_ast(ft, type), NULL)
     return ExportSymbol{kind = ExportSymbolKind.GlobalVar, type = g->type, name = g->name}
 
 
@@ -205,9 +203,12 @@ def typecheck_step2_populate_types(ast: AstFile*) -> ExportSymbol*:
             case AstStatementKind.Import:
                 pass
             case AstStatementKind.GlobalVariableDeclare:
-                exports[nexports++] = handle_global_var(&ast->types, &stmt->var_declaration, False)
+                assert stmt->global_var_declare.value == NULL
+                exports[nexports++] = handle_global_var(&ast->types, stmt->location, stmt->global_var_declare.name, &stmt->global_var_declare.type)
             case AstStatementKind.GlobalVariableDef:
-                exports[nexports++] = handle_global_var(&ast->types, &stmt->var_declaration, True)
+                exp = handle_global_var(&ast->types, stmt->location, stmt->global_var_def.name, &stmt->global_var_def.type)
+                if stmt->global_var_def.public:
+                    exports[nexports++] = exp
             case AstStatementKind.FunctionDeclare | AstStatementKind.FunctionDef:
                 sig = handle_signature(&ast->types, &stmt->function.ast_signature, NULL, &stmt->function.used)
                 stmt->function.types.signature = sig

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -1332,16 +1332,16 @@ def typecheck_statement(state: State*, stmt: AstStatement*) -> None:
                 typecheck_expression_with_implicit_cast(state, stmt->return_value, return_type, msg)
 
         case AstStatementKind.DeclareLocalVar:
-            if state->find_any_var(stmt->var_declaration.name) != NULL:
-                snprintf(msg, sizeof(msg), "a variable named '%s' already exists", stmt->var_declaration.name)
+            if state->find_any_var(stmt->local_var_declare.name) != NULL:
+                snprintf(msg, sizeof(msg), "a variable named '%s' already exists", stmt->local_var_declare.name)
                 fail(stmt->location, msg)
 
-            type = type_from_ast(state->file_types, &stmt->var_declaration.type)
-            state->fom_types->add_variable(type, stmt->var_declaration.name)
+            type = type_from_ast(state->file_types, &stmt->local_var_declare.type)
+            state->fom_types->add_variable(type, stmt->local_var_declare.name)
 
-            if stmt->var_declaration.value != NULL:
+            if stmt->local_var_declare.value != NULL:
                 typecheck_expression_with_implicit_cast(
-                    state, stmt->var_declaration.value, type,
+                    state, stmt->local_var_declare.value, type,
                     "initial value for variable of type <to> cannot be of type <from>")
 
         case AstStatementKind.ExpressionStatement:

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -154,13 +154,21 @@ class GlobalTypeState:
 
 global global_type_state: GlobalTypeState
 
+@public
 global boolType: Type*      # bool
+@public
 global shortType: Type*     # short (16-bit signed)
+@public
 global intType: Type*       # int (32-bit signed)
+@public
 global longType: Type*      # long (64-bit signed)
+@public
 global byteType: Type*      # byte (8-bit unsigned)
+@public
 global floatType: Type*     # float (32-bit)
+@public
 global doubleType: Type*    # double (64-bit)
+@public
 global voidPtrType: Type*   # void*
 
 

--- a/compiler/types_in_ast.jou
+++ b/compiler/types_in_ast.jou
@@ -60,11 +60,9 @@ class FunctionOrMethodTypes:
 
 
 class GlobalVariable:
-    usedptr: bool*  # If non-NULL, set to true when the variable is used. This is how we detect unused imports.
     name: byte[100]  # Same as in user's code, never empty
     type: Type*
-#    defined_in_current_file: bool  # not declare-only (e.g. stdout) or imported
-#    public: bool  # always True if not defined in current file
+    usedptr: bool*  # If non-NULL, set to true when the variable is used. This is how we detect unused imports.
 
 class TypeAndUsedPtr:
     type: Type*

--- a/compiler/types_in_ast.jou
+++ b/compiler/types_in_ast.jou
@@ -60,10 +60,11 @@ class FunctionOrMethodTypes:
 
 
 class GlobalVariable:
+    usedptr: bool*  # If non-NULL, set to true when the variable is used. This is how we detect unused imports.
     name: byte[100]  # Same as in user's code, never empty
     type: Type*
-    defined_in_current_file: bool  # not declare-only (e.g. stdout) or imported
-    usedptr: bool*  # If non-NULL, set to true when the variable is used. This is how we detect unused imports.
+#    defined_in_current_file: bool  # not declare-only (e.g. stdout) or imported
+#    public: bool  # always True if not defined in current file
 
 class TypeAndUsedPtr:
     type: Type*

--- a/stdlib/_jou_startup.jou
+++ b/stdlib/_jou_startup.jou
@@ -17,8 +17,11 @@
 # We can't import FILE from io.jou here, because then we would be
 # trying to define a variable that already exists.
 if WINDOWS or MACOS or NETBSD:
+    @public
     global stdin: void*
+    @public
     global stdout: void*
+    @public
     global stderr: void*
 
 if WINDOWS:

--- a/tests/other_errors/import_private_global_var.jou
+++ b/tests/other_errors/import_private_global_var.jou
@@ -1,0 +1,6 @@
+import "./imported/privates.jou"
+
+def main() -> int:
+    # TODO: error message could be better, should say that it exists but is not @public
+    x = globaah  # Error: no variable named 'globaah'
+    return 0

--- a/tests/other_errors/imported/privates.jou
+++ b/tests/other_errors/imported/privates.jou
@@ -1,6 +1,8 @@
 def private_function() -> None:
     pass
 
+global globaah: int
+
 enum PrivateEnum:
     Foo
     Bar
@@ -10,3 +12,4 @@ enum PrivateEnum:
 def this_function_silences_warnings_about_unused_things() -> None:
     private_function()
     x = PrivateEnum.Foo
+    globaah++

--- a/tests/should_succeed/imported/bar.jou
+++ b/tests/should_succeed/imported/bar.jou
@@ -18,5 +18,9 @@ enum FooBar:
     Bar
 
 @public
+global bar_counter: int
+
+@public
 def bar(point: Point) -> None:
     printf("Bar Bar %d %d\n", point.x, point.y)
+    bar_counter++

--- a/tests/should_succeed/imported/samename1.jou
+++ b/tests/should_succeed/imported/samename1.jou
@@ -1,7 +1,11 @@
-# Tests two files with non-public functions that have same name.
-def internal() -> int:
-    return 1
+# Tests two files with non-public things that have same name.
+global value: int
+
+def internal() -> None:
+    value *= 10
 
 @public
 def public_func_1() -> int:
-    return 10 * internal()
+    value = 1
+    internal()
+    return value

--- a/tests/should_succeed/imported/samename2.jou
+++ b/tests/should_succeed/imported/samename2.jou
@@ -1,7 +1,11 @@
-# Tests two files with non-public functions that have same name.
-def internal() -> int:
-    return 2
+# Tests two files with non-public things that have same name.
+global value: int
+
+def internal() -> None:
+    value *= 20
 
 @public
 def public_func_2() -> int:
-    return 20 * internal()
+    value = 2
+    internal()
+    return value

--- a/tests/should_succeed/local_import.jou
+++ b/tests/should_succeed/local_import.jou
@@ -13,4 +13,8 @@ def main() -> int:
     if foo == FooBar.Bar:
         printf("waaaat\n")
 
+    printf("%d\n", bar_counter)  # Output: 1
+    bar_counter++
+    printf("%d\n", bar_counter)  # Output: 2
+
     return 0

--- a/tests/should_succeed/unused_global.jou
+++ b/tests/should_succeed/unused_global.jou
@@ -1,0 +1,7 @@
+import "stdlib/io.jou"
+
+global foo: int  # Warning: global variable 'foo' defined but not used
+
+def main() -> int:
+    printf("it runs\n")  # Output: it runs
+    return 0


### PR DESCRIPTION
You can use `@public` to make a global variable accessible from other files (just like functions):

```python
@public
global foo: int
```

Without `global`, the variable is private to the file (known as `static` in C and similar languages). Other files cannot access it directly even if they import the file.

Part of #84