### PR TITLE
Windows: do not use "libs" folder

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -202,7 +202,9 @@ jobs:
           key: bootstrap-${{ runner.os }}-${{ hashFiles('*.sh') }}
       - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
         run: touch -c jou_bootstrap.exe
-      - run: ./windows_setup.sh --small
+      # TODO: use --small (#856)
+      #- run: ./windows_setup.sh --small
+      - run: ./windows_setup.sh
         shell: bash
       - name: "Compile and test"
         run: source activate && ./runtests.sh --verbose

--- a/compiler/llvm.jou
+++ b/compiler/llvm.jou
@@ -1,16 +1,16 @@
 if WINDOWS:
     # Please keep in sync with windows_setup.sh
-    link "../libs/libLLVMCore.a"
-    link "../libs/libLLVMX86CodeGen.a"
-    link "../libs/libLLVMAnalysis.a"
-    link "../libs/libLLVMTarget.a"
-    link "../libs/libLLVMPasses.a"
-    link "../libs/libLLVMSupport.a"
-    link "../libs/libLLVMLinker.a"
-    link "../libs/libLTO.a"
-    link "../libs/libLLVMX86AsmParser.a"
-    link "../libs/libLLVMX86Info.a"
-    link "../libs/libLLVMX86Desc.a"
+    link "../mingw64/lib/libLLVMCore.dll.a"
+    link "../mingw64/lib/libLLVMX86CodeGen.dll.a"
+    link "../mingw64/lib/libLLVMAnalysis.dll.a"
+    link "../mingw64/lib/libLLVMTarget.dll.a"
+    link "../mingw64/lib/libLLVMPasses.dll.a"
+    link "../mingw64/lib/libLLVMSupport.dll.a"
+    link "../mingw64/lib/libLLVMLinker.dll.a"
+    link "../mingw64/lib/libLTO.dll.a"
+    link "../mingw64/lib/libLLVMX86AsmParser.dll.a"
+    link "../mingw64/lib/libLLVMX86Info.dll.a"
+    link "../mingw64/lib/libLLVMX86Desc.dll.a"
 else:
     # Linker commands are defined in config.jou, which is auto-generated.
     pass


### PR DESCRIPTION
**This PR breaks `windows_setup.sh --small` temporarily. I will fix it in my next PR.**

Since #852, content of "libs" folder is available directly inside the `mingw64` folder. I will soon get rid of the `libs` folder in a separate PR.