### PR TITLE
Compiler refactor: use AstExpressionKind.Constant for literals

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -146,20 +146,13 @@ class AstInstantiation:
 @public
 enum AstExpressionKind:
     String
-    Int
-    Short
-    Long
-    Byte
-    Float
-    Double
-    Bool
     Null
+    Constant    # e.g. int literals, also accessing `const` values becomes this during type checking
     Array
     Call  # function call or method call
     Instantiate   # MyClass{x=1, y=2}
     Self    # not a variable lookup, so you can't use 'self' as variable name outside a class
     GetVariable
-    Constant    # accessing `const` value, GetVariable changes to Constant during type checking
     GetEnumMember
     GetClassField   # foo.bar, foo->bar
     As
@@ -199,11 +192,6 @@ class AstExpression:
         enum_member: AstEnumMember
         class_field: AstClassField
         string: byte*
-        int_value: int
-        short_value: short
-        long_value: long
-        byte_value: byte
-        bool_value: bool
         call: AstCall
         instantiation: AstInstantiation
         as_: AstAs*  # Must be pointer, because it contains an AstExpression
@@ -231,23 +219,6 @@ class AstExpression:
             case AstExpressionKind.Constant:
                 printf("constant: ")
                 self->constant.print()
-            case AstExpressionKind.Short:
-                printf("short %hd\n", self->short_value)
-            case AstExpressionKind.Int:
-                printf("int %d\n", self->int_value)
-            case AstExpressionKind.Long:
-                printf("long %lld\n", self->long_value)
-            case AstExpressionKind.Byte:
-                printf("byte %d\n", self->byte_value)
-            case AstExpressionKind.Float:
-                printf("float %s\n", self->float_or_double_text)
-            case AstExpressionKind.Double:
-                printf("double %s\n", self->float_or_double_text)
-            case AstExpressionKind.Bool:
-                if self->bool_value:
-                    printf("True\n")
-                else:
-                    printf("False\n")
             case AstExpressionKind.Null:
                 printf("NULL\n")
             case AstExpressionKind.Indexing:

--- a/compiler/builders/ast_to_builder.jou
+++ b/compiler/builders/ast_to_builder.jou
@@ -282,20 +282,6 @@ class AstToBuilder:
                     assert expr->types.orig_type->kind == TypeKind.Array
                     assert expr->types.orig_type->array.item_type == byteType
                     return self->builder->string_array(expr->string, expr->types.orig_type->array.len)
-            case AstExpressionKind.Byte:
-                return self->builder->integer(byteType, expr->byte_value)
-            case AstExpressionKind.Short:
-                return self->builder->integer(shortType, expr->short_value)
-            case AstExpressionKind.Int:
-                return self->builder->integer(intType, expr->int_value)
-            case AstExpressionKind.Long:
-                return self->builder->integer(longType, expr->long_value)
-            case AstExpressionKind.Float:
-                return self->builder->float_or_double(floatType, expr->float_or_double_text)
-            case AstExpressionKind.Double:
-                return self->builder->float_or_double(doubleType, expr->float_or_double_text)
-            case AstExpressionKind.Bool:
-                return self->builder->boolean(expr->bool_value)
             case AstExpressionKind.Null:
                 return self->builder->zero_of_type(voidPtrType)
             case AstExpressionKind.Constant:

--- a/compiler/evaluate.jou
+++ b/compiler/evaluate.jou
@@ -8,13 +8,6 @@ import "./types.jou"
 
 
 @public
-def evaluate_array_length(expr: AstExpression*) -> int:
-    if expr->kind == AstExpressionKind.Int:
-        return expr->int_value
-    fail(expr->location, "cannot evaluate array length at compile time")
-
-
-@public
 def get_special_constant(name: byte*) -> int:
     match name with strcmp:
         case "WINDOWS":
@@ -50,12 +43,8 @@ def evaluate_constant_expression(expr: AstExpression*, result: Constant*) -> boo
     msg: byte[500]
 
     match expr->kind:
-        case AstExpressionKind.Int:
-            *result = int_constant(intType, expr->int_value)
-            return True
-
-        case AstExpressionKind.Bool:
-            *result = Constant{kind = ConstantKind.Bool, boolean = expr->bool_value}
+        case AstExpressionKind.Constant:
+            *result = expr->constant.copy()
             return True
 
         case AstExpressionKind.GetVariable:
@@ -108,6 +97,15 @@ def evaluate_constant_expression(expr: AstExpression*, result: Constant*) -> boo
 
         case _:
             return False
+
+
+@public
+def evaluate_array_length(expr: AstExpression*) -> int:
+    # TODO: this should probably support longs
+    c: Constant
+    if evaluate_constant_expression(expr, &c) and c.get_type() == intType:
+        return c.integer.value as int
+    fail(expr->location, "cannot evaluate array length at compile time")
 
 
 def choose_if_elif_branch(if_stmt: AstIfStatement*) -> AstBody*:

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -6,6 +6,8 @@ import "./token.jou"
 import "./ast.jou"
 import "./errors_and_warnings.jou"
 import "./paths.jou"
