### PR TITLE
Implement `windows_setup.sh --small` differently

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -102,16 +102,15 @@ jobs:
               mingw64/version_info.txt \
               $(find mingw64 -name 'crt*.o') \
               mingw64/bin/gcc.exe \
-              mingw64/lib/gcc/x86_64-w64-mingw32/12.1.0/libgcc.a \
-              mingw64/lib/gcc/x86_64-w64-mingw32/12.1.0/libgcc_eh.a \
-              mingw64/libexec/gcc/x86_64-w64-mingw32/12.1.0/liblto_plugin.dll \
+              mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/libgcc.a \
+              mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/libgcc_eh.a \
+              mingw64/libexec/gcc/x86_64-w64-mingw32/14.2.0/liblto_plugin.dll \
               mingw64/x86_64-w64-mingw32/bin/ld.exe \
               mingw64/x86_64-w64-mingw32/lib/libadvapi32.a \
               mingw64/x86_64-w64-mingw32/lib/libkernel32.a \
               mingw64/x86_64-w64-mingw32/lib/libm.a \
               mingw64/x86_64-w64-mingw32/lib/libmingw32.a \
               mingw64/x86_64-w64-mingw32/lib/libmingwex.a \
-              mingw64/x86_64-w64-mingw32/lib/libmoldname.a \
               mingw64/x86_64-w64-mingw32/lib/libmsvcrt.a \
               mingw64/x86_64-w64-mingw32/lib/libpthread.a \
               mingw64/x86_64-w64-mingw32/lib/libshell32.a \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,59 +12,6 @@ on:
   pull_request:
 
 jobs:
-  # I created a zip file that contains mingw64, but with some large files deleted.
-  # These large files are most of the time unnecessary for developing Jou.
-  # People with slow internet need the smaller zip file.
-  #
-  # This check fails if the zip file contains anything else than what's in the original/full zip file.
-  # It serves two purposes:
-  #   * People can trust the random zip file I have created locally on my system and committed.
-  #   * I can be sure that I didn't accidentally include something unnecessary or do something else dumb.
-  check-small-mingw64:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      # Same URLs as in windows_setup.sh
-      - name: Download the small mingw64
-        run: curl -L -o mingw64-small.zip https://akuli.github.io/mingw64-small.zip
-      - name: Download the full mingw64
-        run: curl -L -o mingw64.zip https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.6-10.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-12.1.0-llvm-14.0.6-mingw-w64msvcrt-10.0.0-r3.zip
-      # Same SHA hashes as in windows_setup.sh
-      - name: Verify the small mingw64
-        run: |
-          if [ "$(sha256sum mingw64-small.zip | cut -d' ' -f1)" != "4d858bd22f084ae362ee6a22a52c2c5b5281d996f96693984a31336873b92686" ]; then
-            echo "verifying failed"
-            exit 1
-          fi
-      - name: Verify the full mingw64
-        run: |
-          if [ "$(sha256sum mingw64.zip | cut -d' ' -f1)" != "9ffef7f7a8dab893bd248085fa81a5a37ed6f775ae220ef673bea8806677836d" ]; then
-            echo "verifying failed"
-            exit 1
-          fi
-      - name: Make sure that all file paths start with mingw64
-        run: |
-          zipinfo -1 mingw64.zip > output.txt
-          zipinfo -1 mingw64-small.zip >> output.txt
-          cat output.txt
-          if [ "$(cut -d/ -f1 output.txt | uniq)" != "mingw64" ]; then
-            exit 1
-          fi
-      - run: ls -lh mingw64*.zip
-      - name: Extract mingw64.zip
-        run: mkdir full && cd full && unzip ../mingw64.zip
-      - name: Extract mingw64-small.zip
-        run: mkdir small && cd small && unzip ../mingw64-small.zip
-      - name: Compare files
-        run: |
-          # diff exits with status 1 because the folders differ.
-          # Put errors to output.txt as well, so that we notice if something goes wrong.
-          (diff -r full small || true) &> output.txt
-          cat output.txt
-          if [ "$(cut -d/ -f1 output.txt | uniq)" != "Only in full" ]; then
-            exit 1
-          fi
-
   build-zip:
     runs-on: windows-latest
     timeout-minutes: 10  # may need to bootstrap

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,7 +74,9 @@ jobs:
             # These .a files don't contain actual code, so they are somewhat small.
             # The DLLs still need to be present when running code that uses LLVM.
             #
