### PR TITLE
Allow empty class

### DIFF
--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -58,7 +58,7 @@ def statement_conflicts_with_an_import(stmt: AstStatement*, importsym: ExportSym
                 importsym->kind == ExportSymbolKind.Type
                 and strcmp(importsym->name, stmt->enumdef.name) == 0
             )
-        case AstStatementKind.Import:
+        case AstStatementKind.Import | AstStatementKind.Pass:
             return False
         case _:
             printf("%d\n", stmt->kind as int)

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -797,7 +797,6 @@ class Parser:
             end = self->tokens->location
             result.assertion.condition_str = read_assertion_from_file(start, end)
         elif self->tokens->is_keyword("pass"):
-            self->check_function_or_method("'pass'")  # TODO: would it be better to allow 'pass' elsewhere?
             self->tokens++
             result.kind = AstStatementKind.Pass
         elif self->tokens->is_keyword("break"):

--- a/compiler/typecheck/step2_populate_types.jou
+++ b/compiler/typecheck/step2_populate_types.jou
@@ -184,6 +184,9 @@ def handle_class_members(ft: FileTypes*, classdef: AstClassDef*) -> None:
                 assert t->classdata.methods != NULL
                 t->classdata.methods[t->classdata.nmethods++] = sig.copy()
 
+            case AstStatementKind.Pass:
+                pass
+
             case _:
                 assert False
 
@@ -200,7 +203,7 @@ def typecheck_step2_populate_types(ast: AstFile*) -> ExportSymbol*:
         assert exports != NULL
 
         match stmt->kind:
-            case AstStatementKind.Import:
+            case AstStatementKind.Import | AstStatementKind.Pass:
                 pass
             case AstStatementKind.GlobalVariableDeclare:
                 exp = handle_global_var(&ast->types, stmt->location, stmt->global_var_declare.name, &stmt->global_var_declare.type, &stmt->global_var_declare.used)

--- a/examples/x11_window.jou
+++ b/examples/x11_window.jou
@@ -8,11 +8,11 @@
 declare usleep(x: int) -> int
 
 class Display:
-    _dummy: int
+    pass
 class XGCValues:
-    _dummy: int
+    pass
 class GC:
-    _dummy: int
+    pass
 
 declare XOpenDisplay(name: byte*) -> Display*
 declare XCreateSimpleWindow(

--- a/stdlib/io.jou
+++ b/stdlib/io.jou
@@ -41,7 +41,7 @@ class FILE:
     # The members that are actually inside this class are
     # platform-specific. Use the functions below instead of trying
     # to accessing the members directly.
-    pass
+    _dummy: int
 
 # Special files for terminal input and output. Platform-specific details are
 # handled in _jou_startup.jou.

--- a/stdlib/io.jou
+++ b/stdlib/io.jou
@@ -41,7 +41,7 @@ class FILE:
     # The members that are actually inside this class are
     # platform-specific. Use the functions below instead of trying
     # to accessing the members directly.
-    _dummy: int
+    pass
 
 # Special files for terminal input and output. Platform-specific details are
 # handled in _jou_startup.jou.

--- a/tests/should_succeed/empty_class.jou
+++ b/tests/should_succeed/empty_class.jou
@@ -1,0 +1,18 @@
+import "stdlib/io.jou"
+
+class Emptie:
+    pass
+
+def main() -> int:
+    e1: Emptie
+    e2 = Emptie{}
+
+    printf("%lld\n", sizeof(e1))  # Output: 0
+    printf("%lld\n", sizeof(e2))  # Output: 0
+
+    if &e1 == NULL:
+        printf("wat?\n")
+    if &e2 == NULL:
+        printf("wat?\n")
+
+    return 0

--- a/tests/should_succeed/pass.jou
+++ b/tests/should_succeed/pass.jou
@@ -1,9 +1,24 @@
 import "stdlib/io.jou"
 
+pass  # not useful, but also not wrong
+
+if WINDOWS:
+    pass
+else:
+    pass
+
 def main() -> int:
+    pass
+
+    if WINDOWS:
+        pass
+    else:
+        pass
+
     a = 114514
     if a == 114514:
         pass
     else:
         puts("wat?")
+
     return 0

--- a/tests/wrong_place/pass_outside_function.jou
+++ b/tests/wrong_place/pass_outside_function.jou
@@ -1,2 +1,0 @@
-# TODO: should this be allowed?
-pass  # Error: 'pass' must be inside a function or method


### PR DESCRIPTION
Fixes #707 

Does not change compiler or stdlib yet, because that would break bootstrapping: older compiler must be able to compile latest compiler with latest stdlib.