### PR TITLE
Make classes private by default

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -22,6 +22,7 @@ enum AstTypeKind:
     Array
 
 
+@public
 class AstArrayType:
     member_type: AstType*
     length: AstExpression*
@@ -33,6 +34,7 @@ class AstArrayType:
         free(self->length)
 
 
+@public
 class AstType:
     kind: AstTypeKind
     location: Location
@@ -97,12 +99,14 @@ class TreePrinter:
 
 
 # Foo.Bar where Foo is an enum
+@public
 class AstEnumMember:
     enum_name: byte[100]
     member_name: byte[100]
 
 
 # foo.bar, foo->bar
+@public
 class AstClassField:
     instance: AstExpression*
     uses_arrow_operator: bool  # distinguishes foo.bar and foo->bar
@@ -114,6 +118,7 @@ class AstClassField:
 
 
 # Foo{bar = 1, baz = 2}
+@public
 class AstInstantiation:
     class_name_location: Location  # TODO: probably not necessary, can use location of the instantiate expression
     class_name: byte[100]
@@ -183,6 +188,7 @@ enum AstExpressionKind:
     And         # x and y
     Or          # x or y
 
+@public
 class AstExpression:
     location: Location
     kind: AstExpressionKind
@@ -382,6 +388,7 @@ class AstExpression:
 
 
 # [foo, bar, baz]
+@public
 class AstArray:
     length: int
     items: AstExpression*
@@ -393,6 +400,7 @@ class AstArray:
 
 
 # foo as bar
+@public
 class AstAs:
     value: AstExpression
     type: AstType
@@ -414,6 +422,7 @@ class AstAs:
 # foo(arg1, arg2, arg3)
 # foo.bar(arg1, arg2, arg3)
 # foo->bar(arg1, arg2, arg3)
+@public
 class AstCall:
     location: Location
     name: byte[100]  # name of function or method
@@ -459,6 +468,7 @@ class AstCall:
 
 
 # assert foo
+@public
 class AstAssertion:
     condition: AstExpression
     condition_str: byte*
@@ -498,6 +508,7 @@ enum AstStatementKind:
     GlobalVariableDeclare
     GlobalVariableDef
 
+@public
 class AstStatement:
     location: Location
     kind: AstStatementKind
@@ -657,6 +668,7 @@ class AstStatement:
 
 
 # Useful for e.g. "while condition: body", "if condition: body"
+@public
 class AstConditionAndBody:
     condition: AstExpression
     body: AstBody
@@ -679,6 +691,7 @@ class AstConditionAndBody:
 
 
 # foo = bar
+@public
 class AstAssignment:
     target: AstExpression
     value: AstExpression
@@ -703,6 +716,7 @@ class AstAssignment:
 #     ...
 # else:
 #     ...
+@public
 class AstIfStatement:
     if_and_elifs: AstConditionAndBody*
     n_if_and_elifs: int  # At least 1 (the if statement). The rest, if any, are elifs.
@@ -733,6 +747,7 @@ class AstIfStatement:
 #         ...
 #     case ...:
 #         ...
+@public
 class AstMatchStatement:
     match_obj: AstExpression
     func_name: byte[100]  # empty if there's no "with foo"
@@ -766,6 +781,7 @@ class AstMatchStatement:
 
 # case case_obj1 | case_obj2 | case_obj3:
 #     body
+@public
 class AstCase:
     case_objs: AstExpression*
     n_case_objs: int
@@ -790,6 +806,7 @@ class AstCase:
 
 # for init; cond; incr:
 #     ...body...
+@public
 class AstForLoop:
     init: AstStatement*   # may be NULL
     cond: AstExpression*  # may be NULL
@@ -835,6 +852,7 @@ class AstForLoop:
 
 
 # name: type = value
+@public
 class AstNameTypeValue:
     name: byte[100]
     name_location: Location
@@ -883,6 +901,7 @@ class AstGlobalVarDeclare:
 
 # global foo: int
 # TODO: support specifying an initial value
+@public
 class AstGlobalVarDef:
     name: byte[100]
     type: AstType
@@ -899,6 +918,7 @@ class AstGlobalVarDef:
 
 
 # typically multiple indented lines after a ":" at end of line
+@public
 class AstBody:
     statements: AstStatement*
     nstatements: int
