### PR TITLE
Make the Jou compiler faster

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -35,6 +35,7 @@ commits=(
     98c5fb2792eaac8bbe7496a176808d684f631d82  # "./windows_setup.sh --small" starts from this commit (release 2025-04-08-2200)
     eed3b974ccb42a01339ead7f6dcaa0913ca2cd64  # fixed-size integer types, e.g. uint64
     c594c326d3031a2894731f60ac9881a206793dfa  # infer types of integers in code
+    99de2976a7f3b34ec6b2b07725c5ad1400313dc1  # bitwise xor operator `^`
 )
 
 for commit in ${commits[@]}; do

--- a/compiler/hash.jou
+++ b/compiler/hash.jou
@@ -18,21 +18,6 @@ import "stdlib/str.jou"
 import "./paths.jou"
 
 
-# TODO: xor should be built in to language, not implemented here
-def xor(a: uint64, b: uint64) -> uint64:
-    result = 0 as uint64
-    power_of_two = 1 as uint64
-
-    while a != 0 or b != 0:
-        if a % 2 != b % 2:
-            result += power_of_two
-        a /= 2
-        b /= 2
-        power_of_two *= 2
-
-    return result
-
-
 # Do not instantiate this as `Hash{}`, that uses wrong initial value.
 # Use new_hash() function.
 @public
@@ -43,7 +28,7 @@ class Hash:
     # Add data to hash
     def add_byte(self, b: byte) -> None:
         assert self->created_correctly  # If this fails, use new_hash() function
-        self->hash = xor(self->hash, b)
+        self->hash ^= b
         self->hash *= 0x100_0000_01b3
 
     def add_bytes(self, data: byte*, len: long) -> None:

--- a/compiler/uvg_analyze.jou
+++ b/compiler/uvg_analyze.jou
@@ -15,6 +15,8 @@ enum VarStatus:
     PossiblyUndefined   # Could hold a garbage or non-garbage value.
     DontAnalyze         # The "don't analyze" UVG instruction has been used.
 
+const VAR_STATUS_COUNT: int = 5
+
 
 if False:
     def print_statuses(uvg: Uvg*, statuses: VarStatus*) -> None:
@@ -68,6 +70,23 @@ def merge(a: VarStatus, b: VarStatus) -> VarStatus:
     return VarStatus.PossiblyUndefined
 
 
+# TODO: Not possible to use VAR_STATUS_COUNT as array size yet
+global merge_table: VarStatus[5][5]
+global merge_table_ready: bool
+
+def init_merge_table() -> None:
+    assert VAR_STATUS_COUNT == 5
+
+    if merge_table_ready:
+        return
+
+    for a = 0; a < VAR_STATUS_COUNT; a++:
+        for b = 0; b < VAR_STATUS_COUNT; b++:
+            merge_table[a][b] = merge(a as VarStatus, b as VarStatus)
+
+    merge_table_ready = True
+
+
 def build_statuses_at_end_before_analyzing(uvg: Uvg*) -> VarStatus**:
     # statuses_at_end[b][v] = status of variable v at end of block b
     statuses_at_end: VarStatus** = malloc(sizeof(statuses_at_end[0]) * uvg->blocks.len)
@@ -81,21 +100,29 @@ def build_statuses_at_end_before_analyzing(uvg: Uvg*) -> VarStatus**:
     return statuses_at_end
 
 
-def build_statuses_at_start_of_block(uvg: Uvg*, statuses_at_end: VarStatus**, blockidx: int) -> VarStatus*:
-    statuses: VarStatus* = malloc(sizeof(statuses[0]) * uvg->varnames.len)
-    if uvg->varnames.len != 0:
-        assert statuses != NULL
+@public
+def build_statuses_at_start_of_block(uvg: Uvg*, statuses_at_end: VarStatus**, block: UvgBlock*) -> VarStatus*:
+    n = uvg->varnames.len
+    if n == 0:
+        return NULL
 
-    for v = 0; v < uvg->varnames.len; v++:
-        if blockidx == 0:
-            # The start block, everything is initially undefined
+    statuses: VarStatus* = malloc(sizeof(statuses[0]) * n)
+    assert statuses != NULL
+
+    if block == uvg->blocks.ptr[0]:
+        # The start block, everything is initially undefined
+        for v = 0; v < n; v++:
             statuses[v] = VarStatus.Undefined
-        else:
+    else:
+        for v = 0; v < n; v++:
             statuses[v] = VarStatus.Unvisited
 
