### PR TITLE
Add fixed-size integer types

### DIFF
--- a/compiler/typecheck/common.jou
+++ b/compiler/typecheck/common.jou
@@ -76,6 +76,14 @@ def type_from_ast(ft: FileTypes*, containing_class: Type*, asttype: AstType*) ->
                     return longType
                 case "byte":
                     return byteType
+                case "int8" | "uint8" | "int16" | "uint16" | "int32" | "uint32" | "int64" | "uint64":
+                    if starts_with(asttype->name, "int"):
+                        signed = True
+                        bits = atoi(&asttype->name[3])  # skip "int"
+                    else:
+                        signed = False
+                        bits = atoi(&asttype->name[4])  # skip "uint"
+                    return get_integer_type(bits, signed)
                 case "bool":
                     return boolType
                 case "float":

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -358,8 +358,8 @@ def init_types() -> None:
         global_type_state.integers[size][0].type.size_in_bits = size
         global_type_state.integers[size][1].type.size_in_bits = size
 
-        sprintf(global_type_state.integers[size][0].type.name, "<%d-bit unsigned integer>", size)
-        sprintf(global_type_state.integers[size][1].type.name, "<%d-bit signed integer>", size)
+        sprintf(global_type_state.integers[size][0].type.name, "uint%d", size)
+        sprintf(global_type_state.integers[size][1].type.name, "int%d", size)
 
     strcpy(global_type_state.integers[8][0].type.name, "byte")
     strcpy(global_type_state.integers[16][1].type.name, "short")

--- a/doc/types.md
+++ b/doc/types.md
@@ -46,9 +46,6 @@ which is basically C's way to say "64-bit number".
 Do not use `%ld` or `%lu`, because
 it prints a 32-bit value on Windows and a 64-bit value on most other systems.
 
