### PR TITLE
Simplify the List.append() method

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,6 +29,7 @@ commits=(
     6d443fa1da12d462fe6f6a64b75ce74227bc13ff  # "const" keyword works with strings
     09fa4d1b9d414d8a05b4e45b316fad043aaf5ad7  # generic classes
     519539bfc5551a6e6b9c3fa3070156b07a534601  # generic class bug fix
+    30bf61efa40832a2429eee34c8cc93e80ea7f591  # @inline
 )
 
 for commit in ${commits[@]}; do

--- a/compiler/builders/ast_to_builder.jou
+++ b/compiler/builders/ast_to_builder.jou
@@ -78,8 +78,7 @@ class AstToBuilder:
             var_name = types->locals.ptr[i].name
             var_type = types->locals.ptr[i].type
             var_ptr = self->builder->stack_alloc(var_type, var_name)
-            local = LocalVar{name = var_name, ptr = var_ptr}
-            self->locals.append(&local, sizeof(local))
+            self->locals.append(LocalVar{name = var_name, ptr = var_ptr})
             if i < types->signature.args.len:
                 # First n local variables are the function arguments
                 self->builder->set_ptr(var_ptr, self->builder->get_argument(i, var_type))
@@ -106,8 +105,7 @@ class AstToBuilder:
             var_name = types->locals.ptr[i].name
             var_type = types->locals.ptr[i].type
             var_ptr = self->builder->stack_alloc(self->map_type(var_type), var_name)
-            local = LocalVar{name = var_name, ptr = var_ptr}
-            self->locals.append(&local, sizeof(local))
+            self->locals.append(LocalVar{name = var_name, ptr = var_ptr})
             if i < args.len:
                 # First n local variables are the function arguments
                 self->builder->set_ptr(var_ptr, args.ptr[i])
@@ -181,11 +179,10 @@ class AstToBuilder:
                 arg = self->builder->dereference(self->build_expression(call->method_call_self))
             else:
                 arg = self->build_expression(call->method_call_self)
-            args.append(&arg, sizeof(arg))
+            args.append(arg)
 
         for p = call->args.ptr; p < call->args.end(); p++:
-            arg = self->build_expression(p)
-            args.append(&arg, sizeof(arg))
+            args.append(self->build_expression(p))
 
         result = self->call_or_inline(call->called_signature, args)
         free(args.ptr)
@@ -531,8 +528,7 @@ class AstToBuilder:
             self->builder->branch(self->build_expression(cond), bodyblock, doneblock)
 
         # Within loop body, 'break' skips to after loop, 'continue' goes to incr.
-        loop = Loop{on_break = doneblock, on_continue = incrblock}
-        self->loops.append(&loop, sizeof(loop))
+        self->loops.append(Loop{on_break = doneblock, on_continue = incrblock})
 
         # Run loop body. When done, go to incr.
         self->builder->set_current_block(bodyblock)

--- a/compiler/builders/uvg_builder.jou
+++ b/compiler/builders/uvg_builder.jou
@@ -51,7 +51,7 @@ class UBuilder:
 
         b = self->current_block
         assert b != NULL
-        b->instructions.append(&ins, sizeof(ins))
+        b->instructions.append(ins)
 
     def begin_statement_in_a_body(self) -> None:
         self->add_instruction(UvgInstruction{kind = UvgInstructionKind.Statement})

--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -250,7 +250,7 @@ class CompileState:
 
         check_imports_at_start_of_file(fs.ast.body)
 
-        self->files.append(&fs, sizeof(fs))
+        self->files.append(fs)
 
         for stmt = fs.ast.body.ptr; stmt < fs.ast.body.end(); stmt++:
             if stmt->kind == AstStatementKind.Import:
@@ -284,7 +284,7 @@ class CompileState:
                         msg: byte[500]
                         snprintf(msg, sizeof msg, "file \"%s\" is imported twice", stmt->import_statement.specified_path)
                         fail(stmt->location, msg)
-                seen_before.append(&from, sizeof(from))
+                seen_before.append(from)
 
                 for es = pending_exports[from_index].ptr; es < pending_exports[from_index].end(); es++:
                     if command_line_args.verbosity >= 2:
@@ -478,8 +478,7 @@ def main(argc: int, argv: byte**) -> int:
     objpaths = List[byte*]{}
     for f = compst.files.ptr; f < compst.files.end(); f++:
         llvm_ir = f->build_llvm_ir()
-        path = compile_llvm_ir_to_object_file(llvm_ir)
-        objpaths.append(&path, sizeof(path))
+        objpaths.append(compile_llvm_ir_to_object_file(llvm_ir))
         LLVMDisposeModule(llvm_ir)
 
     # Check for missing main() as late as possible, so that other errors come first.

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -361,8 +361,7 @@ class Parser:
 
                 params = List[AstType]{}
                 while not self->tokens->is_operator("]"):
-                    param = self->parse_type()
-                    params.append(&param, sizeof(param))
+                    params.append(self->parse_type())
                     if not self->tokens->is_operator(","):
                         break
                     self->tokens++
@@ -444,7 +443,7 @@ class Parser:
                     self->tokens++
                     self_arg.type = self->parse_type()
 
-                result.args.append(&self_arg, sizeof(self_arg))
+                result.args.append(self_arg)
                 used_self = True
 
             else:
@@ -460,7 +459,7 @@ class Parser:
                             "there are multiple arguments named '%s'", arg.name)
                         fail(arg.name_location, message)
 
-                result.args.append(&arg, sizeof(arg))
+                result.args.append(arg)
 
             if not self->tokens->is_operator(","):
                 break
@@ -499,8 +498,7 @@ class Parser:
         self->tokens++
 
         while not self->tokens->is_operator(")"):
-            arg = self->parse_expression()
-            result.args.append(&arg, sizeof(arg))
+            result.args.append(self->parse_expression())
             if not self->tokens->is_operator(","):
                 break
             self->tokens++
@@ -533,8 +531,7 @@ class Parser:
                 self->tokens->fail_expected_got(msg)
             self->tokens++
 