+import "./constants.jou"
+import "./types.jou"
 
 
 # arity = number of operands, e.g. 2 for a binary operator such as "+"
@@ -501,32 +503,32 @@ class Parser:
 
         match self->tokens->kind:
             case TokenKind.Short:
-                expr.kind = AstExpressionKind.Short
-                expr.short_value = self->tokens->short_value
+                expr.kind = AstExpressionKind.Constant
+                expr.constant = int_constant(shortType, self->tokens->short_value)
                 self->tokens++
             case TokenKind.Int:
-                expr.kind = AstExpressionKind.Int
-                expr.int_value = self->tokens->int_value
+                expr.kind = AstExpressionKind.Constant
+                expr.constant = int_constant(intType, self->tokens->int_value)
                 self->tokens++
             case TokenKind.Long:
-                expr.kind = AstExpressionKind.Long
-                expr.long_value = self->tokens->long_value
+                expr.kind = AstExpressionKind.Constant
+                expr.constant = int_constant(longType, self->tokens->long_value)
                 self->tokens++
             case TokenKind.Byte:
-                expr.kind = AstExpressionKind.Byte
-                expr.byte_value = self->tokens->byte_value
+                expr.kind = AstExpressionKind.Constant
+                expr.constant = int_constant(byteType, self->tokens->byte_value)
+                self->tokens++
+            case TokenKind.Float:
+                expr.kind = AstExpressionKind.Constant
+                expr.constant = Constant{kind = ConstantKind.Float, float_or_double_text = self->tokens->short_string}
+                self->tokens++
+            case TokenKind.Double:
+                expr.kind = AstExpressionKind.Constant
+                expr.constant = Constant{kind = ConstantKind.Double, float_or_double_text = self->tokens->short_string}
                 self->tokens++
             case TokenKind.String:
                 expr.kind = AstExpressionKind.String
                 expr.string = strdup(self->tokens->long_string)
-                self->tokens++
-            case TokenKind.Float:
-                expr.kind = AstExpressionKind.Float
-                expr.float_or_double_text = self->tokens->short_string
-                self->tokens++
-            case TokenKind.Double:
-                expr.kind = AstExpressionKind.Double
-                expr.float_or_double_text = self->tokens->short_string
                 self->tokens++
             case TokenKind.Name:
                 if self->tokens[1].is_operator("("):
@@ -541,12 +543,12 @@ class Parser:
                     self->tokens++
             case _:
                 if self->tokens->is_keyword("True"):
-                    expr.kind = AstExpressionKind.Bool
-                    expr.bool_value = True
+                    expr.kind = AstExpressionKind.Constant
+                    expr.constant = Constant{kind = ConstantKind.Bool, boolean = True}
                     self->tokens++
                 elif self->tokens->is_keyword("False"):
-                    expr.kind = AstExpressionKind.Bool
-                    expr.bool_value = False
+                    expr.kind = AstExpressionKind.Constant
+                    expr.constant = Constant{kind = ConstantKind.Bool, boolean = False}
                     self->tokens++
                 elif self->tokens->is_keyword("NULL"):
                     expr.kind = AstExpressionKind.Null

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -53,17 +53,7 @@ def short_expression_description(expr: AstExpression*) -> byte[200]:
     result: byte[200]
 
     match expr->kind:
-        case (
-            AstExpressionKind.String
-            | AstExpressionKind.Int
-            | AstExpressionKind.Short
-            | AstExpressionKind.Long
-            | AstExpressionKind.Byte
-            | AstExpressionKind.Float
-            | AstExpressionKind.Double
-            | AstExpressionKind.Bool
-            | AstExpressionKind.Constant
-        ):
+        case AstExpressionKind.String | AstExpressionKind.Constant:
             return "a constant"
         case AstExpressionKind.Null:
             return "NULL"
@@ -838,20 +828,8 @@ def typecheck_expression(state: State*, expr: AstExpression*, type_hint: Type*) 
     handle_conflicting_class_field_and_enum_member_syntax(state, expr)
 
     match expr->kind:
-        case AstExpressionKind.Bool:
-            result = boolType
-        case AstExpressionKind.Byte:
-            result = byteType
-        case AstExpressionKind.Double:
-            result = doubleType
-        case AstExpressionKind.Float:
-            result = floatType
-        case AstExpressionKind.Short:
-            result = shortType
-        case AstExpressionKind.Int:
-            result = intType
-        case AstExpressionKind.Long:
-            result = longType
+        case AstExpressionKind.Constant:
+            result = expr->constant.get_type()
         case AstExpressionKind.Null:
             result = voidPtrType
         case AstExpressionKind.String:


### PR DESCRIPTION
#797 added support for compile-time constants. To do that, it introduced `AstExpressionType.Constant`, which represent an expression whose value is known at compile time.

This PR refactors the compiler to also use `AstExpressionType.Constant` for integer literals (e.g. `123`), `True`/`False` and a few other things.