-            # Please keep in sync with compiler/llvm.jou
+            # The same list of files is in:
+            #   - compiler/llvm.jou
+            #   - bootstrap.sh
             mingw64/lib/libLLVMCore.dll.a
             mingw64/lib/libLLVMX86CodeGen.dll.a
             mingw64/lib/libLLVMAnalysis.dll.a

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,9 +21,7 @@ jobs:
           fetch-depth: 0  # Fetch the whole Git history for bootstrapping
       - uses: actions/cache@v4
         with:
-          path: |
-            jou_bootstrap.exe
-            libs/*.a
+          path: jou_bootstrap.exe
           key: bootstrap-${{ runner.os }}-${{ hashFiles('*.sh') }}
       - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
         run: touch -c jou_bootstrap.exe
@@ -112,9 +110,7 @@ jobs:
           fetch-depth: 0  # Fetch the whole Git history for bootstrapping
       - uses: actions/cache@v4
         with:
-          path: |
-            jou_bootstrap.exe
-            libs/*.a
+          path: jou_bootstrap.exe
           key: bootstrap-${{ runner.os }}-${{ hashFiles('*.sh') }}
       - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
         run: touch -c jou_bootstrap.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
           key: bootstrap-${{ runner.os }}-${{ hashFiles('*.sh') }}
       - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
         run: touch -c jou_bootstrap.exe
-      # TODO: figure out why --small doesn't work here
+      # Do not use --small because it relies on a previously built zip
       - run: source activate && ./windows_setup.sh
         shell: bash
       - run: source activate && mingw32-make

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@
 /libs
 /mingw64
 /mingw64.zip
-/mingw64-small.zip
+
+# "windows_setup.sh --small" downloads a Jou release instead of mingw64.zip
+/jou_windows_64bit_*.zip
 
 *.dll
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /jou_bootstrap
 /jou
 /config.jou
-/libs
 /mingw64
 /mingw64.zip
 
@@ -32,3 +31,6 @@
 
 # LibreOffice lock file
 .~lock.*#
+
+# Stuff that is no longer a thing but someone might still have locally
+/libs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,8 @@ Following the [instructions in the README](README.md#setup) is enough.
     If you have a slow internet connection
     and it takes a long time for `windows_setup.sh` to download mingw64,
     you can instead run `./windows_setup.sh --small`.
-    This way it uses `mingw64-small.zip`,
-    which is just like the usual mingw64, but with many large files deleted to make it smaller.
-    I created it locally on my computer.
-    If you don't want to trust it, you can run `windows_setup.sh` without `--small`
-    or look at how `.github/workflows/windows.yml` compares `mingw64-small.zip` to the original `mingw64.zip`.
+    Instead of downloading the full mingw64 (about 1GB),
+    this will get a minimal version of MinGW from a [release](#releases) of Jou (about 50MB).
 5. Compile Jou:
     ```
     source activate
@@ -44,7 +41,12 @@ Following the [instructions in the README](README.md#setup) is enough.
     where `C:\Users\YourName\Desktop` is the folder where you cloned Jou.
     If you don't want to run it every time you open a Git Bash window to work on Jou,
     you can instead add it to your PATH permanently with Control Panel.
-    When you run `mingw32-make` for the first time, it [bootstraps Jou from Git history](README.md#bootstrapping).
+
+    When you run `mingw32-make` for the first time, it
+    [bootstraps Jou from Git history](README.md#bootstrapping).
+    If you used the `--small` option of `windows_setup.sh`,
+    the bootstrapping process will begin at the downloaded Jou release
+    instead of the last version that came with a compiler written in C.
 6. Compile and run hello world:
     ```
     ./jou.exe examples/hello.jou

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -4,7 +4,7 @@ jou_bootstrap.exe: bootstrap.sh
 	bash ./bootstrap.sh
 
 jou.exe: jou_bootstrap.exe $(wildcard compiler/*.jou compiler/*/*.jou)
