### PR TITLE
Compiler code cleanup: delete TypeKind.OpaqueClass

### DIFF
--- a/compiler/builders/llvm_builder.jou
+++ b/compiler/builders/llvm_builder.jou
@@ -97,8 +97,9 @@ def type_to_llvm(type: Type*) -> LLVMType*:
             return LLVMIntType(type->size_in_bits)
         case TypeKind.Bool:
             return LLVMInt1Type()
-        case TypeKind.OpaqueClass | TypeKind.TypeVar:
-            # these are compiler internal/temporary things and should never end up here
+        case TypeKind.TypeVar:
+            # This is compiler internal/temporary thing and should never end up here.
+            # Please create an issue on GitHub if you get an error from the following line.
             assert False
         case TypeKind.Class:
             return class_type_to_llvm(type)

--- a/compiler/builders/llvm_builder.jou
+++ b/compiler/builders/llvm_builder.jou
@@ -99,8 +99,7 @@ def type_to_llvm(type: Type*) -> LLVMType*:
             return LLVMInt1Type()
         case TypeKind.TypeVar:
             # This is compiler internal/temporary thing and should never end up here.
-            # Please create an issue on GitHub if you get an error from the following line.
-            assert False
+            assert False  # please create an issue on GitHub if this errors
         case TypeKind.Class:
             return class_type_to_llvm(type)
         case TypeKind.Enum:

--- a/compiler/typecheck/step1_create_types.jou
+++ b/compiler/typecheck/step1_create_types.jou
@@ -31,7 +31,7 @@ def typecheck_step1_create_types(ast: AstFile*) -> ExportSymbol*:
                 name = stmt->classdef.name
                 public = stmt->classdef.public
                 usedptr = &stmt->classdef.used
-                t = create_opaque_class(name)
+                t = create_class(name)
                 stmt->classdef.type = t
             case AstStatementKind.Enum:
                 name = stmt->enumdef.name

--- a/compiler/typecheck/step1_create_types.jou
+++ b/compiler/typecheck/step1_create_types.jou
@@ -31,7 +31,7 @@ def typecheck_step1_create_types(ast: AstFile*) -> ExportSymbol*:
                 name = stmt->classdef.name
                 public = stmt->classdef.public
                 usedptr = &stmt->classdef.used
-                t = create_class(name)
+                t = create_empty_class(name)
                 stmt->classdef.type = t
             case AstStatementKind.Enum:
                 name = stmt->enumdef.name

--- a/compiler/typecheck/step2_populate_types.jou
+++ b/compiler/typecheck/step2_populate_types.jou
@@ -167,7 +167,7 @@ def handle_class_members(ft: FileTypes*, classdef: AstClassDef*) -> None:
     # Previous type-checking step created an opaque class.
     t = classdef->type
     assert t != NULL
-    assert t->kind == TypeKind.OpaqueClass
+    assert t->kind == TypeKind.Class
     t->kind = TypeKind.Class
 
     memset(&t->classdata, 0, sizeof t->classdata)

--- a/compiler/typecheck/step2_populate_types.jou
+++ b/compiler/typecheck/step2_populate_types.jou
@@ -168,7 +168,6 @@ def handle_class_members(ft: FileTypes*, classdef: AstClassDef*) -> None:
     t = classdef->type
     assert t != NULL
     assert t->kind == TypeKind.Class
-    t->kind = TypeKind.Class
 
     memset(&t->classdata, 0, sizeof t->classdata)
 

--- a/compiler/typecheck/step2_populate_types.jou
+++ b/compiler/typecheck/step2_populate_types.jou
@@ -169,8 +169,6 @@ def handle_class_members(ft: FileTypes*, classdef: AstClassDef*) -> None:
     assert t != NULL
     assert t->kind == TypeKind.Class
 
-    memset(&t->classdata, 0, sizeof t->classdata)
-
     n = classdef->n_generic_typevars
     if n > 0:
         # When defining generic class List[T], create a temporary type named T.

--- a/compiler/typecheck/step2_populate_types.jou
+++ b/compiler/typecheck/step2_populate_types.jou
@@ -164,7 +164,7 @@ def check_class_member_not_exist(t: Type*, name: byte*, location: Location) -> N
 
 
 def handle_class_members(ft: FileTypes*, classdef: AstClassDef*) -> None:
-    # Previous type-checking step created an opaque class.
+    # Previous type-checking step created an empty class.
     t = classdef->type
     assert t != NULL
     assert t->kind == TypeKind.Class

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -42,7 +42,6 @@ enum TypeKind:
     VoidPointer
     Array
     Class
-    OpaqueClass  # class with unknown members. TODO do we need this?
     TypeVar  # the unknown type "T" of "class List[T]"
     Enum
 
@@ -187,13 +186,12 @@ class Type:
                 | TypeKind.Bool
                 | TypeKind.Enum
                 | TypeKind.VoidPointer
-                | TypeKind.OpaqueClass
             ):
                 return self
 
     def short_description(self) -> byte*:
         match self->kind:
-            case TypeKind.OpaqueClass | TypeKind.Class:
+            case TypeKind.Class:
                 return "a class"
             case TypeKind.Enum:
                 return "an enum"
@@ -391,10 +389,10 @@ def create_simple_type(name: byte*, kind: TypeKind) -> Type*:
     return &result->type
 
 
-# Used for classes before their members are known.
+# Creates a class with no members. Used for classes before their members are known.
 @public
-def create_opaque_class(name: byte*) -> Type*:
-    return create_simple_type(name, TypeKind.OpaqueClass)
+def create_class(name: byte*) -> Type*:
+    return create_simple_type(name, TypeKind.Class)
 
 
 # Used for generics. This creates the unknown type "T" when defining class "List[T]".

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -391,7 +391,7 @@ def create_simple_type(name: byte*, kind: TypeKind) -> Type*:
 
 # Creates a class with no members. Used for classes before their members are known.
 @public
-def create_class(name: byte*) -> Type*:
+def create_empty_class(name: byte*) -> Type*:
     return create_simple_type(name, TypeKind.Class)
 
 


### PR DESCRIPTION
This was useless. It felt like a good idea when it was added but it really serves no purpose.