### PR TITLE
Fail CI if using ```python3 accidentally

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          if git grep '```python3' || git grep '```py$' || git grep '```py3$'; then
+          if git grep -E '```(python3|py$|py3)' '*.md'; then
             echo 'Error: Jou code in markdown files must be marked with ```python'
             exit 1
           fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,18 @@ jobs:
       - uses: actions/checkout@v4
       - run: shellcheck --color=always --shell=bash --exclude=SC2086,SC2059,SC2046,SC2235,SC2002,SC2206,SC2068,SC2207,SC2013 *.sh activate
 
+  # For consistency, Jou code in markdown files should use ```python, not ```python3
+  python-in-markdown:
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          if git grep '```python3' || git grep '```py$' || git grep '```py3$'; then
+            echo 'Error: Jou code in markdown files must be marked with ```python'
+            exit 1
+          fi
+
   editorconfig-checker:
     timeout-minutes: 1
     runs-on: ubuntu-latest

--- a/doc/compiler_internals/architecture-and-design.md
+++ b/doc/compiler_internals/architecture-and-design.md
@@ -2,7 +2,7 @@
 
 Suppose you have file `foo.jou` with the following content:
 
-```python3
+```python
 import "./bar.jou"
 import "stdlib/io.jou"
 
@@ -14,7 +14,7 @@ def main() -> int:
 
 And file `bar.jou` with this content:
 
-```python3
+```python
 import "stdlib/io.jou"
 
 @public


### PR DESCRIPTION
Jou code in markdown files uses "Python" syntax highlighting. GitHub supports multiple ways of specifying it, at least the following:

    ```python
    ```python3
    ```py
    ```py3

`doctest.sh` only supports the `python` marker. This PR adds a check to CI that fails if any of the other markers are used.