-        for b = 0; b < uvg->blocks.len; b++:
-            if uvg->blocks.ptr[b]->jumps_to(uvg->blocks.ptr[blockidx]):
-                statuses[v] = merge(statuses[v], statuses_at_end[b][v])
+    # Merge statuses of source blocks that jump to the current block
+    for b = 0; b < uvg->blocks.len; b++:
+        if uvg->blocks.ptr[b]->jumps_to(block):
+            # This function is O(n^2) but barely so, the following loop should be really fast in practice
+            for v = 0; v < n; v++:
+                statuses[v] = merge_table[statuses_at_end[b][v] as int][statuses[v] as int]
 
     return statuses
 
@@ -132,6 +159,7 @@ def handle_missing_return_statement(uvg: Uvg*, location: Location) -> None:
         show_warning(location, msg)
 
 
+@public
 def update_statuses_based_on_instructions(uvg: Uvg*, statuses: VarStatus*, block: UvgBlock*, warn: bool) -> None:
     msg: byte[500]
 
@@ -165,8 +193,9 @@ def update_statuses_based_on_instructions(uvg: Uvg*, statuses: VarStatus*, block
                 statuses[ins->var] = VarStatus.DontAnalyze
 
 
+@public
 def analyze_block(uvg: Uvg*, statuses_at_end: VarStatus**, blockidx: int, warn: bool) -> bool:
-    statuses = build_statuses_at_start_of_block(uvg, statuses_at_end, blockidx)
+    statuses = build_statuses_at_start_of_block(uvg, statuses_at_end, uvg->blocks.ptr[blockidx])
     update_statuses_based_on_instructions(uvg, statuses, uvg->blocks.ptr[blockidx], warn)
 
     if memcmp(statuses, statuses_at_end[blockidx], sizeof(statuses[0]) * uvg->varnames.len) != 0:
@@ -219,6 +248,8 @@ def mark_reachable_blocks(blocks: List[UvgBlock*], ignore: bool*, marked: bool*,
 
 @public
 def uvg_analyze(uvg: Uvg*) -> None:
+    init_merge_table()
+
     assert uvg->blocks.len >= 1  # must have at least start block
 
     queue: bool* = calloc(sizeof(queue[0]), uvg->blocks.len)

--- a/compiler/uvg_analyze.jou
+++ b/compiler/uvg_analyze.jou
@@ -100,7 +100,6 @@ def build_statuses_at_end_before_analyzing(uvg: Uvg*) -> VarStatus**:
     return statuses_at_end
 
 
-@public
 def build_statuses_at_start_of_block(uvg: Uvg*, statuses_at_end: VarStatus**, block: UvgBlock*) -> VarStatus*:
     n = uvg->varnames.len
     if n == 0:
@@ -159,7 +158,6 @@ def handle_missing_return_statement(uvg: Uvg*, location: Location) -> None:
         show_warning(location, msg)
 
 
-@public
 def update_statuses_based_on_instructions(uvg: Uvg*, statuses: VarStatus*, block: UvgBlock*, warn: bool) -> None:
     msg: byte[500]
 
@@ -193,7 +191,6 @@ def update_statuses_based_on_instructions(uvg: Uvg*, statuses: VarStatus*, block
                 statuses[ins->var] = VarStatus.DontAnalyze
 
 
-@public
 def analyze_block(uvg: Uvg*, statuses_at_end: VarStatus**, blockidx: int, warn: bool) -> bool:
     statuses = build_statuses_at_start_of_block(uvg, statuses_at_end, uvg->blocks.ptr[blockidx])
     update_statuses_based_on_instructions(uvg, statuses, uvg->blocks.ptr[blockidx], warn)


### PR DESCRIPTION
Recompiling the Jou compiler with no changes done to it is now about ~~40%~~ 45% faster. On my ancient laptop, it took 2.8 seconds before and it's now ~~1.7~~ 1.55 seconds.

<details>
<summary>Script used to measure performance</summary>

```
#!/bin/bash
set -ex
make
./jou -o jou2 compiler/main.jou

#valgrind --tool=callgrind ./jou -v -o jou2 compiler/main.jou

(
    for i in $(seq 5); do time ./jou -o jou2 compiler/main.jou; done
) 2>&1 | tr , . | python3 -c '
import re, sys
data = re.findall(r"real\s+0m(.*)s", sys.stdin.read())
print(sum(map(float, data)) / len(data))
'
```

</details>