### PR TITLE
Fix memory leak in compiler

### DIFF
--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -821,6 +821,7 @@ def typecheck_expression(state: State*, expr: AstExpression*, type_hint: Type*) 
                 while expr->constant.array_string.len < type_hint->array.len:
                     expr->constant.array_string.append("", 1)
                 strcpy(expr->constant.array_string.ptr, s)
+                free(s)
                 assert expr->constant.get_type() == type_hint
                 result = type_hint
             else:


### PR DESCRIPTION
When doing `foo: byte[10] = "hi"` or similar, the string `"hi"` turns from a pointer string constant into an array string constant. Since #813 (PR that introduced this bug), pointer string constants are internally `byte*` and array string constants are `List[byte]`. This PR frees the `byte*` string after constructing the corresponding `List[byte]`.

Fixes #819 