### PR TITLE
GitHub Actions: Verify checksum of editorconfig

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           if [ "$(sha256sum ec-linux-amd64.tar.gz  | cut -d' ' -f1)" != "5e6a63097904be33c8d18e960f54fd8f60ada5464fe0056cd3dbbd0678584d15" ]; then
             echo "Checksum doesn't match! Maybe someone added malware to the release?"
+            exit 1
           fi
       - run: tar xf ec-linux-amd64.tar.gz bin/ec-linux-amd64
       - run: bin/ec-linux-amd64

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: wget https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.2.0/ec-linux-amd64.tar.gz
+      - name: Verify checksum
+        run: |
+          if [ "$(sha256sum ec-linux-amd64.tar.gz  | cut -d' ' -f1)" != "5e6a63097904be33c8d18e960f54fd8f60ada5464fe0056cd3dbbd0678584d15" ]; then
+            echo "Checksum doesn't match! Maybe someone added malware to the release?"
+          fi
       - run: tar xf ec-linux-amd64.tar.gz bin/ec-linux-amd64
       - run: bin/ec-linux-amd64
 


### PR DESCRIPTION
Theorethically, `editorconfig-checker` people could upload a malicious release of `editorconfig-checker` with the same version number, and Jou's CI setup would pick it up. This prevents that. It is a very unlikely attack, but adding a checksum doesn't matter either.

Most other downloaded things already use checksums. See e.g. `windows_setup.sh`.