-	rm -rf compiler/jou_compiled && ./jou_bootstrap.exe -o jou.exe --linker-flags "$(wildcard libs/lib*.a)" compiler/main.jou
+	rm -rf compiler/jou_compiled && ./jou_bootstrap.exe -o jou.exe compiler/main.jou
 
 # Does not delete tmp/bootstrap_cache because bootstrapping is slow.
 .PHONY: clean

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,7 +32,7 @@ commits=(
     30bf61efa40832a2429eee34c8cc93e80ea7f591  # @inline
     722d066c840bf9c07dafd69e5bd1d12823f04b25  # bug fixes for using @inline in generic classes
     e7fea1f2ed602a7c191f8c8c605fa56ae2468723  # JOU_MINGW_DIR environment variable
-    98c5fb2792eaac8bbe7496a176808d684f631d82  # "./windows_setup.sh --small" starts from this commit
+    98c5fb2792eaac8bbe7496a176808d684f631d82  # "./windows_setup.sh --small" starts from this commit (release 2025-04-08-2200)
 )
 
 for commit in ${commits[@]}; do

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,7 +32,7 @@ commits=(
     30bf61efa40832a2429eee34c8cc93e80ea7f591  # @inline
     722d066c840bf9c07dafd69e5bd1d12823f04b25  # bug fixes for using @inline in generic classes
     e7fea1f2ed602a7c191f8c8c605fa56ae2468723  # JOU_MINGW_DIR environment variable
-    212db69885bd1f18e7fa67458110b81b3b1cd812  # "./windows_setup.sh --small" starts from this commit
+    98c5fb2792eaac8bbe7496a176808d684f631d82  # "./windows_setup.sh --small" starts from this commit
 )
 
 for commit in ${commits[@]}; do

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -161,7 +161,7 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
         echo "Copying files..."
         mkdir $folder/libs
         for file in mingw64/lib/libLLVM*.dll.a mingw64/lib/libLTO.dll.a; do
-            cp -v $file $folder/libs/${file/.dll/}
+            cp -v $file $folder/libs/$(basename -s .dll.a $file).a
         done
     fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,6 +33,7 @@ commits=(
     722d066c840bf9c07dafd69e5bd1d12823f04b25  # bug fixes for using @inline in generic classes
     e7fea1f2ed602a7c191f8c8c605fa56ae2468723  # JOU_MINGW_DIR environment variable
     98c5fb2792eaac8bbe7496a176808d684f631d82  # "./windows_setup.sh --small" starts from this commit (release 2025-04-08-2200)
+    4dc6d2bc6a88472949b34ac9797b8fae17b6fde5  # on Windows, "libs" folder is no longer used
 )
 
 for commit in ${commits[@]}; do
@@ -154,15 +155,16 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
         fi
     )
 
-    if [[ "$OS" =~ Windows ]] && [ $i -le 15 ]; then
+    if [[ "$OS" =~ Windows ]] && [ $i -le 16 ]; then
+        echo "Copying files..."
         # These files used to be in a separate "libs" folder next to mingw64 folder.
         # Now they are in mingw64/lib.
         # They were also named slightly differently.
-        echo "Copying files..."
-        mkdir $folder/libs
+        #
         # The same list of files is in:
         #   - .github/workflows/windows.yml
         #   - compiler/llvm.jou
+        mkdir $folder/libs
         cp mingw64/lib/libLLVMCore.dll.a $folder/libs/libLLVMCore.a
         cp mingw64/lib/libLLVMX86CodeGen.dll.a $folder/libs/libLLVMX86CodeGen.a
         cp mingw64/lib/libLLVMAnalysis.dll.a $folder/libs/libLLVMAnalysis.a

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -160,9 +160,20 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
         # They were also named slightly differently.
         echo "Copying files..."
         mkdir $folder/libs
