### PR TITLE
Add compile-time asserts

### DIFF
--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -64,7 +64,7 @@ def statement_conflicts_with_an_import(stmt: AstStatement*, importsym: ExportSym
                 importsym->kind == ExportSymbolKind.Type
                 and strcmp(importsym->name, stmt->enumdef.name) == 0
             )
-        case AstStatementKind.Import | AstStatementKind.Link | AstStatementKind.Pass:
+        case AstStatementKind.Import | AstStatementKind.Link | AstStatementKind.Pass | AstStatementKind.Assert:
             return False
         case _:
             printf("%d\n", stmt->kind as int)

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -907,7 +907,11 @@ class Parser:
                 result.return_value = malloc(sizeof *result.return_value)
                 *result.return_value = self->parse_expression()
         elif self->tokens->is_keyword("assert"):
-            self->check_function_or_method("'assert'")
+            match self->what_are_we_parsing:
+                case WhatAreWeParsing.FunctionBody | WhatAreWeParsing.MethodBody | WhatAreWeParsing.TopLevel:
+                    pass
+                case WhatAreWeParsing.ClassBody:
+                    fail(self->tokens->location, "'assert' cannot be placed inside a class unless it is inside a method")
             self->tokens++
             result.kind = AstStatementKind.Assert
             start = self->tokens->location

--- a/compiler/typecheck/step2_populate_types.jou
+++ b/compiler/typecheck/step2_populate_types.jou
@@ -219,7 +219,7 @@ def typecheck_step2_populate_types(ast: AstFile*) -> List[ExportSymbol]:
 
     for stmt = ast->body.ptr; stmt < ast->body.end(); stmt++:
         match stmt->kind:
-            case AstStatementKind.Import | AstStatementKind.Pass:
+            case AstStatementKind.Import | AstStatementKind.Pass | AstStatementKind.Assert:
                 pass
             case AstStatementKind.GlobalVariableDeclare:
                 exp = handle_global_var(&ast->types, stmt->location, stmt->global_var_declare.name, &stmt->global_var_declare.type, &stmt->global_var_declare.used)

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -1460,5 +1460,17 @@ def typecheck_step3_function_and_method_bodies(ast: AstFile*) -> None:
                 for inner = stmt->classdef.body.ptr; inner < stmt->classdef.body.end(); inner++:
                     if inner->kind == AstStatementKind.MethodDef:
                         typecheck_function_or_method_body(&state, &inner->method)
+            case AstStatementKind.Assert:
+                c: Constant
+                if not evaluate_constant_expression(&stmt->assertion.condition, &c, boolType):
+                    # TODO: test this
+                    fail(stmt->location, "cannot evaluate assertion at compile time")
+                if c.get_type() != boolType:
+                    # TODO: test this
+                    msg: byte[500]
+                    snprintf(msg, sizeof(msg), "assertion must be a bool, not %s", c.get_type()->name)
+                    fail(stmt->location, msg)
+                if not c.boolean:
+                    fail(stmt->location, "assertion is False")
             case _:
                 pass

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -1463,7 +1463,6 @@ def typecheck_step3_function_and_method_bodies(ast: AstFile*) -> None:
             case AstStatementKind.Assert:
                 c: Constant
                 if not evaluate_constant_expression(&stmt->assertion.condition, &c, boolType):
-                    # TODO: test this
                     fail(stmt->location, "cannot evaluate assertion at compile time")
                 if c.get_type() != boolType:
                     # TODO: test this

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -1465,7 +1465,6 @@ def typecheck_step3_function_and_method_bodies(ast: AstFile*) -> None:
                 if not evaluate_constant_expression(&stmt->assertion.condition, &c, boolType):
                     fail(stmt->location, "cannot evaluate assertion at compile time")
                 if c.get_type() != boolType:
-                    # TODO: test this
                     msg: byte[500]
                     snprintf(msg, sizeof(msg), "assertion must be a bool, not %s", c.get_type()->name)
                     fail(stmt->location, msg)

--- a/tests/other_errors/assert_cannot_compile_time_evaluate.jou
+++ b/tests/other_errors/assert_cannot_compile_time_evaluate.jou
@@ -1,0 +1,1 @@
+assert lol == wat  # Error: cannot evaluate assertion at compile time

--- a/tests/other_errors/assert_fail_compile_time.jou
+++ b/tests/other_errors/assert_fail_compile_time.jou
@@ -1,0 +1,1 @@
+assert WINDOWS and MACOS  # Error: assertion is False

--- a/tests/should_succeed/assert_success.jou
+++ b/tests/should_succeed/assert_success.jou
@@ -1,5 +1,7 @@
 import "stdlib/io.jou"
 
+assert WINDOWS or not WINDOWS
+
 def main() -> int:
     assert True
     assert 1 == 1

--- a/tests/wrong_place/assert_in_class_body.jou
+++ b/tests/wrong_place/assert_in_class_body.jou
@@ -1,0 +1,2 @@
+class Foo:
+    assert 1 + 2 == 3  # Error: 'assert' cannot be placed inside a class unless it is inside a method

--- a/tests/wrong_place/assert_outside_function.jou
+++ b/tests/wrong_place/assert_outside_function.jou
@@ -1,1 +1,0 @@
-assert 1 + 2 == 3  # Error: 'assert' must be inside a function or method

--- a/tests/wrong_type/assert_compile_time.jou
+++ b/tests/wrong_type/assert_compile_time.jou
@@ -1,0 +1,1 @@
+assert 123  # Error: assertion must be a bool, not int


### PR DESCRIPTION
It is now possible to write `assert not WINDOWS` outside a function. This way, you can avoid accidentally importing a Windows-specific module on Linux, for example.

Before it produced the following error:

```
compiler error in file "a.jou", line 1: 'assert' must be inside a function or method
```

This is similar to `static_assert` in C/C++.

Fixes #882.