@@ -917,6 +937,7 @@ class AstBody:
 
 
 # function name and parameters in "def" or "declare"
+@public
 class AstSignature:
     name_location: Location
     name: byte[100]  # name of function or method, after "def" keyword
@@ -958,6 +979,7 @@ class AstSignature:
 
 
 # import "./foo.jou"
+@public
 class AstImport:
     specified_path: byte*  # Path in jou code e.g. "stdlib/io.jou"
     resolved_path: byte*  # Absolute path or relative to current working directory e.g. "/home/akuli/jou/stdlib/io.jou"
@@ -975,6 +997,7 @@ class AstImport:
 
 
 # Represents the AST of one Jou file.
+@public
 class AstFile:
     path: byte*  # not owned
     is_main_file: bool  # is this the file passed in Jou compiler command? False means imported file
@@ -993,6 +1016,7 @@ class AstFile:
 
 # def foo() -> bar:
 #     ...
+@public
 class AstFunctionOrMethod:
     ast_signature: AstSignature
     body: AstBody
@@ -1018,6 +1042,7 @@ class AstFunctionOrMethod:
 # union:
 #     foo: type1
 #     bar: type2
+@public
 class AstUnionFields:
     fields: AstNameTypeValue*
     nfields: int
@@ -1038,6 +1063,7 @@ class AstUnionFields:
 
 # class Foo:
 #     ...members...
+@public
 class AstClassDef:
     name: byte[100]
     body: AstBody*
@@ -1061,6 +1087,7 @@ class AstClassDef:
 #     Member1
 #     Member2
 #     Member3
+@public
 class AstEnumDef:
     name: byte[100]
     name_location: Location

--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -1042,6 +1042,8 @@ class AstClassDef:
     name: byte[100]
     body: AstBody*
     type: Type*  # populated in typecheck, NULL before typecheck runs
+    public: bool  # is it decorated with @public
+    used: bool  # used to detect unused classes
 
     def print(self) -> None:
         self->print_with_tree_printer(TreePrinter{})

--- a/compiler/builders/either_builder.jou
+++ b/compiler/builders/either_builder.jou
@@ -16,16 +16,19 @@ import "./llvm_builder.jou"
 import "./uvg_builder.jou"
 
 
+@public
 class EitherBuilderValue:
     lvalue: LBuilderValue
     uvalue: int
 
 
+@public
 class EitherBuilderBlock:
     lblock: LLVMBasicBlock*
     ublock: UvgBlock*  # funny naming :)
 
 
+@public
 class EitherBuilder:
     lbuilder: LBuilder*  # may be NULL
     ubuilder: UBuilder*  # may be NULL

--- a/compiler/builders/llvm_builder.jou
+++ b/compiler/builders/llvm_builder.jou
@@ -220,12 +220,14 @@ def find_enum_member(enumtype: Type*, name: byte*) -> int:
     assert False
 
 
+@public
 class LBuilderValue:
     type: Type*
     llvm_value: LLVMValue*
 
 
 # Not named LLVMBuilder because that is the name of LLVM's thing.
+@public
 class LBuilder:
     llvm_module: LLVMModule*
     llvm_builder: LLVMBuilder*

--- a/compiler/builders/uvg_builder.jou
+++ b/compiler/builders/uvg_builder.jou
@@ -25,6 +25,7 @@ def FALSE_ID() -> int:
     return -3
 
 
+@public
 class UBuilder:
     uvg: Uvg
     current_block: UvgBlock*

--- a/compiler/errors_and_warnings.jou
+++ b/compiler/errors_and_warnings.jou
@@ -1,6 +1,7 @@
 import "stdlib/process.jou"
 import "stdlib/io.jou"
 
+@public
 class Location:
     path: byte*  # Not owned. Points to a string that is held elsewhere.
     lineno: int

--- a/compiler/llvm.jou
+++ b/compiler/llvm.jou
@@ -1,20 +1,28 @@
+@public
 class LLVMModule:
     _dummy: int
+@public
 class LLVMType:
     _dummy: int
+@public
 class LLVMValue:
     _dummy: int
+@public
 class LLVMBasicBlock:
     _dummy: int
+@public
 class LLVMBuilder:
     _dummy: int
 class LLVMPassManager:
     _dummy: int
 
