### PR TITLE
Do not copy mingw64 to many folders when bootstrapping

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -156,6 +156,7 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
     )
 
     if [[ "$OS" =~ Windows ]]; then
+        echo "Copying files..."
         cp -r libs $folder
     fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -141,19 +141,19 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
             sed -i -e s/'LLVMPassManagerBuilderPopulateModulePassManager.*'/'LLVMRunPasses(module, "default<O1>", target.target_machine, pmbuilder)'/g compiler/main.jou
             sed -i -e s/'declare LLVMPassManagerBuilderPopulateModulePassManager.*'/'declare LLVMRunPasses(a:void*, b:void*, c:void*, d:void*) -> void*'/g compiler/llvm.jou
         fi
-    )
 
-    if [[ "$OS" =~ Windows ]] && [ $i -le 14 ]; then
-        # Old version of Jou. Doesn't support the JOU_MINGW_DIR environment variable.
-        # Patch code to find mingw64 in the directory where it is.
-        # This used to copy the mingw64 folder, but it was slow and wasted disk space.
-        # Afaik symlinks aren't really a thing on windows.
-        echo "Patching to specify location of mingw64..."
-        sed -i 's/mingw64/..\\\\..\\\\..\\\\mingw64/g' compiler/run.jou
-        if [ $i == 1 ]; then
-            sed -i 's/mingw64/..\\\\..\\\\..\\\\mingw64/g' bootstrap_compiler/output.c
+        if [[ "$OS" =~ Windows ]] && [ $i -le 14 ]; then
+            # Old version of Jou. Doesn't support the JOU_MINGW_DIR environment variable.
+            # Patch code to find mingw64 in the directory where it is.
+            # This used to copy the mingw64 folder, but it was slow and wasted disk space.
+            # Afaik symlinks aren't really a thing on windows.
+            echo "Patching to specify location of mingw64..."
+            sed -i 's/mingw64/..\\\\..\\\\..\\\\mingw64/g' compiler/run.jou
+            if [ $i == 1 ]; then
+                sed -i 's/mingw64/..\\\\..\\\\..\\\\mingw64/g' bootstrap_compiler/output.c
+            fi
         fi
-    fi
+    )
 
     if [[ "$OS" =~ Windows ]]; then
         cp -r libs $folder

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -187,7 +187,7 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
         fi
     fi
 
-    (cd $folder && $make $make_flags jou.exe)
+    (cd $folder && $make $make_flags jou$exe_suffix)
 done
 
 show_message "Copying the bootstrapped executable"


### PR DESCRIPTION
Instead of wasting about 15G for the bootstrapped compilers, size of `tmp/bootstrap_cache` on Windows is now about 556M after running the bootstrap process. Fixes #848