### PR TITLE
Support `.a` output files

### DIFF
--- a/Makefile.posix
+++ b/Makefile.posix
@@ -28,6 +28,8 @@ config.jou: Makefile.posix
 	echo 'link "$(shell $(LLVM_CONFIG) --ldflags --libs)"' >> config.jou
 	echo '@public' >> config.jou
 	echo 'const JOU_CLANG_PATH: byte* = "$(shell which `$(LLVM_CONFIG) --bindir`/clang || which clang)"' >> config.jou
+	echo '@public' >> config.jou
+	echo 'const JOU_AR_PATH: byte* = "$(shell which `$(LLVM_CONFIG) --bindir`/llvm-ar || which ar)"' >> config.jou
 
 jou_bootstrap: bootstrap.sh
 	env LLVM_CONFIG=$(LLVM_CONFIG) ./bootstrap.sh

--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -492,10 +492,19 @@ def main(argc: int, argv: byte**) -> int:
     compst.free()
     free(stdlib)
 
-    exepath = decide_exe_path()
-    run_linker(objpaths, exepath, linker_flags)
-    free(linker_flags)
+    exepath: byte* = NULL
+    if (
+        command_line_args.outfile != NULL
+        and strlen(command_line_args.outfile) > 2
+        and ends_with(command_line_args.outfile, ".a")
+    ):
+        # Output .a file instead of executable
+        run_ar(objpaths, command_line_args.outfile)
+    else:
+        exepath = decide_exe_path()
+        run_linker(objpaths, exepath, linker_flags)
 
+    free(linker_flags)
     for p = objpaths.ptr; p < objpaths.end(); p++:
         free(*p)
     free(objpaths.ptr)

--- a/compiler/run.jou
+++ b/compiler/run.jou
@@ -28,12 +28,10 @@ def quote_paths(paths: List[byte*]) -> byte*:
     return result
 
 
-@public
-def run_linker(objpaths: List[byte*], exepath: byte*, linker_flags: byte*) -> None:
-    quoted_object_files = quote_paths(objpaths)
-
-    command: byte*
-    if WINDOWS:
+# On Linux, we prefer LLVM tools (clang and llvm-ar) of the same LLVM version.
+# On Windows, the tools are in mingw64/bin folder.
+if WINDOWS:
+    def get_mingw_command(exe_filename: byte*, args: byte*) -> byte*:
         # Assume mingw with clang has been downloaded with windows_setup.sh.
         #
         # During the bootstrapping, the location of mingw is something
@@ -49,15 +47,27 @@ def run_linker(objpaths: List[byte*], exepath: byte*, linker_flags: byte*) -> No
             asprintf(&mingw_dir, "%s\\mingw64", dirname(jou_exe))
             free(jou_exe)
 
-        # Could also use clang, but gcc has less dependencies so we can make the Windows zips smaller.
-        # Windows quoting is weird. The outermost quotes get stripped here.
-        asprintf(&command, "\"\"%s\\bin\\gcc.exe\" %s -o \"%s\" %s\"", mingw_dir, quoted_object_files, exepath, linker_flags)
-        free(mingw_dir)
-    else:
-        # Assume clang is installed and use it to link. Could use lld, but clang is needed anyway.
-        asprintf(&command, "'%s' %s -o '%s' %s", JOU_CLANG_PATH, quoted_object_files, exepath, linker_flags)
+        result: byte*
 
+        # Windows quoting is weird. The outermost quotes get stripped here.
+        asprintf(&result, "\"\"%s\\bin\\%s\" %s\"", exe_filename, args)
+
+
+@public
+def run_linker(objpaths: List[byte*], exepath: byte*, linker_flags: byte*) -> None:
+    quoted_object_files = quote_paths(objpaths)
+
+    args: byte*
+    asprintf(&args, "%s -o \"%s\" %s", quoted_object_files, exepath, linker_flags)
     free(quoted_object_files)
+
+    command: byte*
+    if WINDOWS:
+        # Could also use clang, but gcc has less dependencies so we can make the Windows zips smaller.
+        command = get_mingw_command("gcc.exe", args)
+    else:
+        asprintf(&command, "'%s' %s", JOU_CLANG_PATH, args)
+    free(args)
 
     if command_line_args.verbosity >= 1:
         printf("Running linker: %s\n", command)

--- a/compiler/run.jou
+++ b/compiler/run.jou
@@ -78,6 +78,30 @@ def run_linker(objpaths: List[byte*], exepath: byte*, linker_flags: byte*) -> No
 
 
 @public
+def run_ar(objpaths: List[byte*], a_path: byte*) -> None:
+    assert ends_with(a_path, ".a")
+    quoted_object_files = quote_paths(objpaths)
+
+    args: byte*
+    asprintf(&args, "rcs \"%s\" %s", a_path, quoted_object_files)
+    free(quoted_object_files)
+
+    command: byte*
+    if WINDOWS:
+        command = get_mingw_command("ar.exe", args)
+    else:
+        asprintf(&command, "'%s' %s", JOU_AR_PATH, args)
+    free(args)
+
+    if command_line_args.verbosity >= 1:
+        printf("Running ar: %s\n", command)
+
+    if system(command) != 0:
+        exit(1)
+    free(command)
+
+
+@public
 def run_exe(exepath: byte*, valgrind: bool) -> int:
     command: byte*
     if WINDOWS:


### PR DESCRIPTION
This makes it easy to sprinkle a little bit of Jou code into a project written in C. If you do `-o foo.a` when compiling Jou code, `foo.a` will contain object files for your program and whatever it uses from the Jou standard library.

For example, I placed this to `test.jou`:

```python
import "stdlib/io.jou"
import "stdlib/list.jou"
import "stdlib/mem.jou"


def main() -> int:
    args = List[byte*]{}
    args.append("Hello")
    args.append(" ")
    args.append("World!")
    args.append("\n")

    for i = 0; i < args.len; i++:
        printf("%s", args.ptr[i])

    free(args.ptr)
    return 0
```

And compiled it to `.a` and gave that to a C compiler:

```
akuli@akuli-desktop:~/jou$ jou -o test.a test.jou
akuli@akuli-desktop:~/jou$ file test.a
test.a: current ar archive
akuli@akuli-desktop:~/jou$ cc test.a
akuli@akuli-desktop:~/jou$ ./a.out
Hello World!
```

Here's what ended up in the `.a` file:

```
akuli@akuli-desktop:~/jou$ ar t test.a
_assert_fail_6462dea0597d2c04_75f89d3cb3be1ebe.o
test_dce56ce79d1cbb8c_c159ba627f5e1510.o
io_113a41539cd5dd30_ad9ac958397bd736.o
list_665829f653098331_b202293f74d46422.o
mem_1d45d615c5de45c1_4e6b4fbee1296e6b.o
```

If the Jou code contains `link` statements, you will need to specify the corresponding flags when compiling the `.a` file with a C compiler:

```
akuli@akuli-desktop:~/jou$ jou -o compiler.a compiler/main.jou 
akuli@akuli-desktop:~/jou$ cc compiler.a -L/usr/lib/llvm-19/lib -lLLVM-19
akuli@akuli-desktop:~/jou$ ./a.out examples/hello.jou 
Hello World
```