+@public
 class LLVMTarget:
     _dummy: int
+@public
 class LLVMTargetData:
     _dummy: int
+@public
 class LLVMTargetMachine:
     _dummy: int
 

--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -146,6 +146,10 @@ class FileState:
                     if not stmt->global_var_declare.public and not stmt->global_var_declare.used:
                         snprintf(msg, sizeof msg, "global variable '%s' declared but not used", stmt->global_var_declare.name)
                         show_warning(stmt->location, msg)
+                case AstStatementKind.Class:
+                    if not stmt->classdef.public and not stmt->classdef.used:
+                        snprintf(msg, sizeof msg, "class '%s' defined but not used", stmt->classdef.name)
+                        show_warning(stmt->location, msg)
                 case _:
                     pass
 

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -145,16 +145,16 @@ def decorate(stmt: AstStatement*, decor: byte*, location: Location) -> None:
                 if strcmp(stmt->function.ast_signature.name, "main") == 0:
                     fail(location, "the main() function cannot be @public")
                 stmt->function.public = True
+            case AstStatementKind.MethodDef:
+                fail(location, "methods cannot be decorated with @public, a class is either fully public or fully private")
+            case AstStatementKind.Class:
+                stmt->classdef.public = True
             case AstStatementKind.Enum:
                 stmt->enumdef.public = True
             case AstStatementKind.GlobalVariableDeclare:
                 stmt->global_var_declare.public = True
             case AstStatementKind.GlobalVariableDef:
                 stmt->global_var_def.public = True
-            # Temporarily allow and ignore using @public on enums, classes and global variables.
-            # This is needed for the bootstrap compiler to accept new syntax.
-            case AstStatementKind.Class:
-                pass  # TODO: handle these cases properly
             case _:
                 fail(location, "the @public decorator cannot be used here")
     else:

--- a/compiler/token.jou
+++ b/compiler/token.jou
@@ -25,6 +25,7 @@ enum TokenKind:
     Operator
     EndOfFile  # Marks the end of an array of tokens.
 
+@public
 class Token:
     kind: TokenKind
     location: Location

--- a/compiler/typecheck/common.jou
+++ b/compiler/typecheck/common.jou
@@ -18,6 +18,7 @@ enum ExportSymbolKind:
     Type
     GlobalVar
 
+@public
 class ExportSymbol:
     kind: ExportSymbolKind
     name: byte[100]  # TODO: maybe this should be 200 because it can be ClassName.method_name? or something else?

--- a/compiler/typecheck/step1_create_types.jou
+++ b/compiler/typecheck/step1_create_types.jou
@@ -29,8 +29,8 @@ def typecheck_step1_create_types(ast: AstFile*) -> ExportSymbol*:
         match stmt->kind:
             case AstStatementKind.Class:
                 name = stmt->classdef.name
-                public = True
-                usedptr = NULL
+                public = stmt->classdef.public
+                usedptr = &stmt->classdef.used
                 t = create_opaque_class(name)
                 stmt->classdef.type = t
             case AstStatementKind.Enum:

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -3,6 +3,7 @@ import "stdlib/str.jou"
 
 import "./errors_and_warnings.jou"
 
+@public
 class ClassField:
     name: byte[100]
     type: Type*
@@ -37,6 +38,7 @@ enum TypeKind:
     OpaqueClass  # class with unknown members, used temporarily during type checking
     Enum
 
+@public
 class Type:
     name: byte[500]   # All types have a name for error messages and debugging.
     kind: TypeKind
@@ -283,6 +285,7 @@ def create_enum(name: byte*, membercount: int, membernames: byte[100]*) -> Type*
     return &result->type
 
 
+@public
 class Signature:
     name: byte[100]  # Function or method name. For methods it does not include the name of the class.
     nargs: int

--- a/compiler/types_in_ast.jou
+++ b/compiler/types_in_ast.jou
@@ -11,6 +11,7 @@ import "stdlib/mem.jou"
 import "./types.jou"
 
 
+@public
 class ExpressionTypes:
     # Type of value that the expression evaluates to, before implicit casts are applied.
     # This is NULL before type checking, and if the expression  calling '-> None' function/method.
@@ -24,6 +25,7 @@ class ExpressionTypes:
     implicit_array_to_pointer_cast: bool    # Foo[N] to Foo*
 
 