-        for file in mingw64/lib/libLLVM*.dll.a mingw64/lib/libLTO.dll.a; do
-            cp -v $file $folder/libs/$(basename -s .dll.a $file).a
-        done
+        # The same list of files is in:
+        #   - .github/workflows/windows.yml
+        #   - compiler/llvm.jou
+        cp mingw64/lib/libLLVMCore.dll.a $folder/libs/libLLVMCore.a
+        cp mingw64/lib/libLLVMX86CodeGen.dll.a $folder/libs/libLLVMX86CodeGen.a
+        cp mingw64/lib/libLLVMAnalysis.dll.a $folder/libs/libLLVMAnalysis.a
+        cp mingw64/lib/libLLVMTarget.dll.a $folder/libs/libLLVMTarget.a
+        cp mingw64/lib/libLLVMPasses.dll.a $folder/libs/libLLVMPasses.a
+        cp mingw64/lib/libLLVMSupport.dll.a $folder/libs/libLLVMSupport.a
+        cp mingw64/lib/libLLVMLinker.dll.a $folder/libs/libLLVMLinker.a
+        cp mingw64/lib/libLTO.dll.a $folder/libs/libLTO.a
+        cp mingw64/lib/libLLVMX86AsmParser.dll.a $folder/libs/libLLVMX86AsmParser.a
+        cp mingw64/lib/libLLVMX86Info.dll.a $folder/libs/libLLVMX86Info.a
+        cp mingw64/lib/libLLVMX86Desc.dll.a $folder/libs/libLLVMX86Desc.a
     fi
 
     if [[ "$OS" =~ Windows ]] && [ $i == 1 ]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -154,9 +154,12 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
         fi
     )
 
-    if [[ "$OS" =~ Windows ]]; then
+    if [[ "$OS" =~ Windows ]] && [ $i -le 15 ]; then
+        # These files used to be in a separate "libs" folder next to mingw64 folder.
+        # Now they are in mingw64/lib.
         echo "Copying files..."
-        cp -r libs $folder
+        mkdir $folder/libs
+        cp mingw64/lib/libLLVM*.dll.a mingw64/lib/libLTO.dll.a $folder/libs
     fi
 
     if [[ "$OS" =~ Windows ]] && [ $i == 1 ]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,6 +32,7 @@ commits=(
     30bf61efa40832a2429eee34c8cc93e80ea7f591  # @inline
     722d066c840bf9c07dafd69e5bd1d12823f04b25  # bug fixes for using @inline in generic classes
     e7fea1f2ed602a7c191f8c8c605fa56ae2468723  # JOU_MINGW_DIR environment variable
+    6f6622072f6b3a321e53619606dcc09a82c8232c  # "./windows_setup.sh --small" starts from this commit
 )
 
 for commit in ${commits[@]}; do

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,7 +32,7 @@ commits=(
     30bf61efa40832a2429eee34c8cc93e80ea7f591  # @inline
     722d066c840bf9c07dafd69e5bd1d12823f04b25  # bug fixes for using @inline in generic classes
     e7fea1f2ed602a7c191f8c8c605fa56ae2468723  # JOU_MINGW_DIR environment variable
-    6f6622072f6b3a321e53619606dcc09a82c8232c  # "./windows_setup.sh --small" starts from this commit
+    212db69885bd1f18e7fa67458110b81b3b1cd812  # "./windows_setup.sh --small" starts from this commit
 )
 
 for commit in ${commits[@]}; do
@@ -157,9 +157,12 @@ static void optimize(void *module, int level) { (void)module; (void)level; }'$'\
     if [[ "$OS" =~ Windows ]] && [ $i -le 15 ]; then
         # These files used to be in a separate "libs" folder next to mingw64 folder.
         # Now they are in mingw64/lib.
+        # They were also named slightly differently.
         echo "Copying files..."
         mkdir $folder/libs
