### PR TITLE
Add extend() and extend_from_ptr() methods to List

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -28,6 +28,7 @@ commits=(
     ec92977acf51c265c28eefdab36d7ef272ac9eda  # the "const" keyword
     6d443fa1da12d462fe6f6a64b75ce74227bc13ff  # "const" keyword works with strings
     09fa4d1b9d414d8a05b4e45b316fad043aaf5ad7  # generic classes
+    519539bfc5551a6e6b9c3fa3070156b07a534601  # generic class bug fix
 )
 
 for commit in ${commits[@]}; do

--- a/compiler/constants.jou
+++ b/compiler/constants.jou
@@ -100,8 +100,7 @@ class Constant:
             case ConstantKind.ArrayString:
                 old = self.array_string
                 self.array_string = List[byte]{}
-                for p = old.ptr; p < old.end(); p++:
-                    self.array_string.append(p, sizeof(*p))
+                self.array_string.extend(old)
             case ConstantKind.PointerString:
                 self.pointer_string = strdup(self.pointer_string)
             case _:

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -204,12 +204,10 @@ def fail_with_implicit_cast_error(location: Location, template: byte*, from: Typ
     while *template != '\0':
         if starts_with(template, "<from>"):
             template = &template[6]
-            for p = &from->name[0]; *p != '\0'; p++:
-                message.append(p, 1)
+            message.extend_from_ptr(from->name, strlen(from->name), 1)
         elif starts_with(template, "<to>"):
             template = &template[4]
-            for p = &to->name[0]; *p != '\0'; p++:
-                message.append(p, 1)
+            message.extend_from_ptr(to->name, strlen(to->name), 1)
         else:
             message.append(template++, 1)
 

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -22,10 +22,9 @@ class ClassData:
 
     def substitute_generic_params_to_fields(self, from: Type**, to: Type**, n: int) -> List[ClassField]:
         result = List[ClassField]{}
-        for f1 = self->fields.ptr; f1 < self->fields.end(); f1++:
-            f2 = *f1
-            f2.type = f2.type->substitute_generic_params(from, to, n)
-            result.append(&f2, sizeof(f2))
+        result.extend(self->fields)
+        for f = result.fields.ptr; f < result.fields.end(); f++:
+            f->type = f->type->substitute_generic_params(from, to, n)
         return result
 
     def substitute_generic_params_to_methods(self, from: Type**, to: Type**, n: int) -> List[Signature]:
@@ -436,8 +435,7 @@ def create_typevar(name: byte*) -> Type*:
 @public
 def create_enum(name: byte*, members: List[byte[100]]) -> Type*:
     copied_members = List[byte[100]]{}
-    for p = members.ptr; p < members.end(); p++:
-        copied_members.append(p, sizeof(*p))
+    copied_members.extend(members)
 
     result: TypeInfo* = calloc(1, sizeof *result)
     result->type = Type{kind = TypeKind.Enum, enum_members = copied_members}
@@ -562,6 +560,5 @@ class Signature:
     def copy(self) -> Signature:
         result = *self
         result.args = List[NameAndType]{}
-        for arg = self->args.ptr; arg < self->args.end(); arg++:
-            result.args.append(arg, sizeof(*arg))
+        result.args.extend(self->args)
         return result

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -23,7 +23,7 @@ class ClassData:
     def substitute_generic_params_to_fields(self, from: Type**, to: Type**, n: int) -> List[ClassField]:
         result = List[ClassField]{}
         result.extend(self->fields)
-        for f = result.fields.ptr; f < result.fields.end(); f++:
+        for f = result.ptr; f < result.end(); f++:
             f->type = f->type->substitute_generic_params(from, to, n)
         return result
 

--- a/stdlib/list.jou
+++ b/stdlib/list.jou
@@ -52,6 +52,18 @@ class List[T]:
         memcpy(self->end(), item, itemsize)
         self->len++
 
+    # Append n items to the list, starting at the given pointer.
+    # For example, with n=3, this appends ptr[0], ptr[1] and ptr[2].
+    def extend_from_ptr(self, ptr: T*, n: long, itemsize: long) -> None:
+        self->grow(self->len + n, itemsize)
+        memcpy(self->end(), ptr, n * itemsize)
+        self->len += n
+
+    # Append all items in the given list.
+    def extend(self, other: List[T]) -> None:
+        if other.len > 0:  # Needed, because empty lists may have unknown itemsize
+            self->extend_from_ptr(other.ptr, other.len, other.itemsize)
+
     # Return a pointer just beyond the last element of the list.
     # Use list.end()[-1] to get the last element.
     def end(self) -> T*:

--- a/tests/should_succeed/list_test.jou
+++ b/tests/should_succeed/list_test.jou
@@ -33,6 +33,32 @@ def test_grow() -> None:
     free(list.ptr)
 
 
+def test_extend() -> None:
+    list = List[int]{}
+    one = 1
+    list.append(&one, sizeof(one))
+
+    # Extend from pointer
+    arr = [2, 3, 4, 5]
+    list.extend_from_ptr(arr, 4, sizeof(arr[0]))
+
+    # Extend from another list
+    list2 = List[int]{}
+    for i = 11; i <= 99; i += 11:
+        list2.append(&i, sizeof(i))
+    list.extend(list2)
+    free(list2.ptr)
+
+    # Output: 1,2,3,4,5,11,22,33,44,55,66,77,88,99
+    for p = list.ptr; p < list.end(); p++:
+        if p > list.ptr:
+            printf(",")
+        printf("%d", *p)
+    printf("\n")
+
+    free(list.ptr)
+
+
 def test_pop() -> None:
     list = List[int]{}
     for i = 11; i <= 44; i += 11:
@@ -59,5 +85,6 @@ def test_pop() -> None:
 def main() -> int:
     test_empty_list()
     test_grow()
+    test_extend()
     test_pop()
     return 0


### PR DESCRIPTION
Use `list.extend(other_list)` to append all items from another list.

Use `list.extend_from_ptr(ptr, 3, sizeof(ptr[0]))` to append `ptr[0]`, `ptr[1]` and `ptr[2]` to the list.