+@public
 class LocalVariable:
     name: byte[100]  # Same name as in user's code, empty for temporary variables created by compiler
     type: Type*
@@ -31,6 +33,7 @@ class LocalVariable:
 
 # Type information about a function or method defined in the current file.
 # Not created for anything imported from another file.
+@public
 class FunctionOrMethodTypes:
     signature: Signature
     locals: LocalVariable*
@@ -73,6 +76,7 @@ class SignatureAndUsedPtr:
     usedptr: bool*  # used to detect unused imports
 
 
+@public
 class FileTypes:
     globals: GlobalVariable*
     nglobals: int

--- a/compiler/uvg.jou
+++ b/compiler/uvg.jou
@@ -12,12 +12,14 @@ enum UvgInstructionKind:
     Set             # *x = something
     DontAnalyze     # do_something_complicated(&x)
 
+@public
 class UvgInstruction:
     location: Location
     kind: UvgInstructionKind
     var: int
 
 
+@public
 class UvgBranch:
     then: UvgBlock*
     otherwise: UvgBlock*
@@ -31,6 +33,7 @@ enum UvgTerminatorKind:
     Return
     Unreachable
 
+@public
 class UvgTerminator:
     kind: UvgTerminatorKind
     union:
@@ -38,6 +41,7 @@ class UvgTerminator:
         branch: UvgBranch       # UvgTerminatorKind.Branch
 
 
+@public
 class UvgBlock:
     instructions: UvgInstruction*
     ninstructions: int
@@ -57,6 +61,7 @@ class UvgBlock:
 
 
 # We build one UVG for each function.
+@public
 class Uvg:
     signature: Signature*
 

--- a/doc/imports.md
+++ b/doc/imports.md
@@ -36,9 +36,9 @@ Practically, here's what you need to know:
 
 ## Public
 
-If you want a function to be importable, mark it with `@public`.
-Functions not marked with `@public` are "private within file":
-they can only be used within the file that defines the function.
+If you want a function, [class](classes.md), [enum](enums.md) or global variable to be importable,
+mark it with `@public`.
+Anything not marked with `@public` can only be used in the same file.
 
 For example:
 
@@ -49,11 +49,23 @@ def only_for_this_file() -> None:
 @public
 def visible_in_files_that_import_this_file() -> None:
     ...
+
+class OnlyForThisFile:
+    field: int
+    def method(self) -> None:
+        ...
+
+@public
+class VisibleInFilesThatImportThisFile:
+    field: int
+    def method(self) -> None:
+        ...
 ```
 
-Currently this only applies to functions, including `declare`,
-but extending it to other things is planned.
-See [issue #84](https://github.com/Akuli/jou/issues/84).
+Class fields and methods are always public.
+This means that if you have an instance of a class,
+you can simply call any method defined in the class.
+If you don't like this, please create an issue on GitHub to discuss it.
 
 
 ## Conflicting Names

--- a/doc/imports.md
+++ b/doc/imports.md
@@ -60,12 +60,21 @@ class VisibleInFilesThatImportThisFile:
     field: int
     def method(self) -> None:
         ...
+
+global kinda_ok_variable: int
+
+@public
+global many_people_consider_this_bad: int
 ```
 
 Class fields and methods are always public.
 This means that if you have an instance of a class,
 you can simply call any method defined in the class.
 If you don't like this, please create an issue on GitHub to discuss it.
+
+Many people dislike global variables, especially when they are accessed in multiple files.
+That said, Jou lets you mark a global variable as `@public` and import it into another file,
+because sometimes that is the best solution.
 
 
 ## Conflicting Names

--- a/doc/imports.md
+++ b/doc/imports.md
@@ -37,8 +37,8 @@ Practically, here's what you need to know:
 ## Public
 
 If you want a function, [class](classes.md), [enum](enums.md) or global variable to be importable,
-mark it with `@public`.
-Anything not marked with `@public` can only be used in the same file.
+make it public with the `@public` decorator.
+Anything not decorated with `@public` can only be used in the same file.
 
 For example:
 
@@ -73,7 +73,7 @@ you can simply call any method defined in the class.
 If you don't like this, please create an issue on GitHub to discuss it.
 
 Many people dislike global variables, especially when they are accessed in multiple files.