-            field = AstInstantiationField{name = field_name, value = self->parse_expression()}
-            result.fields.append(&field, sizeof(field))
+            result.fields.append(AstInstantiationField{name = field_name, value = self->parse_expression()})
 
             if not self->tokens->is_operator(","):
                 break
@@ -552,8 +549,7 @@ class Parser:
 
         result = List[AstExpression]{}
         while not self->tokens->is_operator("]"):
-            item = self->parse_expression()
-            result.append(&item, sizeof(item))
+            result.append(self->parse_expression())
             if not self->tokens->is_operator(","):
                 break
             self->tokens++
@@ -948,8 +944,7 @@ class Parser:
             self->tokens++
             cond = self->parse_expression_with_unnecessary_parens_warning("if statement condition")
             body = self->parse_body()
-            if_or_elif = AstConditionAndBody{condition = cond, body = body}
-            ifs_and_elifs.append(&if_or_elif, sizeof(if_or_elif))
+            ifs_and_elifs.append(AstConditionAndBody{condition = cond, body = body})
             if not self->tokens->is_keyword("elif"):
                 break
 
@@ -969,7 +964,7 @@ class Parser:
                     snprintf(msg, sizeof(msg), "this loop is inside another loop that also uses variable '%s'", varname)
                     show_warning(location, msg)
                     break
-        self->loop_vars.append(&varname, sizeof(varname))
+        self->loop_vars.append(varname)
 
     def exit_loop_body(self) -> None:
         self->loop_vars.pop()
@@ -1081,8 +1076,7 @@ class Parser:
                     self->tokens++
                 case_objs = List[AstExpression]{}
                 while True:
-                    case_obj = self->parse_expression()
-                    case_objs.append(&case_obj, sizeof(case_obj))
+                    case_objs.append(self->parse_expression())
                     if self->tokens->is_operator("|"):
                         self->tokens++
                     elif (not parens) and self->tokens->is_operator(":"):
@@ -1095,8 +1089,7 @@ class Parser:
                             self->tokens->fail_expected_got("'|' or '):'")
                         else:
                             self->tokens->fail_expected_got("'|' or ':'")
-                c = AstCase{case_objs = case_objs, body = self->parse_body()}
-                result.cases.append(&c, sizeof(c))
+                result.cases.append(AstCase{case_objs = case_objs, body = self->parse_body()})
         self->tokens++
 
         return result
@@ -1289,8 +1282,7 @@ class Parser:
 
         result = List[AstStatement]{}
         while self->tokens->kind != TokenKind.Dedent:
-            s = self->parse_statement()
-            result.append(&s, sizeof(s))
+            result.append(self->parse_statement())
         self->tokens++
         return result
 
@@ -1331,7 +1323,7 @@ class Parser:
             while not self->tokens->is_operator("]"):
                 if self->tokens->kind != TokenKind.Name:
                     self->tokens->fail_expected_got("name of a generic type variable (typically 'T')")
-                generics.append(&self->tokens->short_string, sizeof(self->tokens->short_string))
+                generics.append(self->tokens->short_string)
                 self->tokens++
 
                 if not self->tokens->is_operator(","):
@@ -1371,7 +1363,7 @@ class Parser:
             if field.value != NULL:
                 fail(field.value->location, "union members cannot have default values")
 
-            result.append(&field, sizeof(field))
+            result.append(field)
             self->eat_newline()
 
         self->tokens++
@@ -1406,7 +1398,7 @@ class Parser:
                     sprintf(error, "the enum has two members named '%s'", self->tokens->short_string)
                     fail(self->tokens->location, error)
 
-            result.members.append(&self->tokens->short_string, sizeof(self->tokens->short_string))
+            result.members.append(self->tokens->short_string)
             self->tokens++
             self->eat_newline()
 
@@ -1419,8 +1411,7 @@ def parse(tokens: Token*, stdlib_path: byte*) -> AstFile:
     result = AstFile{path = tokens[0].location.path}
 
     while parser.tokens->kind != TokenKind.EndOfFile:
-        s = parser.parse_statement()
-        result.body.append(&s, sizeof(s))
+        result.body.append(parser.parse_statement())
 
     assert parser.loop_vars.len == 0
     free(parser.loop_vars.ptr)

--- a/compiler/tokenizer.jou
+++ b/compiler/tokenizer.jou
@@ -250,7 +250,7 @@ class Tokenizer:
             return
 
         assert b != '\r'
-        self->pushback.append(&b, sizeof(b))
+        self->pushback.append(b)
         if b == '\n':
             self->location.lineno--
 
@@ -395,15 +395,15 @@ class Tokenizer:
                         case '\0':
                             fail(self->location, "missing \" to end the string")
                         case 'n':
-                            result.append("\n", 1)
+                            result.append('\n')
                         case 'r':
-                            result.append("\r", 1)
+                            result.append('\r')
                         case 't':
-                            result.append("\t", 1)
+                            result.append('\t')
                         case '\\':
-                            result.append("\\", 1)
+                            result.append('\\')
                         case '"':
-                            result.append("\"", 1)
+                            result.append('"')
                         case '\'':
                             fail(self->location, "single quotes shouldn't be escaped in strings")
                         case '0':
@@ -412,7 +412,7 @@ class Tokenizer:
                             b = self->read_hex_escape_byte()
                             if b == '\0':
                                 fail(self->location, "strings cannot contain zero bytes (\\x00), because that is the special end marker byte")
-                            result.append(&b, sizeof(b))
+                            result.append(b)
                         case '\n':
                             # \ at end of line, string continues on next line
                             pass
@@ -424,9 +424,9 @@ class Tokenizer:
                                 msg = "unknown '\\' escape"
                             fail(self->location, msg)
                 case _:
-                    result.append(&c, sizeof(c))
+                    result.append(c)
 
-        result.append("", 1)
+        result.append('\0')
         return result.ptr
 
     def read_operator(self) -> byte[100]:
