### PR TITLE
Fix stat() linker warning on NetBSD

### DIFF
--- a/compiler/paths.jou
+++ b/compiler/paths.jou
@@ -20,8 +20,6 @@ else:
 @public
 declare dirname(path: byte*) -> byte*
 
-declare stat(path: byte*, buf: byte[1000]*) -> int  # lol
-
 
 @public
 def find_current_executable() -> byte*:
@@ -76,16 +74,15 @@ def find_stdlib() -> byte*:
             # give up, seems like we reached root of file system (e.g. "C:/" or "/")
             break
 
-        path: byte*
+        path, iojou: byte*
         asprintf(&path, "%s/stdlib", exedir)
-
-        iojou: byte*
         asprintf(&iojou, "%s/io.jou", path)
-        buf: byte[1000]
-        stat_result = stat(iojou, &buf)
+
+        f = fopen(iojou, "r")
         free(iojou)
 
-        if stat_result == 0:
+        if f != NULL:
+            fclose(f)
             for k = 0; k < i; k++:
                 free(checked[k])
             free(exedir)


### PR DESCRIPTION
@taahol explained to me that on NetBSD, invoking `stat()` in C actually calls a function named `__stat50()`. There is also a function whose name is actually `stat()`, and it's some legacy thing that produces a linker warning if you try to use it.

Jou is currently using the legacy `stat()`. Let's not use `stat()` at all in the compiler, because we can still avoid it.

I don't know yet what I want to do if I some day add a `stat()` to the Jou standard library.