### PR TITLE
Add EOF constant to stdlib/io.jou

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,6 +25,7 @@ commits=(
     adad3da193f8bb5473c3d63602997ab70a3571cb  # @public can be applied to classes, enums and global variables
     2c2e8efa3be20fb63727d96731b92ec515b872db  # "pass" in class, "if False" at compile time
     d8c1f36e92812185a999f87a1fadc7e9eae78bd0  # the "link" keyword
+    ec92977acf51c265c28eefdab36d7ef272ac9eda  # the "const" keyword
 )
 
 for commit in ${commits[@]}; do

--- a/compiler/tokenizer.jou
+++ b/compiler/tokenizer.jou
@@ -210,8 +210,6 @@ class Tokenizer:
     last_3_bytes: byte[3]
 
     def read_byte(self) -> byte:
-        EOF = -1  # FIXME
-
         c: byte
         if self->pushback_len > 0:
             c = self->pushback[--self->pushback_len]

--- a/examples/aoc2024/day03/part1.jou
+++ b/examples/aoc2024/day03/part1.jou
@@ -38,7 +38,6 @@ def main() -> int:
     i = 0
     while True:
         c = fgetc(f)
-        EOF = -1  # TODO: belongs to stdlib
         if c == EOF:
             break
         assert i < max_size

--- a/examples/aoc2024/day03/part2.jou
+++ b/examples/aoc2024/day03/part2.jou
@@ -54,7 +54,6 @@ def main() -> int:
     i = 0
     while True:
         c = fgetc(f)
-        EOF = -1  # TODO: belongs to stdlib
         if c == EOF:
             break
         assert i < max_size

--- a/examples/aoc2024/day15/part1.jou
+++ b/examples/aoc2024/day15/part1.jou
@@ -62,7 +62,7 @@ def main() -> int:
 
     while True:
         c = fgetc(f)
-        if c == -1:  # TODO: EOF constant
+        if c == EOF:
             break
         if c == '\n':
             continue

--- a/examples/aoc2024/day15/part2.jou
+++ b/examples/aoc2024/day15/part2.jou
@@ -171,7 +171,7 @@ def main() -> int:
     while True:
         #getchar()
         c = fgetc(f)
-        if c == -1:  # TODO: EOF constant
+        if c == EOF:
             break
         if c == '\n':
             continue

--- a/stdlib/io.jou
+++ b/stdlib/io.jou
@@ -15,9 +15,16 @@ declare puts(string: byte*) -> int  # Print a string followed by "\n"
 @public
 declare printf(pattern: byte*, ...) -> int  # Example: printf("%s %d\n", "hi", 123)
 
-# Keyboard input
-# TODO: add EOF and errno, explain here how to use them
-# TODO: add stdin and explain how to use fgets(..., stdin)
+@public
+const EOF: int = -1
+
+# Reads one character of keyboard input (stdin).
+#
+# Return value is either a valid byte (use 'as byte') or EOF. If EOF is
+# returned, it means either end of file or reading error. You can use
+# ferror(stdin) to determine whether there was an error.
+#
+# See fgets() if you want to read a line.
 @public
 declare getchar() -> int
 

--- a/tests/should_succeed/file.jou
+++ b/tests/should_succeed/file.jou
@@ -25,7 +25,7 @@ def read_hello_123() -> None:
     rewind(f)
     while True:
         c = fgetc(f)
-        if c < 0:
+        if c == EOF:
             break
         printf("%c", c as byte)  # Output: hello 123
 


### PR DESCRIPTION
`getchar()` and `fgets()` return the constant `EOF` when reading fails or end of file occurs. EOF is `-1` on all platforms that Jou currently supports, so in the past, the number `-1` has been hard-coded every time EOF was needed.

I also documented how EOF constant is meant to be used.