-        cp mingw64/lib/libLLVM*.dll.a mingw64/lib/libLTO.dll.a $folder/libs
+        for file in mingw64/lib/libLLVM*.dll.a mingw64/lib/libLTO.dll.a; do
+            cp -v $file $folder/libs/${file/.dll/}
+        done
     fi
 
     if [[ "$OS" =~ Windows ]] && [ $i == 1 ]; then

--- a/compiler/llvm.jou
+++ b/compiler/llvm.jou
@@ -4,7 +4,9 @@ if WINDOWS:
     # These files don't contain actual code. The DLLs still need to be in
     # current directory or PATH when running the compiler.
     #
-    # Please keep in sync with .github/workflows/windows.yml
+    # The same list of files is in:
+    #   - .github/workflows/windows.yml
+    #   - bootstrap.sh
     link "../mingw64/lib/libLLVMCore.dll.a"
     link "../mingw64/lib/libLLVMX86CodeGen.dll.a"
     link "../mingw64/lib/libLLVMAnalysis.dll.a"

--- a/compiler/llvm.jou
+++ b/compiler/llvm.jou
@@ -1,8 +1,10 @@
 if WINDOWS:
     # These .dll.a files define what symbols the corresponding .dll files have.
     #
-    # These .a files don't contain actual code. The DLLs still need to be
-    # present when running the compiler.
+    # These files don't contain actual code. The DLLs still need to be in
+    # current directory or PATH when running the compiler.
+    #
+    # Please keep in sync with .github/workflows/windows.yml
     link "../mingw64/lib/libLLVMCore.dll.a"
     link "../mingw64/lib/libLLVMX86CodeGen.dll.a"
     link "../mingw64/lib/libLLVMAnalysis.dll.a"

--- a/compiler/llvm.jou
+++ b/compiler/llvm.jou
@@ -1,16 +1,19 @@
 if WINDOWS:
-    # Please keep in sync with windows_setup.sh
-    link "../libs/libLLVMCore.a"
-    link "../libs/libLLVMX86CodeGen.a"
-    link "../libs/libLLVMAnalysis.a"
-    link "../libs/libLLVMTarget.a"
-    link "../libs/libLLVMPasses.a"
-    link "../libs/libLLVMSupport.a"
-    link "../libs/libLLVMLinker.a"
-    link "../libs/libLTO.a"
-    link "../libs/libLLVMX86AsmParser.a"
-    link "../libs/libLLVMX86Info.a"
-    link "../libs/libLLVMX86Desc.a"
+    # These .dll.a files define what symbols the corresponding .dll files have.
+    #
+    # These .a files don't contain actual code. The DLLs still need to be
+    # present when running the compiler.
+    link "../mingw64/lib/libLLVMCore.dll.a"
+    link "../mingw64/lib/libLLVMX86CodeGen.dll.a"
+    link "../mingw64/lib/libLLVMAnalysis.dll.a"
+    link "../mingw64/lib/libLLVMTarget.dll.a"
+    link "../mingw64/lib/libLLVMPasses.dll.a"
+    link "../mingw64/lib/libLLVMSupport.dll.a"
+    link "../mingw64/lib/libLLVMLinker.dll.a"
+    link "../mingw64/lib/libLTO.dll.a"
+    link "../mingw64/lib/libLLVMX86AsmParser.dll.a"
+    link "../mingw64/lib/libLLVMX86Info.dll.a"
+    link "../mingw64/lib/libLLVMX86Desc.dll.a"
 else:
     # Linker commands are defined in config.jou, which is auto-generated.
     pass

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -31,7 +31,7 @@ Usage: $0 [--small] [--offline-mingw64 path/to/file.zip]
         Use this if you have slow internet. See CONTRIBUTING.md for a detailed
         explanation about what this does.
 
