### PR TITLE
Add User-Agent header to check-markdown-links.py

### DIFF
--- a/check-markdown-links.py
+++ b/check-markdown-links.py
@@ -42,13 +42,14 @@ def find_links_in_file(markdown_file_path):
 
 @cache
 def check_https_link(url):
-    # TODO: delete when Advent of Code stops returning 403 for our requests
-    if "adventofcode.com" in url:
-        return "ok"
+    # Give website owners some sort of idea why we are doing these requests.
+    headers = {
+        "User-Agent": "check-markdown-links.py/1.0 (+https://github.com/Akuli/jou)"
+    }
 
     try:
         # Many sites redirect to front page for bad URLs. Let's not treat that as ok.
-        response = requests.head(url, timeout=10, allow_redirects=False)
+        response = requests.head(url, timeout=10, allow_redirects=False, headers=headers)
     except requests.exceptions.RequestException as e:
         return f"HTTP HEAD request failed: {e}"
 


### PR DESCRIPTION
For two reasons:
1. It is good if website owners can look at their server logs to figure out why I'm doing these requests, and contact me if they want me to stop
2. The default user-agent `python-requests/x.y.z` (x.y.z = version number) is often banned, e.g. advent of code