@@ -578,12 +578,11 @@ def tokenize_without_indent_dedent_tokens(file: FILE*, path: byte*) -> Token*:
     #  * It is easier to detect an unexpected indentation in the beginning
     #    of the file, as it becomes just like any other indentation.
     #  * Line numbers start at 1.
-    tokenizer.pushback.append("\n", 1)
+    tokenizer.pushback.append('\n')
 
     tokens = List[Token]{}
     while tokens.len == 0 or tokens.end()[-1].kind != TokenKind.EndOfFile:
-        t = tokenizer.read_token()
-        tokens.append(&t, sizeof(t))
+        tokens.append(tokenizer.read_token())
 
     free(tokenizer.pushback.ptr)
     return tokens.ptr
@@ -601,16 +600,14 @@ def handle_indentations(raw_tokens: Token*) -> Token*:
             # This makes it similar to how other newline and dedent tokens work:
             # the dedents always come after a newline token.
             if t > raw_tokens and t[-1].kind != TokenKind.Newline:
-                nl = Token{location = t->location, kind = TokenKind.Newline}
-                tokens.append(&nl, sizeof(nl))
+                tokens.append(Token{location = t->location, kind = TokenKind.Newline})
             while level != 0:
-                dedent = Token{location = t->location, kind = TokenKind.Dedent}
-                tokens.append(&dedent, sizeof(dedent))
+                tokens.append(Token{location = t->location, kind = TokenKind.Dedent})
                 level -= 4
-            tokens.append(t, sizeof(*t))
+            tokens.append(*t)
             break
 
-        tokens.append(t, sizeof(*t))
+        tokens.append(*t)
 
         if t->kind == TokenKind.Newline:
             after_newline = t->location
@@ -620,13 +617,11 @@ def handle_indentations(raw_tokens: Token*) -> Token*:
                 fail(after_newline, "indentation must be a multiple of 4 spaces")
 
             while level < t->indentation_level:
-                indent = Token{location = after_newline, kind = TokenKind.Indent}
-                tokens.append(&indent, sizeof(indent))
+                tokens.append(Token{location = after_newline, kind = TokenKind.Indent})
                 level += 4
 
             while level > t->indentation_level:
-                dedent = Token{location = after_newline, kind = TokenKind.Dedent}
-                tokens.append(&dedent, sizeof(dedent))
+                tokens.append(Token{location = after_newline, kind = TokenKind.Dedent})
                 level -= 4
 
     # Delete the newline token in the beginning.

--- a/compiler/typecheck/step1_create_types.jou
+++ b/compiler/typecheck/step1_create_types.jou
@@ -24,8 +24,7 @@ def handle_generics(t: Type*, classdef: AstClassDef*) -> None:
     assert t->kind == TypeKind.Class
     assert classdef->is_generic()
     for nameptr = classdef->generic_typevar_names.ptr; nameptr < classdef->generic_typevar_names.end(); nameptr++:
-        typevar = create_typevar(*nameptr)
-        t->classdata.generic_params.append(&typevar, sizeof(typevar))
+        t->classdata.generic_params.append(create_typevar(*nameptr))
 
     old_name: byte[500] = t->name
     t->name = create_type_name_with_params(old_name, t->classdata.generic_params)
@@ -70,7 +69,6 @@ def typecheck_step1_create_types(ast: AstFile*) -> List[ExportSymbol]:
                 k = ExportSymbolKind.GenericClass
             else:
                 k = ExportSymbolKind.Type
-            es = ExportSymbol{kind = k, type = t, name = name}
-            exports.append(&es, sizeof(es))
+            exports.append(ExportSymbol{kind = k, type = t, name = name})
 
     return exports

--- a/compiler/typecheck/step2_populate_types.jou
+++ b/compiler/typecheck/step2_populate_types.jou
@@ -99,7 +99,7 @@ def handle_signature(ft: FileTypes*, ast: AstFunctionOrMethod*, self_class: Type
             snprintf(msg, sizeof(msg), "type of self must be %s* (default) or %s", self_class->name, self_class->name)
             fail(astarg->type.location, msg)
 
-        sig.args.append(&arg, sizeof(arg))
+        sig.args.append(arg)
 
     sig.is_noreturn = astsig->return_type.is_noreturn()
     if astsig->return_type.is_none() or astsig->return_type.is_noreturn():
@@ -177,7 +177,7 @@ def handle_class_members(ft: FileTypes*, classdef: AstClassDef*) -> None:
                     union_id = union_id++,
                 }
                 check_class_member_not_exist(t, f.name, stmt->location)
-                t->classdata.fields.append(&f, sizeof(f))
+                t->classdata.fields.append(f)
 
             case AstStatementKind.ClassUnion:
                 uid = union_id++
@@ -194,7 +194,7 @@ def handle_class_members(ft: FileTypes*, classdef: AstClassDef*) -> None:
                         union_id = uid,
                     }
                     check_class_member_not_exist(t, f.name, ntv->name_location)
-                    t->classdata.fields.append(&f, sizeof(f))
+                    t->classdata.fields.append(f)
 
             case AstStatementKind.MethodDef:
                 # Don't handle the method body yet: that is a part of step 3, not step 2
@@ -202,8 +202,7 @@ def handle_class_members(ft: FileTypes*, classdef: AstClassDef*) -> None:
                 stmt->method.types.signature = sig
 
                 check_class_member_not_exist(t, sig.name, stmt->location)
-                sig2 = sig.copy()
-                t->classdata.methods.append(&sig2, sizeof(sig2))
+                t->classdata.methods.append(sig.copy())
 
             case AstStatementKind.Pass:
                 pass
@@ -226,15 +225,15 @@ def typecheck_step2_populate_types(ast: AstFile*) -> List[ExportSymbol]:
             case AstStatementKind.GlobalVariableDeclare:
                 exp = handle_global_var(&ast->types, stmt->location, stmt->global_var_declare.name, &stmt->global_var_declare.type, &stmt->global_var_declare.used)
                 if stmt->global_var_declare.public:
