### PR TITLE
Windows build: include mingw32-make.exe

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -142,7 +142,7 @@ jobs:
             mingw64/lib/libLLVMX86Info.dll.a
             mingw64/lib/libLLVMX86Desc.dll.a
 
-            # This is here only for "./windows_setup.sh --small".
+            # Meant to be used only for developing Jou with "./windows_setup.sh --small".
             mingw64/bin/mingw32-make.exe
           )
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -141,6 +141,9 @@ jobs:
             mingw64/lib/libLLVMX86AsmParser.dll.a
             mingw64/lib/libLLVMX86Info.dll.a
             mingw64/lib/libLLVMX86Desc.dll.a
+
+            # This is here only for "./windows_setup.sh --small".
+            mingw64/bin/mingw32-make.exe
           )
 
           for file in ${files[@]}; do


### PR DESCRIPTION
Similarly to #852, this is needed to get rid of `akuli.github.io/mingw64-small.zip`, but this will make the Jou release zip files slightly bigger.