-  --offline-zip <path/to/file.zip>
+  --offline-zip path/to/file.zip
         Usually this script downloads one zip file, but if this option is used,
         nothing will be downloaded from internet. The file is instead copied
         from the given path. This can be used to set up a Jou dev environment

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -50,13 +50,13 @@ else
     if [ $small = yes ]; then
         # User has slow internet and doesn't want to download the whole mingw64 (about 1GB).
         # Instead, download a release of Jou (about 50MB), and extract mingw and Jou compiler from there.
-        url=https://github.com/Akuli/jou/releases/download/2025-04-08-1600/jou_windows_64bit_2025-04-08-1600.zip
-        filename=jou_windows_64bit_2025-04-08-1600.zip
-        sha=50b85b43aa3fc7055df4a85d8650d47b8de3700f86b371337f9f7daf99d86f4b
+        url=https://github.com/Akuli/jou/releases/download/2025-04-08-2000/jou_windows_64bit_2025-04-08-2000.zip
+        filename=jou_windows_64bit_2025-04-08-2000.zip
+        sha=da9fc23e0ee270d176171d2370d25abe42d09895cc69ae531f6d714398039eb9
         # This is the folder where the downloaded Jou compiler (jou.exe) will go.
         # Placing it here makes bootstrap.sh use our downloaded Jou compiler
         # instead of starting from scratch.
-        jou_exe_folder=tmp/bootstrap_cache/016_6f6622072f6b3a321e53619606dcc09a82c8232c
+        jou_exe_folder=tmp/bootstrap_cache/016_212db69885bd1f18e7fa67458110b81b3b1cd812
     else
         url=https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.7-12.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-llvm-19.1.7-mingw-w64msvcrt-12.0.0-r3.zip
         filename=mingw64.zip

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -50,13 +50,14 @@ else
     if [ $small = yes ]; then
         # A special small version of mingw64 that comes with the repo, for people with slow internet.
         # See .github/workflows/windows.yml for code that checks the contents of the zip so that you can trust it.
+        # TODO: this is still LLVM 14
         url=https://akuli.github.io/mingw64-small.zip
         filename=mingw64-small.zip
         sha=4d858bd22f084ae362ee6a22a52c2c5b5281d996f96693984a31336873b92686
     else
-        url=https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.6-10.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-12.1.0-llvm-14.0.6-mingw-w64msvcrt-10.0.0-r3.zip
+        url=https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.7-12.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-llvm-19.1.7-mingw-w64msvcrt-12.0.0-r3.zip
         filename=mingw64.zip
-        sha=9ffef7f7a8dab893bd248085fa81a5a37ed6f775ae220ef673bea8806677836d
+        sha=5937a482247bebc2eca8c0b93fa43ddb17d94968adfff3f2e0c63c94608ee76b
     fi
 
     if [ -z "$offline_mingw64" ]; then

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -83,7 +83,7 @@ else
         mkdir -vp $jou_exe_folder
         unzip -q $filename -d tmp/windows_setup_extracted
         mv tmp/windows_setup_extracted/jou/mingw64 ./
