### PR TITLE
Make global variable declarations private by default

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -510,7 +510,7 @@ class AstStatement:
         return_value: AstExpression*        # can be NULL
         assignment: AstAssignment           # also used for +=, -= etc
         local_var_declare: AstNameTypeValue # DeclareLocalVar
-        global_var_declare: AstNameTypeValue  # GlobalVariableDeclare
+        global_var_declare: AstGlobalVarDeclare  # GlobalVariableDeclare
         global_var_def: AstGlobalVarDef     # GlobalVariableDef
         class_field: AstNameTypeValue       # ClassField
         union_fields: AstUnionFields        # ClassUnion
@@ -589,7 +589,7 @@ class AstStatement:
                 self->enumdef.print_with_tree_printer(tp)
             case AstStatementKind.GlobalVariableDeclare:
                 printf("declare global var ")
-                self->global_var_declare.print_with_tree_printer(NULL)
+                self->global_var_declare.print()
                 printf("\n")
             case AstStatementKind.GlobalVariableDef:
                 printf("define global var ")
@@ -865,7 +865,24 @@ class AstNameTypeValue:
             free(self->value)
 
 
+# declare global foo: int
+class AstGlobalVarDeclare:
+    name: byte[100]
+    type: AstType
+    public: bool  # is it decorated with @public
+    used: bool  # used to detect unused global variables
+
+    def print(self) -> None:
+        printf("%s: ", self->name)
+        self->type.print(True)
+        printf("\n")
+
+    def free(self) -> None:
+        self->type.free()
+
+
 # global foo: int
+# TODO: support specifying an initial value
 class AstGlobalVarDef:
     name: byte[100]
     type: AstType

--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -142,6 +142,10 @@ class FileState:
                     if not stmt->global_var_def.public and not stmt->global_var_def.used:
                         snprintf(msg, sizeof msg, "global variable '%s' defined but not used", stmt->global_var_def.name)
                         show_warning(stmt->location, msg)
+                case AstStatementKind.GlobalVariableDeclare:
+                    if not stmt->global_var_declare.public and not stmt->global_var_declare.used:
+                        snprintf(msg, sizeof msg, "global variable '%s' declared but not used", stmt->global_var_declare.name)
+                        show_warning(stmt->location, msg)
                 case _:
                     pass
 

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -147,11 +147,13 @@ def decorate(stmt: AstStatement*, decor: byte*, location: Location) -> None:
                 stmt->function.public = True
             case AstStatementKind.Enum:
                 stmt->enumdef.public = True
+            case AstStatementKind.GlobalVariableDeclare:
+                stmt->global_var_declare.public = True
             case AstStatementKind.GlobalVariableDef:
                 stmt->global_var_def.public = True
             # Temporarily allow and ignore using @public on enums, classes and global variables.
             # This is needed for the bootstrap compiler to accept new syntax.
-            case AstStatementKind.Class | AstStatementKind.GlobalVariableDeclare:
+            case AstStatementKind.Class:
                 pass  # TODO: handle these cases properly
             case _:
                 fail(location, "the @public decorator cannot be used here")
