### PR TITLE
Fix compiler crash when generic class references itself

### DIFF
--- a/compiler/typecheck/common.jou
+++ b/compiler/typecheck/common.jou
@@ -150,14 +150,23 @@ def type_from_ast(ft: FileTypes*, containing_class: Type*, asttype: AstType*) ->
                 fail(asttype->location, msg)
 
             assert expected == got
-            n = got
+            nparams = got
 
-            from = gclass->classdata.generic_params
-            to: Type** = malloc(sizeof(to[0]) * n)
+            from: Type** = malloc(sizeof(from[0]) * nparams)
+            to: Type** = malloc(sizeof(to[0]) * nparams)
+            assert from != NULL
             assert to != NULL
-            for i = 0; i < n; i++:
-                to[i] = type_from_ast(ft, containing_class, &asttype->generic.param_types[i])
+            n = 0
+            for i = 0; i < nparams; i++:
+                from_item = gclass->classdata.generic_params[i]
+                to_item = type_from_ast(ft, containing_class, &asttype->generic.param_types[i])
+                if from_item != to_item:
+                    from[n] = from_item
+                    to[n] = to_item
+                    n++
 
             result = gclass->substitute_generic_params(from, to, n)
+
+            free(from)
             free(to)
             return result

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -127,8 +127,14 @@ class Type:
     # This method is used to create List[int] from a generic List[T].
     # The result is cached similarly to arrays.
     def substitute_generic_params(self, from: Type**, to: Type**, n: int) -> Type*:
+        if n == 0:
+            return self
+
+        assert n > 0
         for i = 0; i < n; i++:
             assert from[i]->kind == TypeKind.TypeVar
+            # Do not allow replacing any type with itself, creates confusing bugs
+            assert from[i] != to[i]
 
         match self->kind:
             case TypeKind.TypeVar:

--- a/tests/should_succeed/generic_bug_with_substituting_T_to_T.jou
+++ b/tests/should_succeed/generic_bug_with_substituting_T_to_T.jou
@@ -1,0 +1,16 @@
+# This is a test for https://github.com/Akuli/jou/issues/814
+
+@public
+class Foo[T]:
+    def grow(self) -> None:
+        pass
+
+    def extend(self, other: Foo[T]) -> None:
+        pass
+
+
+def main() -> int:
+    a = Foo[int]{}
+    b = Foo[int]{}
+    a.extend(b)
+    return 0


### PR DESCRIPTION
Fixes #814 

The problem was that when replacing `T` with `T` in `Foo[T]`, we created a new type named `Foo[T]` instead of reusing the same one.