### PR TITLE
Do not cache bootstrap compiler on macos

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -54,12 +54,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch the whole Git history for bootstrapping
-      - uses: actions/cache@v4
-        with:
-          path: jou_bootstrap
-          key: bootstrap-${{ runner.os }}-${{ matrix.params.llvm-version }}-${{ matrix.params.opt-level }}-${{ hashFiles('bootstrap.sh') }}
-      - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
-        run: touch -c jou_bootstrap
       - run: brew install bash diffutils llvm@${{ matrix.params.llvm-version }}
       - name: "Select LLVM version"
         run: echo "LLVM_CONFIG=/opt/homebrew/opt/llvm@${{ matrix.params.llvm-version }}/bin/llvm-config" >> $GITHUB_ENV


### PR DESCRIPTION
Fixes #833 

The cached bootstrap compiler stopped working for some reason. There's no need to cache it at all. MacOS tests are not ran every time someone makes a pull request, so they don't need to be particularly fast.