### PR TITLE
Delete the `short` data type

### DIFF
--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -297,7 +297,6 @@ class Parser:
             or self->tokens->is_keyword("None")
             or self->tokens->is_keyword("void")
             or self->tokens->is_keyword("noreturn")
-            or self->tokens->is_keyword("short")
             or self->tokens->is_keyword("int")
             or self->tokens->is_keyword("long")
             or self->tokens->is_keyword("byte")

--- a/compiler/tokenizer.jou
+++ b/compiler/tokenizer.jou
@@ -25,7 +25,7 @@ def is_keyword(word: byte*) -> bool:
             | "return" | "if" | "elif" | "else" | "while" | "for" | "pass" | "break" | "continue"
             | "True" | "False" | "None" | "NULL" | "void" | "noreturn"
             | "and" | "or" | "not" | "self" | "as" | "sizeof" | "assert"
-            | "bool" | "byte" | "short" | "int" | "long" | "float" | "double" | "match" | "with" | "case"
+            | "bool" | "byte" | "int" | "long" | "float" | "double" | "match" | "with" | "case"
         ):
             return True
         case _:

--- a/compiler/typecheck/common.jou
+++ b/compiler/typecheck/common.jou
@@ -68,8 +68,6 @@ def type_from_ast(ft: FileTypes*, containing_class: Type*, asttype: AstType*) ->
     match asttype->kind:
         case AstTypeKind.Named:
             match asttype->name with strcmp:
-                case "short":
-                    return shortType
                 case "int":
                     return intType
                 case "long":

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -318,8 +318,6 @@ global global_type_state: GlobalTypeState
 @public
 global boolType: Type*      # bool
 @public
-global shortType: Type*     # short (16-bit signed)
-@public
 global intType: Type*       # int (32-bit signed)
 @public
 global longType: Type*      # long (64-bit signed)
@@ -364,7 +362,6 @@ def init_types() -> None:
         sprintf(global_type_state.integers[size][1].type.name, "int%d", size)
 
     strcpy(global_type_state.integers[8][0].type.name, "byte")
-    strcpy(global_type_state.integers[16][1].type.name, "short")
     strcpy(global_type_state.integers[32][1].type.name, "int")
     strcpy(global_type_state.integers[64][1].type.name, "long")
 

--- a/doc/compiler_internals/syntax-spec.md
+++ b/doc/compiler_internals/syntax-spec.md
@@ -101,7 +101,6 @@ Jou has a few different kinds of tokens:
     - `assert`
     - `bool`
     - `byte`
-    - `short`
     - `int`
     - `long`
     - `float`

--- a/doc/types.md
+++ b/doc/types.md
@@ -10,7 +10,7 @@ Jou has the following signed integer types:
 | Name              | Size              | How to print  | Min value                     | Max value                     |
 |-------------------|-------------------|---------------|-------------------------------|-------------------------------|
 | `int8`            | 1 byte (8 bits)   | `%d`          | `-128`                        | `127`                         |
-| `int16` or `short`| 2 bytes (16 bits) | `%d`          | `-32_768`                     | `32_767`                      |
+| `int16`           | 2 bytes (16 bits) | `%d`          | `-32_768`                     | `32_767`                      |
 | `int32` or `int`  | 4 bytes (32 bits) | `%d`          | `-2_147_483_648`              | `2_147_483_647`               |
 | `int64` or `long` | 8 bytes (64 bits) | `%lld`        | `-9_223_372_036_854_775_808`  | `9_223_372_036_854_775_807`   |
 
@@ -25,7 +25,6 @@ And the following unsigned integer types:
 
 For convenience, the most commonly used types have simpler names
 `byte` always means same as `uint8`,
-`short` always means same as `uint16`,
 `int` always means same as `int32`, and
 `long` always means same as `int64`.
 

--- a/tests/should_succeed/printf.jou
+++ b/tests/should_succeed/printf.jou
@@ -3,9 +3,9 @@ import "stdlib/str.jou"
 
 def main() -> int:
     printf("Hello world\n")  # Output: Hello world
-    printf("short %hd\n", 11451 as short) # Output: short 11451
-    printf("number %d\n", 123)  # Output: number 123
-    printf("long %lld\n", 123451234512345 as long)  # Output: long 123451234512345
+    printf("16-bit %d\n", 11451 as int16) # Output: 16-bit 11451
+    printf("32-bit %d\n", 123)  # Output: number 123
+    printf("64-bit %lld\n", 123451234512345 as int64)  # Output: 64-bit 123451234512345
     s = "yo"
     printf("string %s\n", s)  # Output: string yo
     printf("string %s\n", "yo")  # Output: string yo

--- a/tests/should_succeed/printf.jou
+++ b/tests/should_succeed/printf.jou
@@ -4,7 +4,7 @@ import "stdlib/str.jou"
 def main() -> int:
     printf("Hello world\n")  # Output: Hello world
     printf("16-bit %d\n", 11451 as int16) # Output: 16-bit 11451
-    printf("32-bit %d\n", 123)  # Output: number 123
+    printf("32-bit %d\n", 123)  # Output: 32-bit 123
     printf("64-bit %lld\n", 123451234512345 as int64)  # Output: 64-bit 123451234512345
     s = "yo"
     printf("string %s\n", s)  # Output: string yo


### PR DESCRIPTION
Use `int16` instead of `short`. It does the same thing but the name is more explicit.

Also, `short` was never really used anywhere. The main use case I can think of is audio: a typical `.wav` file is a few headers and a big list of 16-bit integers. I haven't done much audio stuff with Jou.

Related to #515 