-                    exports.append(&exp, sizeof(exp))
+                    exports.append(exp)
             case AstStatementKind.GlobalVariableDef:
                 exp = handle_global_var(&ast->types, stmt->location, stmt->global_var_def.name, &stmt->global_var_def.type, &stmt->global_var_def.used)
                 if stmt->global_var_def.public:
-                    exports.append(&exp, sizeof(exp))
+                    exports.append(exp)
             case AstStatementKind.Const:
                 exp = handle_const(&ast->types, stmt->location, &stmt->const_statement)
                 if stmt->const_statement.public:
-                    exports.append(&exp, sizeof(exp))
+                    exports.append(exp)
                 else:
                     exp.free()
             case AstStatementKind.FunctionDeclare | AstStatementKind.FunctionDef:
@@ -242,7 +241,7 @@ def typecheck_step2_populate_types(ast: AstFile*) -> List[ExportSymbol]:
                 stmt->function.types.signature = sig
                 if stmt->function.public:
                     exp = ExportSymbol{kind = ExportSymbolKind.Function, name = sig.name, funcsignature = sig.copy()}
-                    exports.append(&exp, sizeof(exp))
+                    exports.append(exp)
             case AstStatementKind.Class:
                 handle_class_members(&ast->types, &stmt->classdef)
             case AstStatementKind.Enum | AstStatementKind.Link:

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -209,9 +209,9 @@ def fail_with_implicit_cast_error(location: Location, template: byte*, from: Typ
             template = &template[4]
             message.extend_from_ptr(to->name, strlen(to->name), 1)
         else:
-            message.append(template++, 1)
+            message.append(*template++)
 
-    message.append("", 1)
+    message.append('\0')
     fail(location, message.ptr)
 
 
@@ -653,7 +653,7 @@ def typecheck_instantiation(state: State*, inst: AstInstantiation*, location: Lo
             "value for field '%s' of class %s must be of type <to>, not <from>",
             f->name, t->name)
         typecheck_expression_with_implicit_cast(state, &f->value, field->type, msg)
-        specified_fields.append(&field, sizeof(field))
+        specified_fields.append(field)
 
     for i1 = 0; i1 < inst->fields.len; i1++:
         for i2 = i1+1; i2 < inst->fields.len; i2++:
@@ -692,7 +692,7 @@ def cast_array_members_to_a_common_type(
                 found = True
                 break
         if not found:
-            distinct.append(&itemtype, sizeof(itemtype))
+            distinct.append(itemtype)
 
     compatible_with_all = List[Type*]{}
 
@@ -704,7 +704,7 @@ def cast_array_members_to_a_common_type(
                 break
 
         if t_compatible_with_all_others:
-            compatible_with_all.append(t, sizeof(*t))
+            compatible_with_all.append(*t)
 
     if compatible_with_all.len > 1:
         # Remove void* if exists, so that type of ["hello", NULL] becomes byte*[2]
@@ -819,7 +819,7 @@ def typecheck_expression(state: State*, expr: AstExpression*, type_hint: Type*) 
                 expr->constant.kind = ConstantKind.ArrayString
                 expr->constant.array_string = List[byte]{}
                 while expr->constant.array_string.len < type_hint->array.len:
-                    expr->constant.array_string.append("", 1)
+                    expr->constant.array_string.append('\0')
                 strcpy(expr->constant.array_string.ptr, s)
                 free(s)
                 assert expr->constant.get_type() == type_hint

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -37,7 +37,7 @@ class ClassData:
                 arg->type = arg->type->substitute_generic_params(from, to, n)
             if sig2.return_type != NULL:
                 sig2.return_type = sig2.return_type->substitute_generic_params(from, to, n)
-            result.append(&sig2, sizeof(sig2))
+            result.append(sig2)
         return result
 
 
@@ -109,7 +109,7 @@ class Type:
         arr->type = Type{kind = TypeKind.Array, array = ArrayType{item_type = self, len = len}}
         snprintf(arr->type.name, sizeof arr->type.name, "%s[%d]", self->name, len)
 
-        info->related_types.append(&arr, sizeof(arr))
+        info->related_types.append(arr)
         return &arr->type
 
     # This method is used to create List[int] from a generic List[T].
@@ -139,8 +139,7 @@ class Type:
 
                 generic_params = List[Type*]{}
                 for p = self->classdata.generic_params.ptr; p < self->classdata.generic_params.end(); p++:
-                    subbed = (*p)->substitute_generic_params(from, to, n)
-                    generic_params.append(&subbed, sizeof(subbed))
+                    generic_params.append((*p)->substitute_generic_params(from, to, n))
 
                 # Results are cached in related_types, just like arrays.
                 # Before we go further, let's check if the type we want is already cached.
@@ -160,7 +159,7 @@ class Type:
                 # the already cached type.
                 new_info: TypeInfo* = calloc(1, sizeof(*new_info))
                 assert new_info != NULL
-                info->related_types.append(&new_info, sizeof(new_info))
+                info->related_types.append(new_info)
                 result = &new_info->type
                 *result = *self
                 result->name = create_type_name_with_params(self->name, generic_params)
@@ -408,7 +407,7 @@ def get_integer_type(size_in_bits: int, is_signed: bool) -> Type*:
 # do it anyway, but communicating this to valgrind is complicated because of
 # how pointers and arrays work.
 def satisfy_valgrind(ti: TypeInfo*) -> None:
-    global_type_state.other_types.append(&ti, sizeof(ti))
+    global_type_state.other_types.append(ti)
 
 
 def create_simple_type(name: byte*, kind: TypeKind) -> Type*:

--- a/compiler/types_in_ast.jou
+++ b/compiler/types_in_ast.jou
@@ -54,7 +54,7 @@ class FunctionOrMethodTypes:
         assert strlen(name) < sizeof(var.name)
         strcpy(var.name, name)
 
-        self->locals.append(&var, sizeof(var))
+        self->locals.append(var)
 
     def free(self) -> None:
         free(self->locals.ptr)
@@ -89,12 +89,10 @@ class FileTypes:
     functions: List[SignatureAndUsedPtr]
 
     def add_function(self, signature: Signature*, usedptr: bool*) -> None:
-        item = SignatureAndUsedPtr{signature = signature->copy(), usedptr = usedptr}
-        self->functions.append(&item, sizeof(item))
+        self->functions.append(SignatureAndUsedPtr{signature = signature->copy(), usedptr = usedptr})
 
     def _add_type_internal(self, t: Type*, usedptr: bool*) -> None:
-        item = TypeAndUsedPtr{type = t, usedptr = usedptr}
-        self->available_types.append(&item, sizeof(item))
+        self->available_types.append(TypeAndUsedPtr{type = t, usedptr = usedptr})
 
     def add_type(self, t: Type*, usedptr: bool*) -> None:
         assert strstr(t->name, "[") == NULL  # must be able to find the types by name
@@ -110,14 +108,14 @@ class FileTypes:
         assert strlen(name) < sizeof g.name
         strcpy(g.name, name)
 
-        self->globals.append(&g, sizeof(g))
+        self->globals.append(g)
         return &self->globals.end()[-1]
 
     def add_constant(self, name: byte*, value: Constant*, usedptr: bool*) -> None:
         c = NamedConstant{value = value->copy(), usedptr = usedptr}
         assert strlen(name) < sizeof(c.name)
         strcpy(c.name, name)
-        self->constants.append(&c, sizeof(c))
+        self->constants.append(c)
 
     # This is safe to call if self has been zero-initialized.
     def free(self) -> None:

--- a/compiler/uvg.jou
+++ b/compiler/uvg.jou
@@ -139,7 +139,7 @@ class Uvg:
         b: UvgBlock* = malloc(sizeof(*b))
         assert b != NULL
         memset(b, 0, sizeof(*b))
-        self->blocks.append(&b, sizeof(b))
+        self->blocks.append(b)
         return b
 
     def has_local_var(self, varname: byte*) -> bool:
@@ -164,5 +164,5 @@ class Uvg:
             strcpy(actual_varname, varname)
 
         index = self->varnames.len
-        self->varnames.append(&actual_varname, sizeof(actual_varname))
+        self->varnames.append(actual_varname)
         return index as int

--- a/examples/aoc2023/day05/part2.jou
+++ b/examples/aoc2023/day05/part2.jou
@@ -19,8 +19,7 @@ class Map:
     def get_input_range_starts(self) -> List[long]:
         result = List[long]{}
         for i = 0; i < self->ntriples; i++:
-            n = self->triples[i][1]
-            result.append(&n, sizeof(n))
+            result.append(self->triples[i][1])
         return result
 
     def map_number(self, n: long) -> long:
@@ -43,10 +42,10 @@ class Map:
             # Solve equation:   output = n - source_start + dest_start
             n = output + source_start - dest_start
             if self->map_number(n) == output:
-                result.append(&n, sizeof(n))
+                result.append(n)
 
         if self->map_number(output) == output:
-            result.append(&output, sizeof(output))
+            result.append(output)
 
         return result
 
@@ -137,7 +136,7 @@ def main() -> int:
 
     # Let's also try start of each seed range
     for i = 0; i < input->n_seed_ranges; i++:
-        interesting_inputs.append(&input->seed_ranges[i].start, sizeof(input->seed_ranges[i].start))
+        interesting_inputs.append(input->seed_ranges[i].start)
 
     smallest = -1 as long
     for p = interesting_inputs.ptr; p < interesting_inputs.end(); p++:

--- a/examples/aoc2023/day08/part2.jou
+++ b/examples/aoc2023/day08/part2.jou
@@ -134,9 +134,9 @@ def get_z_counts(input: Input*, start: Node*) -> ZCounts:
                 for k = 0L; k < nstates; k++:
                     if states[k]->name[2] == 'Z':
                         if k < i:
-                            non_repeating.append(&k, sizeof(k))
+                            non_repeating.append(k)
                         else:
-                            first_cycle.append(&k, sizeof(k))
+                            first_cycle.append(k)
                 free(states)
 
                 assert first_cycle.len != 0

--- a/examples/aoc2023/day12/part1.jou
+++ b/examples/aoc2023/day12/part1.jou
@@ -25,7 +25,7 @@ def substitute_questionmarks_in_all_ways(questional_string: byte*) -> List[byte[
 
     strcpy(temp, questional_string)
     result = List[byte[100]]{}
-    result.append(&temp, sizeof(temp))
+    result.append(temp)
     return result
 
 

--- a/examples/aoc2023/day12/part2.jou
+++ b/examples/aoc2023/day12/part2.jou
@@ -128,9 +128,8 @@ def main() -> int:
             if questional_string[i] == '?':
                 n_question_marks++
 
-        initial_state = State{questional_string=questional_string, numbers=numbers, repeat_count=1}
         states = List[State]{}
-        states.append(&initial_state, sizeof(initial_state))
+        states.append(State{questional_string=questional_string, numbers=numbers, repeat_count=1})
 
         while n_question_marks --> 0:
             states.grow(2*states.len, sizeof(states.ptr[0]))

--- a/examples/aoc2023/day14/part2.jou
+++ b/examples/aoc2023/day14/part2.jou
@@ -71,7 +71,7 @@ def main() -> int:
     cycle_start = -1
     cycle_length = -1
     while cycle_start == -1 and cycle_length == -1:
-        previous_states.append(&grid, sizeof(grid))
+        previous_states.append(grid)
 
         grid = grid.copy()
         roll(&grid, [0, -1])

--- a/examples/aoc2023/day16/part1.jou
+++ b/examples/aoc2023/day16/part1.jou
@@ -59,7 +59,7 @@ def run_beam(grid: Grid*, start_beam: LightBeam) -> bool[4][200][200]*:
     assert result != NULL
 
     todo = List[LightBeam]{}
-    todo.append(&start_beam, sizeof(start_beam))
+    todo.append(start_beam)
 
     while todo.len > 0:
         beam = todo.ptr[--todo.len]
@@ -76,8 +76,7 @@ def run_beam(grid: Grid*, start_beam: LightBeam) -> bool[4][200][200]*:
             dir = next_dirs[i]
             location = [beam.location[0] + dir[0], beam.location[1] + dir[1]]
             if grid->is_in_bounds(location):
-                beam2 = LightBeam{location = location, direction = dir}
-                todo.append(&beam2, sizeof(beam2))
+                todo.append(LightBeam{location = location, direction = dir})
 
     free(todo.ptr)
     return result

--- a/examples/aoc2023/day16/part2.jou
+++ b/examples/aoc2023/day16/part2.jou
@@ -60,7 +60,7 @@ def run_beam(grid: Grid*, start_beam: LightBeam) -> int:
     assert visited != NULL
 
     todo = List[LightBeam]{}
-    todo.append(&start_beam, sizeof(start_beam))
+    todo.append(start_beam)
 
     while todo.len > 0:
         beam = todo.ptr[--todo.len]
@@ -77,8 +77,7 @@ def run_beam(grid: Grid*, start_beam: LightBeam) -> int:
             dir = next_dirs[i]
             location = [beam.location[0] + dir[0], beam.location[1] + dir[1]]
             if grid->is_in_bounds(location):
-                beam2 = LightBeam{location = location, direction = dir}
-                todo.append(&beam2, sizeof(beam2))
+                todo.append(LightBeam{location = location, direction = dir})
 
     free(todo.ptr)
 

--- a/examples/aoc2023/day18/part1.jou
+++ b/examples/aoc2023/day18/part1.jou
@@ -83,8 +83,7 @@ def read_input_to_grid(filename: byte*) -> Grid:
 
 def fill_with_f(grid: Grid*) -> None:
     todo = List[int[2]]{}
-    start = [0, 0]
-    todo.append(&start, sizeof(start))
+    todo.append([0, 0])
 
     while todo.len > 0:
         point = todo.ptr[--todo.len]
@@ -94,13 +93,10 @@ def fill_with_f(grid: Grid*) -> None:
         grid->set(point, 'f')
 
         # Append neighbors to todo list
-        neighbors: int[2][4] = [
-            [point[0], point[1]-1],
-            [point[0], point[1]+1],
-            [point[0]-1, point[1]],
-            [point[0]+1, point[1]],
-        ]
-        todo.extend_from_ptr(neighbors, 4, sizeof(neighbors[0]))
+        todo.append([point[0], point[1]-1])
+        todo.append([point[0], point[1]+1])
+        todo.append([point[0]-1, point[1]])
+        todo.append([point[0]+1, point[1]])
 
     free(todo.ptr)
 

--- a/examples/aoc2023/day18/part2.jou
+++ b/examples/aoc2023/day18/part2.jou
@@ -21,8 +21,7 @@ def parse_hex_string(s: byte*, len: int) -> int:
 
 def read_input_as_points(filename: byte*) -> List[int[2]]:
     result = List[int[2]]{}
-    start = [0, 0]
-    result.append(&start, sizeof(start))
+    result.append([0, 0])
 
     f = fopen(filename, "r")
     assert f != NULL
@@ -51,8 +50,7 @@ def read_input_as_points(filename: byte*) -> List[int[2]]:
         else:
             assert False
 
-        point = [x, y]
-        result.append(&point, sizeof(point))
+        result.append([x, y])
 
     fclose(f)
 

--- a/examples/aoc2023/day19/part1.jou
+++ b/examples/aoc2023/day19/part1.jou
@@ -90,9 +90,8 @@ def parse_workflow(s: byte*) -> Workflow:
 
         assert strlen(var) == 1
         assert op == '>' or op == '<'
-        if_expr = Expression{var = var[0], greater_than = (op == '>'), value = num}
-        wf.ifs.append(&if_expr, sizeof(if_expr))
-        wf.thens.append(&then, sizeof(then))
+        wf.ifs.append(Expression{var = var[0], greater_than = (op == '>'), value = num})
+        wf.thens.append(then)
 
 
 def find_workflow(workflows: List[Workflow], name: byte*) -> Workflow*:
@@ -127,9 +126,7 @@ def main() -> int:
         if line[0] == '\0':
             # end of workflows
             break
-
-        workflow = parse_workflow(line)
-        workflows.append(&workflow, sizeof(workflow))
+        workflows.append(parse_workflow(line))
 
     xmas: XMAS
     result = 0

--- a/examples/aoc2023/day19/part2.jou
+++ b/examples/aoc2023/day19/part2.jou
@@ -83,7 +83,7 @@ class UnionOfBoxes:
             # Split the existing box at boundaries of what we're removing.
             # Delete the parts we don't like.
             have = List[Box]{}
-            have.append(&existing, sizeof(existing))
+            have.append(existing)
             for coord_idx = 0; coord_idx < 4; coord_idx++:
                 splits = [box.mins[coord_idx], box.maxs[coord_idx] + 1]
                 for s = &splits[0]; s < &splits[2]; s++:
@@ -92,7 +92,7 @@ class UnionOfBoxes:
                         if have.ptr[i].can_split(*s, coord_idx):
                             split = have.ptr[i].split(*s, coord_idx)
                             have.ptr[i] = split[0]
-                            have.append(&split[1], sizeof(split[1]))
+                            have.append(split[1])
 
                     # Delete unwanted small boxes
                     for i = have.len - 1; i >= 0; i--:
@@ -108,7 +108,7 @@ class UnionOfBoxes:
     def add_box(self, box: Box) -> None:
         if not box.is_empty():
             self->remove_box(box)
-            self->boxes.append(&box, sizeof(box))
+            self->boxes.append(box)
 
     def add_union_of_boxes(self, u: UnionOfBoxes) -> None:
         for p = u.boxes.ptr; p < u.boxes.end(); p++:
@@ -185,9 +185,8 @@ def parse_workflow(s: byte*) -> Workflow:
         else:
             assert False
 
-        if_box = Box{mins=mins, maxs=maxs}
-        wf.ifs.append(&if_box, sizeof(if_box))
-        wf.thens.append(&then, sizeof(then))
+        wf.ifs.append(Box{mins=mins, maxs=maxs})
+        wf.thens.append(then)
 
 
 def find_workflow(workflows: List[Workflow], name: byte*) -> Workflow*:
@@ -209,17 +208,13 @@ def main() -> int:
         if line[0] == '\0':
             # end of workflows
             break
-
-        workflow = parse_workflow(line)
-        workflows.append(&workflow, sizeof(workflow))
+        workflows.append(parse_workflow(line))
 
     fclose(f)
 
     # add dummy "A" and "R" workflows
-    workflow = parse_workflow("A{A}")
-    workflows.append(&workflow, sizeof(workflow))
-    workflow = parse_workflow("R{R}")
-    workflows.append(&workflow, sizeof(workflow))
+    workflows.append(parse_workflow("A{A}"))
+    workflows.append(parse_workflow("R{R}"))
 
     start_bounds = UnionOfBoxes{}
     start_bounds.add_box(Box{mins=[1,1,1,1], maxs=[4000,4000,4000,4000]})

--- a/examples/aoc2023/day20/part1.jou
+++ b/examples/aoc2023/day20/part1.jou
@@ -59,8 +59,7 @@ class TodoList:
     items: List[GonnaSend]
 
     def send_later(self, from: Module*, to: Module*, value: bool) -> None:
-        item = GonnaSend{from=from, to=to, value=value}
-        self->items.append(&item, sizeof(item))
+        self->items.append(GonnaSend{from=from, to=to, value=value})
 
     def pop_left(self) -> GonnaSend:
         result = self->items.ptr[0]

--- a/examples/aoc2023/day20/part2.jou
+++ b/examples/aoc2023/day20/part2.jou
@@ -96,8 +96,7 @@ class TodoList:
     items: List[GonnaSend]
 
     def send_later(self, from: Module*, to: Module*, value: bool) -> None:
-        item = GonnaSend{from=from, to=to, value=value}
-        self->items.append(&item, sizeof(item))
+        self->items.append(GonnaSend{from=from, to=to, value=value})
 
     def pop_left(self) -> GonnaSend:
         result = self->items.ptr[0]

--- a/examples/aoc2023/day23/part1.jou
+++ b/examples/aoc2023/day23/part1.jou
@@ -35,9 +35,8 @@ def get_next_paths(path: List[int[2]], grid: Grid*) -> List[int[2]][4]:
                     break
 
         if can_go:
-            next = [x, y]
             result[i].extend(path)
-            result[i].append(&next, sizeof(next))
+            result[i].append([x, y])
 
     return result
 
@@ -52,8 +51,7 @@ def main() -> int:
 
     paths: List[int[2]][1000]
     paths[0] = List[int[2]]{}
-    start = [1, 0]
-    paths[0].append(&start, sizeof(start))
+    paths[0].append([1, 0])
     npaths = 1
 
     result = 0

--- a/examples/aoc2023/day23/part2.jou
+++ b/examples/aoc2023/day23/part2.jou
@@ -116,8 +116,7 @@ def create_graph_of_intersections(grid: Grid*) -> Graph*:
     intersections = List[int[2]]{}
 
     todo = List[int[2]]{}
-    start = [1, 0]
-    todo.append(&start, sizeof(start))
+    todo.append([1, 0])
 
     while todo.len > 0:
         p = todo.ptr[--todo.len]
@@ -130,13 +129,12 @@ def create_graph_of_intersections(grid: Grid*) -> Graph*:
         if already_found:
             continue
 
-        intersections.append(&p, sizeof(p))
+        intersections.append(p)
 
         neighbors = find_connected_intersections(grid, p)
         for i = 0; i < 4; i++:
             if neighbors[i][0] != -1:
-                neighbor = [neighbors[i][0], neighbors[i][1]]
-                todo.append(&neighbor, sizeof(neighbor))
+                todo.append([neighbors[i][0], neighbors[i][1]])
 
     free(todo.ptr)
 

--- a/examples/aoc2024/day11/part1.jou
+++ b/examples/aoc2024/day11/part1.jou
@@ -35,7 +35,7 @@ def blink(stones: List[long]*) -> None:
         elif count_digits(stones->ptr[i]) % 2 == 0:
             pair = split_digits(stones->ptr[i])
             stones->ptr[i] = pair[0]
-            stones->append(&pair[1], sizeof(pair[1]))
+            stones->append(pair[1])
         else:
             stones->ptr[i] *= 2024
 
@@ -51,8 +51,7 @@ def main() -> int:
 
     stones = List[long]{}
     for i = 0; words[i] != NULL; i++:
-        stone = atoll(words[i])
-        stones.append(&stone, sizeof(stone))
+        stones.append(atoll(words[i]))
 
     free(words)
 

--- a/examples/aoc2024/day17/part2.jou
+++ b/examples/aoc2024/day17/part2.jou
@@ -104,8 +104,7 @@ def find_matching_inputs(code: int*, desired_output: int*, desired_output_len: i
         if last7 == -1 or last7 == 0:
             # The input can actually be zero. It's not banned by the required
             # last 7 bits.
-            zero = 0L
-            results.append(&zero, sizeof(zero))
+            results.append(0)
     else:
         for last10 = 0; last10 < 1024; last10++:  # all 10 bit numbers
             if (
@@ -120,7 +119,7 @@ def find_matching_inputs(code: int*, desired_output: int*, desired_output_len: i
                     x *= 8  # shift left to make room
                     x = xor(x, last_bits(last10, 3))
                     assert last_bits(x, 10) == last10
-                    results.append(&x, sizeof(x))
+                    results.append(x)
                 free(new_results.ptr)
 
     return results

--- a/examples/aoc2024/day20/part1.jou
+++ b/examples/aoc2024/day20/part1.jou
@@ -7,8 +7,7 @@ import "stdlib/mem.jou"
 
 def find_path_through_maze(grid: Grid) -> List[int[2]]:
     path = List[int[2]]{}
-    start = grid.find_first('S')
-    path.append(&start, sizeof(start))
+    path.append(grid.find_first('S'))
 
     while grid.get(path.end()[-1]) != 'E':
         x = path.end()[-1][0]
@@ -40,7 +39,7 @@ def find_path_through_maze(grid: Grid) -> List[int[2]]:
             chosen_neighbor = &neighbors[i]
 
         assert chosen_neighbor != NULL
-        path.append(chosen_neighbor, sizeof(*chosen_neighbor))
+        path.append(*chosen_neighbor)
 
     return path
 

--- a/examples/aoc2024/day20/part2.jou
+++ b/examples/aoc2024/day20/part2.jou
@@ -7,8 +7,7 @@ import "stdlib/mem.jou"
 
 def find_path_through_maze(grid: Grid) -> List[int[2]]:
     path = List[int[2]]{}
-    start = grid.find_first('S')
-    path.append(&start, sizeof(start))
+    path.append(grid.find_first('S'))
 
     while grid.get(path.end()[-1]) != 'E':
         x = path.end()[-1][0]
@@ -40,7 +39,7 @@ def find_path_through_maze(grid: Grid) -> List[int[2]]:
             chosen_neighbor = &neighbors[i]
 
         assert chosen_neighbor != NULL
-        path.append(chosen_neighbor, sizeof(*chosen_neighbor))
+        path.append(*chosen_neighbor)
 
     return path
 

--- a/examples/aoc2024/day21/part1.jou
+++ b/examples/aoc2024/day21/part1.jou
@@ -57,8 +57,7 @@ class KeyPad:
 
     def get_presses(self, what_to_write: byte*) -> List[byte[100]]:
         result = List[byte[100]]{}
-        empty: byte[100] = ""
-        result.append(&empty, sizeof(empty))
+        result.append("")
 
         for p = &what_to_write[0]; *p != '\0'; p++:
             if p == &what_to_write[0]:
@@ -103,9 +102,9 @@ class KeyPad:
                 strcat(v_then_h, "A")
 
                 if not self->goes_to_blank(h_then_v):
-                    result2.append(&h_then_v, sizeof(h_then_v))
+                    result2.append(h_then_v)
                 if not self->goes_to_blank(v_then_h):
-                    result2.append(&v_then_h, sizeof(v_then_h))
+                    result2.append(v_then_h)
 
             free(result.ptr)
             result = result2

--- a/examples/list_example.jou
+++ b/examples/list_example.jou
@@ -10,17 +10,9 @@ def main() -> int:
     foo = List[int]{}
 
     # Add items to list
-    #
-    # Due to limitations of the Jou language, it is currently impossible to write
-    # a simple list.append(item) method instead of list.append(&item, sizeof(item)).
-    # Inline functions (https://github.com/Akuli/jou/issues/791) will help with
-    # this when they are implemented.
-    n = 7
-    foo.append(&n, sizeof(n))
-    n++
-    foo.append(&n, sizeof(n))
-    n++
-    foo.append(&n, sizeof(n))
+    foo.append(7)
+    foo.append(8)
+    foo.append(9)
 
     # Iterating with indexes
     # Output: 7

--- a/stdlib/list.jou
+++ b/stdlib/list.jou
@@ -43,14 +43,11 @@ class List[T]:
         self->ptr = realloc(self->ptr, self->alloc)
         assert self->ptr != NULL  # If this fails, we ran out of memory
 
-    # Add *item to end of the list.
-    #
-    # The "itemsize" argument must be sizeof(*item). Unfortunately it is not
-    # possible to tell the compiler to determine it automatically.
-    def append(self, item: T*, itemsize: long) -> None:
-        self->grow(self->len + 1, itemsize)
-        memcpy(self->end(), item, itemsize)
-        self->len++
+    # Add item to end of the list.
+    @inline
+    def append(self, item: T) -> None:
+        self->grow(self->len + 1, sizeof(item))
+        self->ptr[self->len++] = item
 
     # Append n items to the list, starting at the given pointer.
     # For example, with n=3, this appends ptr[0], ptr[1] and ptr[2].

--- a/tests/should_succeed/list_test.jou
+++ b/tests/should_succeed/list_test.jou
@@ -23,7 +23,7 @@ def test_grow() -> None:
 
     # Make sure that nothing breaks if we append after growing
     for i = 4; i < 10; i++:
-        list.append(&i, sizeof(i))
+        list.append(i)
 
     # Output: 123456789
     for p = list.ptr; p < list.end(); p++:
@@ -35,8 +35,7 @@ def test_grow() -> None:
 
 def test_extend() -> None:
     list = List[int]{}
-    one = 1
-    list.append(&one, sizeof(one))
+    list.append(1)
 
     # Extend from pointer
     arr = [2, 3, 4, 5]
@@ -45,7 +44,7 @@ def test_extend() -> None:
     # Extend from another list
     list2 = List[int]{}
     for i = 11; i <= 99; i += 11:
-        list2.append(&i, sizeof(i))
+        list2.append(i)
     list.extend(list2)
     free(list2.ptr)
 
@@ -62,7 +61,7 @@ def test_extend() -> None:
 def test_pop() -> None:
     list = List[int]{}
     for i = 11; i <= 44; i += 11:
-        list.append(&i, sizeof(i))
+        list.append(i)
     printf("%lld items, last is %d\n", list.len, list.end()[-1])  # Output: 4 items, last is 44
     list.pop()
     printf("%lld items, last is %d\n", list.len, list.end()[-1])  # Output: 3 items, last is 33
@@ -74,8 +73,9 @@ def test_pop() -> None:
     printf("%lld items\n", list.len)  # Output: 0 items
 
     assert list.ptr != NULL  # same memory will be reused
-    for i = 1; i <= 3; i++:
-        list.append(&i, sizeof(i))
+    list.append(1)
+    list.append(2)
+    list.append(3)
     # Output: len=3 [1,2,3]
     printf("len=%lld [%d,%d,%d]\n", list.len, list.ptr[0], list.ptr[1], list.ptr[2])
 


### PR DESCRIPTION
This is now just like in Python. Possible with `@inline` now that #821 is merged.

Old: `list.append(&item, sizeof(item))`
New: `list.append(item)`