-Support for other combinations of sizes and signed/unsigned is planned, but not implemented.
-See [issue #164](https://github.com/Akuli/jou/issues/164).
-
 
 ## Floating-point numbers
 

--- a/doc/types.md
+++ b/doc/types.md
@@ -5,22 +5,46 @@ This page documents all types in the Jou programming language.
 
 ## Integers
 
-| Name      | Example   | Size              | Signed?   | How to print  | Min value                     | Max value                     |
-|-----------|-----------|-------------------|-----------|---------------|-------------------------------|-------------------------------|
-| `byte`    | `'a'`     | 1 byte (8 bits)   | unsigned  | `%d`          | `0`                           | `255`                         |
-| `short`   | `1234S`   | 2 bytes (16 bits) | signed    | `%d`          | `-32_768`                     | `32_767`                      |
-| `int`     | `1234`    | 4 bytes (32 bits) | signed    | `%d`          | `-2_147_483_648`              | `2_147_483_647`               |
-| `long`    | `1234L`   | 8 bytes (64 bits) | signed    | `%lld`        | `-9_223_372_036_854_775_808`  | `9_223_372_036_854_775_807`   |
+Jou has the following signed integer types:
 
-Integers in Jou code may contain underscores.
+| Name              | Example       | Size              | How to print  | Min value                     | Max value                     |
+|-------------------|---------------|-------------------|---------------|-------------------------------|-------------------------------|
+| `int8`            | `123 as int8` | 1 byte (8 bits)   | `%d`          | `-128`                        | `127`                         |
+| `int16` or `short`| `123S`        | 2 bytes (16 bits) | `%d`          | `-32_768`                     | `32_767`                      |
+| `int32` or `int`  | `123`         | 4 bytes (32 bits) | `%d`          | `-2_147_483_648`              | `2_147_483_647`               |
+| `int64` or `long` | `123L`        | 8 bytes (64 bits) | `%lld`        | `-9_223_372_036_854_775_808`  | `9_223_372_036_854_775_807`   |
+
+And the following unsigned integer types:
+
+| Name              | Example           | Size              | How to print  | Min value | Max value                     |
+|-------------------|-------------------|-------------------|---------------|-----------|-------------------------------|
+| `uint8` or `byte` | `'a'`             | 1 byte (8 bits)   | `%d`          | `0`       | `255`                         |
+| `uint16`          | `123 as uint16`   | 2 bytes (16 bits) | `%d`          | `0`       | `65_535`                      |
+| `uint32`          | `123 as uint32`   | 4 bytes (32 bits) | `%u`          | `0`       | `4_294_967_295`               |
+| `uint64`          | `123 as uint64`   | 8 bytes (64 bits) | `%llu`        | `0`       | `18_446_744_073_709_551_615`  |
+
+For convenience, the most commonly used types have simpler names
+`byte` always means same as `uint8`,
+`short` always means same as `uint16`,
+`int` always means same as `int32`, and
+`long` always means same as `int64`.
+
+Values of integers in Jou code may contain underscores.
 They are ignored, but they often make large numbers much more readable.
 
 Integers wrap around if you exceed their minimum/maximum values.
 For example, `(0 as byte) - (1 as byte)` produces `255 as byte`.
 It is not possible to invoke [UB](ub.md) by overflowing integers.
 
-When printing, `%d` can be used for anything smaller than `int`,
-because numbers smaller than `int` are automatically converted to `int`.
+When printing, `%d` can be used for anything smaller than 32 bits,
+because values smaller than `int` are automatically converted to `int`.
+With 32-bit and 64-bit values, you need to be more careful:
+use `u` for unsigned and add `ll` for 64-bit values.
+
+The `ll` in `%lld` and `%llu` is short for "long long",
+which is basically C's way to say "64-bit number".
+Do not use `%ld` or `%lu`, because
+it prints a 32-bit value on Windows and a 64-bit value on most other systems.
 
 Support for other combinations of sizes and signed/unsigned is planned, but not implemented.
 See [issue #164](https://github.com/Akuli/jou/issues/164).

--- a/tests/should_succeed/fixed_size_types.jou
+++ b/tests/should_succeed/fixed_size_types.jou
@@ -1,0 +1,43 @@
+import "stdlib/io.jou"
+
+
+# This ensures that int32 can be passed to a function that expects int
+def print_ints(a: int, b: int) -> None:
+    printf("%d %d\n", a, b)
+
+
+def main() -> int:
+    # Sizes in bytes
+    signed8: int8 = 'x' as int8
+    unsigned8: uint8 = 'x'
+    signed16: int16 = 1234S
+    unsigned16: uint16 = 1234S as uint16
+    signed32: int32 = 1234567890
+    unsigned32: uint32 = 1234567890 as uint32
+    signed64: int64 = 123456789123456789L
+    unsigned64: uint64 = 123456789123456789L as uint64
+
+    printf("%lld %lld\n", sizeof(signed8), sizeof(unsigned8))  # Output: 1 1
+    printf("%lld %lld\n", sizeof(signed16), sizeof(unsigned16))  # Output: 2 2
+    printf("%lld %lld\n", sizeof(signed32), sizeof(unsigned32))  # Output: 4 4
+    printf("%lld %lld\n", sizeof(signed64), sizeof(unsigned64))  # Output: 8 8
+
+    # byte and uint8 are the same
+    b: byte = 'y'
+    unsigned8 = b
+    b = unsigned8
+    printf("%c%c\n", b, unsigned8)  # Output: yy
+
+    # int and int32 are the same
+    n: int = 123
+    signed32 = n
+    n = signed32
+    print_ints(n, signed32)  # Output: 123 123
+
+    # long and int64 are the same
+    big: long = 123123123123123L
+    signed64 = big
+    big = signed64
+    printf("%lld %lld\n", big, big)  # Output: 123123123123123 123123123123123
+
+    return 0

--- a/tests/should_succeed/sizeof.jou
+++ b/tests/should_succeed/sizeof.jou
@@ -27,7 +27,6 @@ def main() -> int:
     by: byte
     n: int
     m: long
-
     printf("%lld %lld %lld %lld\n", sizeof bo, sizeof by, sizeof n, sizeof m)  # Output: 1 1 4 8
 
     # test that operator precedence works

--- a/tests/wrong_type/uint16_instead_of_byte.jou
+++ b/tests/wrong_type/uint16_instead_of_byte.jou
@@ -1,0 +1,11 @@
+def want_int(n: int) -> None:
+    pass
+
+def want_byte(b: byte) -> None:
+    pass
+
+def main() -> int:
+    n = 123 as uint16
+    want_int(n)
+    want_byte(n)  # Error: first argument of function want_byte(b: byte) should have type byte, not uint16
+    return 0


### PR DESCRIPTION
Adds 8 new types to the Jou language:
- `int8`
- `uint8` (same as `byte`)
- `int16` (same as `short`)
- `uint16` 
- `int32` (same as `int`)
- `uint32`
- `int64` (same as `long`)
- `uint64`

Fixes #164