### PR TITLE
When developing Jou compiler, don't recompile from scratch every time

### DIFF
--- a/Makefile.posix
+++ b/Makefile.posix
@@ -33,7 +33,7 @@ jou_bootstrap: bootstrap.sh
 	env LLVM_CONFIG=$(LLVM_CONFIG) ./bootstrap.sh
 
 jou: jou_bootstrap config.jou $(wildcard compiler/*.jou compiler/*/*.jou)
-	rm -rf compiler/jou_compiled && ./jou_bootstrap -o jou compiler/main.jou
+	./jou_bootstrap -o jou compiler/main.jou
 
 # Does not delete tmp/bootstrap_cache because bootstrapping is slow.
 .PHONY: clean

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -4,7 +4,7 @@ jou_bootstrap.exe: bootstrap.sh
 	bash ./bootstrap.sh
 
 jou.exe: jou_bootstrap.exe $(wildcard compiler/*.jou compiler/*/*.jou)
-	rm -rf compiler/jou_compiled && ./jou_bootstrap.exe -o jou.exe compiler/main.jou
+	./jou_bootstrap.exe -o jou.exe compiler/main.jou
 
 # Does not delete tmp/bootstrap_cache because bootstrapping is slow.
 .PHONY: clean


### PR DESCRIPTION
Basically applies #847 to developing the Jou compiler. Recompiling after a simple change now takes 1 second instead of 8 seconds.