### PR TITLE
Improve markdown link checker

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,9 +46,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-            python-version: '3.13'
-      - run: pip install requests
-      - run: python check-markdown-links.py --retry=5
+          python-version: '3.13'
+      - name: Cache state file of link checker
+        uses: actions/cache@v3
+        with:
+          path: links.json
+          key: links-${{ hashFiles('check-markdown-links.py') }}
+      - run: pip install requests==2.32.3
+      - run: python check-markdown-links.py
 
   # Run the release script to make sure it doesn't error.
   release-dry-run:

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,8 @@
 # LibreOffice lock file
 .~lock.*#
 
+# State file of check-markdown-links.py, goes to GitHub Actions cache, not committed to Git
+links.json
+
 # Stuff that is no longer a thing but someone might still have locally
 /libs

--- a/check-markdown-links.py
+++ b/check-markdown-links.py
@@ -7,8 +7,6 @@ import os
 import re
 import subprocess
 import sys
-import time
-from functools import cache
 from http.client import responses as status_code_names
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -42,7 +40,6 @@ def find_links_in_file(markdown_file_path):
                 yield (markdown_file_path, lineno, target)
 
 
-@cache
 def check_https_link(url):
     # Give website owners some sort of idea why we are doing these requests.
     headers = {
@@ -112,6 +109,7 @@ def check_link(markdown_file_path, target, offline_mode=False):
             return "assume ok (offline mode)"
         if link_ok_recently(target, timedelta(minutes=1)):
             return "assume ok (was ok less than 1 minute ago)"
+
         result = check_https_link(target)
 
         if result == "ok":

--- a/check-markdown-links.py
+++ b/check-markdown-links.py
@@ -37,7 +37,7 @@ def find_links_in_file(markdown_file_path):
         ]
         for regex in link_regexes:
             for target in re.findall(regex, line):
-                yield (markdown_file_path, lineno, target)
+                yield (lineno, target)
 
 
 def check_https_link(url):
@@ -159,21 +159,11 @@ def main():
     )
     args = parser.parse_args()
 
-    remaining_links = []
-    for path in find_markdown_files():
-        for link in find_links_in_file(path):
-            remaining_links.append(link)
-
-    if not remaining_links:
-        print("Error: no links found")
-        sys.exit(1)
-
     good_links = 0
     bad_links = 0
 
     for path in find_markdown_files():
-        for link in find_links_in_file(path):
-            path, lineno, target = link
+        for lineno, target in find_links_in_file(path):
             result = check_link(path, target, offline_mode=args.offline)
             print(f"{path}:{lineno}: {result}")
             if result == "ok" or result.startswith("assume ok"):
@@ -181,7 +171,10 @@ def main():
             else:
                 bad_links += 1
 
-    assert good_links + bad_links > 0
+    if good_links + bad_links == 0:
+        print("Error: no links found")
+        sys.exit(1)
+
     print()
     print(f"checked {good_links + bad_links} links: {good_links} good, {bad_links} bad")
     if bad_links > 0:

--- a/check-markdown-links.py
+++ b/check-markdown-links.py
@@ -1,5 +1,5 @@
 """Check that links in markdown files point to reasonable places."""
-# Get from https://github.com/Akuli/porcupine/
+# There is a similar script in https://github.com/Akuli/porcupine/
 
 import argparse
 import json


### PR DESCRIPTION
- Do not complain if a link has been down for less than 3 days.
- Delete the retrying logic. It is no longer needed.
- Use a hard-coded/pinned version of Python's `requests` library. This is better for security (although `requests` is very unlikely to get hacked) and makes the check less likely to break by itself.