-That said, Jou lets you mark a global variable as `@public` and import it into another file,
+That said, Jou lets you decorate a global variable as `@public` and import it into another file,
 because sometimes that is the best solution.
 
 
@@ -85,9 +85,8 @@ and `baz.jou` also defines a function `foo()` with `@public`,
 then you cannot use `bar.jou` and `baz.jou` in the same project.
 To work around this, rename the functions or don't use `@public`.
 
-The same applies to basically anything public (that is, accessible from other files).
-However, it's fine to have multiple methods with the same name in different classes
-as long as the class names are different.
+The same applies to anything decorated with `@public`.
+However, it's fine to have multiple methods with the same name in different public classes.
 For example, [the `ast.jou` file in the Jou compiler](../compiler/ast.jou)
 has many classes whose name starts with `Ast` to prevent conflicts with other files,
 and most of them have methods named `print()` and `free()`.

--- a/examples/aoc2023/day24/bigint.jou
+++ b/examples/aoc2023/day24/bigint.jou
@@ -13,6 +13,7 @@ def bigint(value: long) -> BigInt:
     return result
 
 
+@public
 class BigInt:
     data: byte[48]  # little endian, last byte includes sign bit
 

--- a/examples/aoc2023/grid.jou
+++ b/examples/aoc2023/grid.jou
@@ -7,6 +7,7 @@ import "stdlib/mem.jou"
 import "stdlib/io.jou"
 
 
+@public
 class Grid:
     width: int
     height: int

--- a/stdlib/io.jou
+++ b/stdlib/io.jou
@@ -36,6 +36,7 @@ declare getchar() -> int
 @public
 declare scanf(pattern: byte*, ...) -> int  # Parse keyboard input (stdin)
 
+@public
 class FILE:
     # The members that are actually inside this class are
     # platform-specific. Use the functions below instead of trying

--- a/tests/other_errors/import_private_class.jou
+++ b/tests/other_errors/import_private_class.jou
@@ -1,0 +1,5 @@
+import "./imported/privates.jou"
+
+# TODO: error message could be better, should say that it exists but is not @public
+def foo() -> PrivateClass:  # Error: there is no type named 'PrivateClass'
+    return PrivateClass{}

--- a/tests/other_errors/imported/privates.jou
+++ b/tests/other_errors/imported/privates.jou
@@ -1,6 +1,9 @@
 def private_function() -> None:
     pass
 
+class PrivateClass:
+    x: int
+
 global globaah: int
 declare global decl_g: int
 
@@ -13,4 +16,5 @@ enum PrivateEnum:
 def this_function_silences_warnings_about_unused_things() -> None:
     private_function()
     x = PrivateEnum.Foo
+    y: PrivateClass
     globaah++

--- a/tests/other_errors/public_method.jou
+++ b/tests/other_errors/public_method.jou
@@ -1,0 +1,4 @@
+class Foo:
+    @public  # Error: methods cannot be decorated with @public, a class is either fully public or fully private
+    def bar(self) -> None:
+        pass

--- a/tests/should_succeed/imported/bar.jou
+++ b/tests/should_succeed/imported/bar.jou
@@ -2,6 +2,7 @@
 
 import "stdlib/io.jou"
 
+@public
 class Point:
     x: int
     y: int

--- a/tests/should_succeed/unused_class.jou
+++ b/tests/should_succeed/unused_class.jou
@@ -4,7 +4,7 @@ import "stdlib/io.jou"
 class Foo:
     x: int
 
-class Bar:  # Warning: class Bar defined but not used
+class Bar:  # Warning: class 'Bar' defined but not used
     x: int
 
 def main() -> int:

--- a/tests/should_succeed/unused_class.jou
+++ b/tests/should_succeed/unused_class.jou
@@ -1,0 +1,12 @@
+import "stdlib/io.jou"
+
+@public
+class Foo:
+    x: int
+
+class Bar:  # Warning: class Bar defined but not used
+    x: int
+
+def main() -> int:
+    printf("it runs\n")  # Output: it runs
+    return 0


### PR DESCRIPTION
Example:
```python
class PrivateClass:
    ...

@public
class PublicClass:
    ...
```

For now, all methods are considered public, and there's no warning for unused methods. This turned out to be more difficult to implement than I thought. I created #758.

Closes #84 