### PR TITLE
Fix a corner case in compile-time if statement handling

### DIFF
--- a/compiler/evaluate.jou
+++ b/compiler/evaluate.jou
@@ -101,14 +101,25 @@ def evaluate_if_statements_in_body(body: AstBody*, must_succeed: bool) -> None:
     for i = 0; i < body->nstatements; i++:
         match body->statements[i].kind:
             case AstStatementKind.If:
-                ptr = choose_if_elif_branch(&body->statements[i].if_statement)
+                if_stmt = &body->statements[i].if_statement
+
+                ptr = choose_if_elif_branch(if_stmt)
                 if ptr == NULL and must_succeed:
                     fail(body->statements[i].location, "cannot evaluate condition at compile time")
+
                 if ptr != NULL:
                     replacement = *ptr
                     *ptr = AstBody{}  # avoid double-free
                     replace(body, i, replacement)
                     i--  # cancels i++ to do same index again, so that we handle nested if statements
+                    continue
+
+                # Recurse into inner if statements. Needed when compile-time if
+                # statement is inside a runtime if statement.
+                for k = 0; k < if_stmt->n_if_and_elifs; k++:
+                    evaluate_if_statements_in_body(&if_stmt->if_and_elifs[k].body, False)
+                evaluate_if_statements_in_body(&if_stmt->else_body, False)
+
             case AstStatementKind.WhileLoop:
                 evaluate_if_statements_in_body(&body->statements[i].while_loop.body, False)
             case AstStatementKind.ForLoop:

--- a/tests/should_succeed/compile_time_if.jou
+++ b/tests/should_succeed/compile_time_if.jou
@@ -1,4 +1,5 @@
 import "stdlib/io.jou"
+import "stdlib/process.jou"
 
 # TODO: "if WINDOWS" doesn't work very well inside functions yet.
 #       Ideally only the declares would need compile-time if statements.
@@ -55,5 +56,14 @@ if True:
         # No unreachable code warning for "if False", it acts as commenting out
         if False:
             printf("hello\n")
+
+        # Corner case: compile-time if statement inside a runtime if statement.
+        # Should not produce any unreachable code warnings.
+        # Output: Foo
+        if getenv("does_not_exist") == NULL:
+            if WINDOWS:
+                printf("Foo\n")
+            else:
+                printf("Foo\n")
 
         return 0

--- a/tests/should_succeed/compile_time_if.jou
+++ b/tests/should_succeed/compile_time_if.jou
@@ -55,7 +55,7 @@ if True:
 
         # No unreachable code warning for "if False", it acts as commenting out
         if False:
-            printf("hello\n")
+            totally(not valid, at.all)
 
         # Corner case: compile-time if statement inside a runtime if statement.
         # Should not produce any unreachable code warnings.


### PR DESCRIPTION
Needed for #763 

Previously, compile-time evaluatable if statements inside runtime if statements were never evaluated.

For example, if you don't use windows, the following would procude a compiler warning even though the code would run on Windows:

```python
if some_dynamic_thing() == other_dynamic_thing():
    if WINDOWS:
        do_stuff()  # Warning: this code will never run
```

This PR removes the warning, because it evalutes `if WINDOWS:` at compile time before we do the warnings.