### PR TITLE
Use LLVM 19 for Windows builds (except --small)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -102,16 +102,15 @@ jobs:
               mingw64/version_info.txt \
               $(find mingw64 -name 'crt*.o') \
               mingw64/bin/gcc.exe \
-              mingw64/lib/gcc/x86_64-w64-mingw32/12.1.0/libgcc.a \
-              mingw64/lib/gcc/x86_64-w64-mingw32/12.1.0/libgcc_eh.a \
-              mingw64/libexec/gcc/x86_64-w64-mingw32/12.1.0/liblto_plugin.dll \
+              mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/libgcc.a \
+              mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/libgcc_eh.a \
+              mingw64/libexec/gcc/x86_64-w64-mingw32/14.2.0/liblto_plugin.dll \
               mingw64/x86_64-w64-mingw32/bin/ld.exe \
               mingw64/x86_64-w64-mingw32/lib/libadvapi32.a \
               mingw64/x86_64-w64-mingw32/lib/libkernel32.a \
               mingw64/x86_64-w64-mingw32/lib/libm.a \
               mingw64/x86_64-w64-mingw32/lib/libmingw32.a \
               mingw64/x86_64-w64-mingw32/lib/libmingwex.a \
-              mingw64/x86_64-w64-mingw32/lib/libmoldname.a \
               mingw64/x86_64-w64-mingw32/lib/libmsvcrt.a \
               mingw64/x86_64-w64-mingw32/lib/libpthread.a \
               mingw64/x86_64-w64-mingw32/lib/libshell32.a \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,59 +12,6 @@ on:
   pull_request:
 
 jobs:
-  # I created a zip file that contains mingw64, but with some large files deleted.
-  # These large files are most of the time unnecessary for developing Jou.
-  # People with slow internet need the smaller zip file.
-  #
-  # This check fails if the zip file contains anything else than what's in the original/full zip file.
-  # It serves two purposes:
-  #   * People can trust the random zip file I have created locally on my system and committed.
-  #   * I can be sure that I didn't accidentally include something unnecessary or do something else dumb.
-  check-small-mingw64:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      # Same URLs as in windows_setup.sh
-      - name: Download the small mingw64
-        run: curl -L -o mingw64-small.zip https://akuli.github.io/mingw64-small.zip
-      - name: Download the full mingw64
-        run: curl -L -o mingw64.zip https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.6-10.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-12.1.0-llvm-14.0.6-mingw-w64msvcrt-10.0.0-r3.zip
-      # Same SHA hashes as in windows_setup.sh
-      - name: Verify the small mingw64
-        run: |
-          if [ "$(sha256sum mingw64-small.zip | cut -d' ' -f1)" != "4d858bd22f084ae362ee6a22a52c2c5b5281d996f96693984a31336873b92686" ]; then
-            echo "verifying failed"
-            exit 1
-          fi
-      - name: Verify the full mingw64
-        run: |
-          if [ "$(sha256sum mingw64.zip | cut -d' ' -f1)" != "9ffef7f7a8dab893bd248085fa81a5a37ed6f775ae220ef673bea8806677836d" ]; then
-            echo "verifying failed"
-            exit 1
-          fi
-      - name: Make sure that all file paths start with mingw64
-        run: |
-          zipinfo -1 mingw64.zip > output.txt
-          zipinfo -1 mingw64-small.zip >> output.txt
-          cat output.txt
-          if [ "$(cut -d/ -f1 output.txt | uniq)" != "mingw64" ]; then
-            exit 1
-          fi
-      - run: ls -lh mingw64*.zip
-      - name: Extract mingw64.zip
-        run: mkdir full && cd full && unzip ../mingw64.zip
-      - name: Extract mingw64-small.zip
-        run: mkdir small && cd small && unzip ../mingw64-small.zip
-      - name: Compare files
-        run: |
-          # diff exits with status 1 because the folders differ.
-          # Put errors to output.txt as well, so that we notice if something goes wrong.
-          (diff -r full small || true) &> output.txt
-          cat output.txt
-          if [ "$(cut -d/ -f1 output.txt | uniq)" != "Only in full" ]; then
-            exit 1
-          fi
-
   build-zip:
     runs-on: windows-latest
     timeout-minutes: 10  # may need to bootstrap

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -176,7 +176,11 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
         touch $folder/jou_bootstrap$exe_suffix
     fi
 
-    (cd $folder && $make CC=../../../mingw64/bin/clang.exe jou$exe_suffix)
+    if [[ "$OS" =~ "Windows" ]] && [ $i == 1 ]; then
+        (cd $folder && $make CC=../../../mingw64/bin/clang.exe jou$exe_suffix)
+    else
+        (cd $folder && $make jou$exe_suffix)
+    fi
 done
 
 show_message "Copying the bootstrapped executable"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -176,7 +176,7 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
         touch $folder/jou_bootstrap$exe_suffix
     fi
 
-    (cd $folder && $make jou$exe_suffix)
+    (cd $folder && $make CC=../../../mingw64/bin/clang.exe jou$exe_suffix)
 done
 
 show_message "Copying the bootstrapped executable"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -143,6 +143,7 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
     )
 
     if [[ "$OS" =~ Windows ]]; then
+        echo "Copying files..."
         cp -r libs mingw64 $folder
     fi
 
@@ -162,6 +163,13 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
     fi
 
     (cd $folder && $make jou$exe_suffix)
+
+    if [[ "$OS" =~ Windows ]]; then
+        # TODO: mingw64 is really big. Ideally we would only copy the bits we need,
+        # not the whole thing. For now it's easier to just delete it after use...
+        echo "Deleting files to save space..."
+        rm -r $folder/libs $folder/mingw64
+    fi
 done
 
 show_message "Copying the bootstrapped executable"

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -50,13 +50,15 @@ else
     if [ $small = yes ]; then
         # A special small version of mingw64 that comes with the repo, for people with slow internet.
         # See .github/workflows/windows.yml for code that checks the contents of the zip so that you can trust it.
-        url=https://akuli.github.io/mingw64-small.zip
-        filename=mingw64-small.zip
-        sha=4d858bd22f084ae362ee6a22a52c2c5b5281d996f96693984a31336873b92686
+        echo "Small install is currently not suppported." >&2
+        exit 1
+#        url=https://akuli.github.io/mingw64-small.zip
+#        filename=mingw64-small.zip
+#        sha=4d858bd22f084ae362ee6a22a52c2c5b5281d996f96693984a31336873b92686
     else
-        url=https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.6-10.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-12.1.0-llvm-14.0.6-mingw-w64msvcrt-10.0.0-r3.zip
+        url=https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.7-12.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-llvm-19.1.7-mingw-w64msvcrt-12.0.0-r3.zip
         filename=mingw64.zip
-        sha=9ffef7f7a8dab893bd248085fa81a5a37ed6f775ae220ef673bea8806677836d
+        sha=5937a482247bebc2eca8c0b93fa43ddb17d94968adfff3f2e0c63c94608ee76b
     fi
 
     if [ -z "$offline_mingw64" ]; then


### PR DESCRIPTION
Tested locally in a Windows 7 VM.

This is a first step towards dropping support for LLVM 14, but doesn't fully remove LLVM 14 yet. If you use `./windows_setup.sh --small`, you still get LLVM 14. I will work on that in another PR.