-        mv tmp/windows_setup_extracted/jou/libLLVM*.dll mingw64/bin/
+        mv tmp/windows_setup_extracted/jou/*.dll mingw64/bin/  # will be in PATH while developing
         mv tmp/windows_setup_extracted/jou/jou.exe $jou_exe_folder/
         rm -rf tmp/windows_setup_extracted
     else

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -27,13 +27,15 @@ while [ $# != 0 ]; do
             echo "\
 Usage: $0 [--small] [--offline-mingw64 path/to/file.zip]
 
-  --small                 Use this if you have slow internet. See
-                          CONTRIBUTING.md for a detailed explanation
-                          about what this does.
+  --small
+        Use this if you have slow internet. See CONTRIBUTING.md for a detailed
+        explanation about what this does.
 
-  --offline-zip <path>    Path to already downloaded file. Used to set
-                          up a Jou dev environment on a system with no
-                          internet connection.
+  --offline-zip <path/to/file.zip>
+        Usually this script downloads one zip file, but if this option is used,
+        nothing will be downloaded from internet. The file is instead copied
+        from the given path. This can be used to set up a Jou dev environment
+        on a system with no internet connection.
 "
             exit 2
     esac

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -11,7 +11,7 @@ if ! [[ "$OS" =~ Windows ]]; then
 fi
 
 small=no
-offline_mingw64=
+offline_zip=
 
 while [ $# != 0 ]; do
     case "$1" in
@@ -19,15 +19,22 @@ while [ $# != 0 ]; do
             small=yes
             shift
             ;;
-        --offline-mingw64)
-            offline_mingw64="$2"
+        --offline-zip)
+            offline_zip="$2"
             shift 2
             ;;
         *)
-            echo "Usage: $0 [--small] [--offline-mingw64 path/to/file.zip]"
-            echo ""
-            echo "  --small                     Use this if you have slow internet"
-            echo "  --offline-mingw64 <path>    Use this on systems with no internet"
+            echo "\
+Usage: $0 [--small] [--offline-mingw64 path/to/file.zip]
+
+  --small                 Use this if you have slow internet. See
+                          CONTRIBUTING.md for a detailed explanation
+                          about what this does.
+
+  --offline-zip <path>    Path to already downloaded file. Used to set
+                          up a Jou dev environment on a system with no
+                          internet connection.
+"
             exit 2
     esac
 done
@@ -63,12 +70,12 @@ else
         sha=5937a482247bebc2eca8c0b93fa43ddb17d94968adfff3f2e0c63c94608ee76b
     fi
 
-    if [ -z "$offline_mingw64" ]; then
+    if [ -z "$offline_zip" ]; then
         echo "Downloading $filename..."
         curl -L -o $filename $url
     else
-        echo "Copying $offline_mingw64 to ./$filename..."
-        cp "$offline_mingw64" "$filename"
+        echo "Copying $offline_zip to ./$filename..."
+        cp "$offline_zip" "$filename"
     fi
 
     echo "Verifying $filename..."

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -59,13 +59,13 @@ else
     if [ $small = yes ]; then
         # User has slow internet and doesn't want to download the whole mingw64 (about 1GB).
         # Instead, download a release of Jou (about 50MB), and extract mingw and Jou compiler from there.
-        url=https://github.com/Akuli/jou/releases/download/2025-04-08-2000/jou_windows_64bit_2025-04-08-2000.zip
-        filename=jou_windows_64bit_2025-04-08-2000.zip
-        sha=da9fc23e0ee270d176171d2370d25abe42d09895cc69ae531f6d714398039eb9
+        url=https://github.com/Akuli/jou/releases/download/2025-04-08-2200/jou_windows_64bit_2025-04-08-2200.zip
+        filename=jou_windows_64bit_2025-04-08-2200.zip
+        sha=2945093e2ef7229729f010e45aac9bbe4635a4ee1289857d6aa0cdfb81b0d24b
         # This is the folder where the downloaded Jou compiler (jou.exe) will go.
         # Placing it here makes bootstrap.sh use our downloaded Jou compiler
         # instead of starting from scratch.
-        jou_exe_folder=tmp/bootstrap_cache/016_212db69885bd1f18e7fa67458110b81b3b1cd812
+        jou_exe_folder=tmp/bootstrap_cache/016_98c5fb2792eaac8bbe7496a176808d684f631d82
     else
         url=https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.7-12.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-llvm-19.1.7-mingw-w64msvcrt-12.0.0-r3.zip
         filename=mingw64.zip

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -92,33 +92,6 @@ else
     rm $filename
 fi
 
-# Blog post that explains how .a library is generated from dll file on Windows:
-# https://dev.my-gate.net/2018/06/02/generate-a-def-file-from-a-dll/
-#
-# A simple "grep -r LLVMCreatePassManager" reveals that only libLLVMCore.dll
-# contains the functions we need, so we generate a corresponding .a file.
-# There are also a few other files that I found similarly.
-mkdir -vp libs
-echo "Generating .a files (this can take a while)"
-# Please keep in sync with compiler/llvm.jou
-for name in \
-        libLLVMCore libLLVMX86CodeGen libLLVMAnalysis libLLVMTarget \
-        libLLVMPasses libLLVMSupport libLLVMLinker libLTO libLLVMX86AsmParser \
-        libLLVMX86Info libLLVMX86Desc
-do
-    if [ -f libs/$name.a ]; then
-        echo "  libs/$name.a has already been generated."
-    else
-        echo "  Generating libs/$name.a..."
-        cd libs
-        ../mingw64/bin/gendef.exe ../mingw64/bin/$name.dll
-        ../mingw64/bin/dlltool.exe -d $name.def -l $name.a
-        rm $name.def
-        cd ..
-        echo "    done"
-    fi
-done
-
 echo ""
 echo ""
 echo ""

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -52,7 +52,7 @@ else
         # Instead, download a release of Jou (about 50MB), and extract mingw and Jou compiler from there.
         url=https://github.com/Akuli/jou/releases/download/2025-04-08-1600/jou_windows_64bit_2025-04-08-1600.zip
         filename=jou_windows_64bit_2025-04-08-1600.zip
-        sha=4d858bd22f084ae362ee6a22a52c2c5b5281d996f96693984a31336873b92686
+        sha=50b85b43aa3fc7055df4a85d8650d47b8de3700f86b371337f9f7daf99d86f4b
         # This is the folder where the downloaded Jou compiler (jou.exe) will go.
         # Placing it here makes bootstrap.sh use our downloaded Jou compiler
         # instead of starting from scratch.

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -48,12 +48,15 @@ else
     # This is due to opaque pointer types. Scroll down to "Version Support" here: https://llvm.org/docs/OpaquePointers.html
     # All WinLibs versions and download links: https://winlibs.com/
     if [ $small = yes ]; then
-        # A special small version of mingw64 that comes with the repo, for people with slow internet.
-        # See .github/workflows/windows.yml for code that checks the contents of the zip so that you can trust it.
-        # TODO: this is still LLVM 14
-        url=https://akuli.github.io/mingw64-small.zip
-        filename=mingw64-small.zip
+        # User has slow internet and doesn't want to download the whole mingw64 (about 1GB).
+        # Instead, download a release of Jou (about 50MB), and extract mingw and Jou compiler from there.
+        url=https://github.com/Akuli/jou/releases/download/2025-04-08-1600/jou_windows_64bit_2025-04-08-1600.zip
+        filename=jou_windows_64bit_2025-04-08-1600.zip
         sha=4d858bd22f084ae362ee6a22a52c2c5b5281d996f96693984a31336873b92686
+        # This is the folder where the downloaded Jou compiler (jou.exe) will go.
+        # Placing it here makes bootstrap.sh use our downloaded Jou compiler
+        # instead of starting from scratch.
+        jou_exe_folder=tmp/bootstrap_cache/016_6f6622072f6b3a321e53619606dcc09a82c8232c
     else
         url=https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.7-12.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-llvm-19.1.7-mingw-w64msvcrt-12.0.0-r3.zip
         filename=mingw64.zip
@@ -75,7 +78,17 @@ else
     fi
 
     echo "Extracting $filename..."
-    unzip -q $filename
+    if [ $small = yes ]; then
+        mkdir -vp tmp
+        mkdir -vp $jou_exe_folder
+        unzip -q $filename -d tmp/windows_setup_extracted
+        mv tmp/windows_setup_extracted/jou/mingw64 ./
+        mv tmp/windows_setup_extracted/jou/libLLVM*.dll mingw64/bin/
+        mv tmp/windows_setup_extracted/jou/jou.exe $jou_exe_folder/
+        rm -rf tmp/windows_setup_extracted
+    else
+        unzip -q $filename
+    fi
     rm $filename
 fi
 


### PR DESCRIPTION
Old implementation: Download `akuli.github.io/mingw-small.zip` instead of the full mingw64. There was a CI check that was supposed to convince users that the zip file is safe, but I don't think it was very helpful. You basically had to trust something I created by hand on my computer.

New implementation: Download a release of Jou.