@@ -1097,7 +1099,7 @@ class Parser:
                 result = AstStatement{
                     location = location,
                     kind = AstStatementKind.GlobalVariableDeclare,
-                    global_var_declare = ntv,
+                    global_var_def = AstGlobalVarDef{name = ntv.name, type = ntv.type},
                 }
             else:
                 result = AstStatement{

--- a/compiler/typecheck/step2_populate_types.jou
+++ b/compiler/typecheck/step2_populate_types.jou
@@ -203,8 +203,9 @@ def typecheck_step2_populate_types(ast: AstFile*) -> ExportSymbol*:
             case AstStatementKind.Import:
                 pass
             case AstStatementKind.GlobalVariableDeclare:
-                assert stmt->global_var_declare.value == NULL
-                exports[nexports++] = handle_global_var(&ast->types, stmt->location, stmt->global_var_declare.name, &stmt->global_var_declare.type, NULL)
+                exp = handle_global_var(&ast->types, stmt->location, stmt->global_var_declare.name, &stmt->global_var_declare.type, &stmt->global_var_declare.used)
+                if stmt->global_var_declare.public:
+                    exports[nexports++] = exp
             case AstStatementKind.GlobalVariableDef:
                 exp = handle_global_var(&ast->types, stmt->location, stmt->global_var_def.name, &stmt->global_var_def.type, &stmt->global_var_def.used)
                 if stmt->global_var_def.public:

--- a/stdlib/io.jou
+++ b/stdlib/io.jou
@@ -42,9 +42,13 @@ class FILE:
     # to accessing the members directly.
     _dummy: int
 
-# Special files for terminal input and output.
+# Special files for terminal input and output. Platform-specific details are
+# handled in _jou_startup.jou.
+@public
 declare global stdin: FILE*
+@public
 declare global stdout: FILE*
+@public
 declare global stderr: FILE*
 
 # Open/close a file for reading or writing. Mode can be e.g. "r", "w",

--- a/tests/other_errors/import_private_global_var_declare.jou
+++ b/tests/other_errors/import_private_global_var_declare.jou
@@ -1,0 +1,6 @@
+import "./imported/privates.jou"
+
+def main() -> int:
+    # TODO: error message could be better, should say that it exists but is not @public
+    x = decl_g  # Error: no variable named 'decl_g'
+    return 0

--- a/tests/other_errors/imported/privates.jou
+++ b/tests/other_errors/imported/privates.jou
@@ -2,6 +2,7 @@ def private_function() -> None:
     pass
 
 global globaah: int
+declare global decl_g: int
 
 enum PrivateEnum:
     Foo

--- a/tests/should_succeed/imported/samename1.jou
+++ b/tests/should_succeed/imported/samename1.jou
@@ -1,9 +1,10 @@
 # Tests two files with non-public things that have same name.
 global value: int
-declare global foobar: byte
+declare global the_counter: int
 
 def internal() -> None:
     value *= 10
+    the_counter++
 
 @public
 def public_func_1() -> int:

--- a/tests/should_succeed/imported/samename1.jou
+++ b/tests/should_succeed/imported/samename1.jou
@@ -1,5 +1,6 @@
 # Tests two files with non-public things that have same name.
 global value: int
+declare global foobar: byte
 
 def internal() -> None:
     value *= 10

--- a/tests/should_succeed/imported/samename2.jou
+++ b/tests/should_succeed/imported/samename2.jou
@@ -1,5 +1,6 @@
 # Tests two files with non-public things that have same name.
 global value: int
+declare global foobar: int
 
 def internal() -> None:
     value *= 20

--- a/tests/should_succeed/imported/samename2.jou
+++ b/tests/should_succeed/imported/samename2.jou
@@ -1,9 +1,10 @@
 # Tests two files with non-public things that have same name.
 global value: int
-declare global foobar: int
+declare global the_counter: int
 
 def internal() -> None:
     value *= 20
+    the_counter++
 
 @public
 def public_func_2() -> int:

--- a/tests/should_succeed/same_name_functions_not_public.jou
+++ b/tests/should_succeed/same_name_functions_not_public.jou
@@ -3,6 +3,7 @@ import "./imported/samename1.jou"
 import "./imported/samename2.jou"
 
 # This is declared in other files, let's actually define it to avoid linker errors
+# Must be public so that linker knows it's not only for this file.
 @public
 global the_counter: int
 

--- a/tests/should_succeed/same_name_functions_not_public.jou
+++ b/tests/should_succeed/same_name_functions_not_public.jou
@@ -2,6 +2,12 @@ import "stdlib/io.jou"
 import "./imported/samename1.jou"
 import "./imported/samename2.jou"
 
+# This is declared in other files, let's actually define it to avoid linker errors
+@public
+global the_counter: int
+
 def main() -> int:
+    printf("%d\n", the_counter)  # Output: 0
     printf("%d %d\n", public_func_1(), public_func_2())  # Output: 10 40
+    printf("%d\n", the_counter)  # Output: 2
     return 0

--- a/tests/should_succeed/unused_global.jou
+++ b/tests/should_succeed/unused_global.jou
@@ -1,6 +1,7 @@
 import "stdlib/io.jou"
 
 global foo: int  # Warning: global variable 'foo' defined but not used
+declare global bar: long  # Warning: global variable 'bar' declared but not used
 
 def main() -> int:
     printf("it runs\n")  # Output: it runs


### PR DESCRIPTION
Same as #751 but for the `declare global` syntax. Part of #84.