### PR TITLE
Allow using `.` instead of `->` to look up members from pointers

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -130,7 +130,6 @@ class AstEnumMember:
 @public
 class AstClassField:
     instance: AstExpression*
-    uses_arrow_operator: bool  # distinguishes foo.bar and foo->bar
     field_name: byte[100]
 
     def free(self) -> None:
@@ -179,8 +178,10 @@ enum AstExpressionKind:
     Instantiate   # MyClass{x=1, y=2}
     Self    # not a variable lookup, so you can't use 'self' as variable name outside a class
     GetVariable
-    GetEnumMember
-    GetClassField   # foo.bar, foo->bar
+    DotOperator         # foo.bar (don't know yet which way to interpret it)
+    GetEnumMember       # foo.bar, foo is an enum
+    GetClassField       # foo.bar, foo is an instance of a class
+    GetClassFieldPtr    # foo.bar, foo is a pointer to an instance of a class
     As
     # unary operators
     SizeOf      # sizeof x
@@ -262,6 +263,9 @@ class AstExpression:
                 printf("self\n")
             case AstExpressionKind.GetVariable:
                 printf("get variable \"%s\"\n", self->varname)
+            case AstExpressionKind.DotOperator:
+                printf("get member \"%s\"\n", self->class_field.field_name)
+                self->class_field.instance->print_with_tree_printer(tp.print_prefix(True))
             case AstExpressionKind.GetEnumMember:
                 printf(
                     "get member \"%s\" from enum \"%s\"\n",
@@ -269,10 +273,10 @@ class AstExpression:
                     self->enum_member.enum_name,
                 )
             case AstExpressionKind.GetClassField:
-                printf("get class field \"%s\"", self->class_field.field_name)
-                if self->class_field.uses_arrow_operator:
-                    printf(" with the arrow operator")
-                printf("\n")
+                printf("get class field from instance \"%s\"\n", self->class_field.field_name)
+                self->class_field.instance->print_with_tree_printer(tp.print_prefix(True))
+            case AstExpressionKind.GetClassFieldPtr:
+                printf("get class field from pointer \"%s\"\n", self->class_field.field_name)
                 self->class_field.instance->print_with_tree_printer(tp.print_prefix(True))
             case AstExpressionKind.As:
                 self->as_->print_with_tree_printer(tp)
@@ -433,7 +437,6 @@ class AstCall:
     location: Location
     name: byte[100]  # name of function or method
     method_call_self: AstExpression*  # NULL for function calls, the foo of foo.bar() for method calls
-    uses_arrow_operator: bool  # distinguishes foo->bar() and foo.bar()
     args: List[AstExpression]
     called_signature: Signature*  # populated in typecheck, NULL before typecheck runs, not owned
 
@@ -441,10 +444,7 @@ class AstCall:
         self->print_with_tree_printer(TreePrinter{})
 
     def print_with_tree_printer(self, tp: TreePrinter) -> None:
-        printf("call %s \"%s\"", self->function_or_method(), self->name)
-        if self->uses_arrow_operator:
-            printf(" with the arrow operator")
-        printf("\n")
+        printf("call %s \"%s\"\n", self->function_or_method(), self->name)
 
         if self->method_call_self != NULL:
             sub = tp.print_prefix(self->args.len == 0)

--- a/compiler/builders/ast_to_builder.jou
+++ b/compiler/builders/ast_to_builder.jou
@@ -417,7 +417,7 @@ class AstToBuilder:
                 # We can't do this for all expressions, because e.g. &some_function() is error.
                 return self->builder->dereference(self->build_address_of_expression(expr))
             case AstExpressionKind.DotOperator:
-                # Compiler should replace these with other expression kinds when it knows what they are
+                # Should become other expression kind before we get here
                 assert False
             case AstExpressionKind.GetEnumMember:
                 return self->builder->enum_member(expr->types.orig_type, expr->enum_member.member_name)

--- a/compiler/builders/ast_to_builder.jou
+++ b/compiler/builders/ast_to_builder.jou
@@ -172,7 +172,7 @@ class AstToBuilder:
         if call->method_call_self != NULL:
             # it is a method call, pass self as first argument
             want_pointer = call->called_signature->args.ptr[0].type->is_pointer_type()
-            got_pointer = call->uses_arrow_operator
+            got_pointer = call->method_call_self->types.implicit_cast_type->is_pointer_type()
 
             if want_pointer and not got_pointer:
                 arg = self->build_address_of_expression(call->method_call_self)
@@ -416,18 +416,22 @@ class AstToBuilder:
                 # ptr[foo] can always be evaluated as &ptr[foo], because ptr is already a pointer.
                 # We can't do this for all expressions, because e.g. &some_function() is error.
                 return self->builder->dereference(self->build_address_of_expression(expr))
+            case AstExpressionKind.DotOperator:
+                # Compiler should replace these with other expression kinds when it knows what they are
+                assert False
             case AstExpressionKind.GetEnumMember:
                 return self->builder->enum_member(expr->types.orig_type, expr->enum_member.member_name)
             case AstExpressionKind.GetClassField:
-                if expr->class_field.uses_arrow_operator:
-                    ptr = self->build_expression(expr->class_field.instance)
-                else:
-                    # Evaluate foo.bar as (&temp)->bar, where temp is a temporary copy of foo.
-                    # We need to copy, because it's not always possible to evaluate &foo.
-                    # For example, consider evaluating some_function().some_field.
-                    instance = self->build_expression(expr->class_field.instance)
-                    ptr = self->builder->stack_alloc(self->map_type(expr->class_field.instance->types.implicit_cast_type), NULL)
-                    self->builder->set_ptr(ptr, instance)
+                # Evaluate foo.bar as (&temp).bar, where temp is a temporary copy of foo.
+                # We need to copy, because it's not always possible to evaluate &foo.
+                # For example, consider evaluating some_function().some_field.
+                instance = self->build_expression(expr->class_field.instance)
+                ptr = self->builder->stack_alloc(self->map_type(expr->class_field.instance->types.implicit_cast_type), NULL)
+                self->builder->set_ptr(ptr, instance)
+                fieldptr = self->builder->class_field_pointer(ptr, expr->class_field.field_name)
+                return self->builder->dereference(fieldptr)
+            case AstExpressionKind.GetClassFieldPtr:
+                ptr = self->build_expression(expr->class_field.instance)
                 fieldptr = self->builder->class_field_pointer(ptr, expr->class_field.field_name)
                 return self->builder->dereference(fieldptr)
             case AstExpressionKind.As:
@@ -505,12 +509,12 @@ class AstToBuilder:
 
         match expr->kind:
             case AstExpressionKind.GetClassField:
-                if expr->class_field.uses_arrow_operator:
-                    # &ptr->field = ptr + memory offset
-                    ptr = self->build_expression(expr->class_field.instance)
-                else:
-                    # &obj.field = &obj + memory offset
-                    ptr = self->build_address_of_expression(expr->class_field.instance)
+                # &instance.field = &instance + memory offset
+                ptr = self->build_address_of_expression(expr->class_field.instance)
+                result = self->builder->class_field_pointer(ptr, expr->class_field.field_name)
+            case AstExpressionKind.GetClassFieldPtr:
+                # &pointer.field = pointer + memory offset
+                ptr = self->build_expression(expr->class_field.instance)
                 result = self->builder->class_field_pointer(ptr, expr->class_field.field_name)
             case AstExpressionKind.Self:
                 result = self->local_var_ptr("self")

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -718,7 +718,6 @@ class Parser:
                 if self->tokens[1].is_operator("("):
                     call = self->parse_call()
                     call.method_call_self = instance
-                    call.uses_arrow_operator = start_op->is_operator("->")
                     result = AstExpression{
                         location = call.location,
                         kind = AstExpressionKind.Call,
@@ -727,10 +726,9 @@ class Parser:
                 else:
                     result = AstExpression{
                         location = self->tokens->location,
-                        kind = AstExpressionKind.GetClassField,
+                        kind = AstExpressionKind.DotOperator,
                         class_field = AstClassField{
                             instance = instance,
-                            uses_arrow_operator = start_op->is_operator("->"),
                             field_name = self->tokens->short_string,
                         },
                     }

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -124,7 +124,7 @@ def short_expression_description(expr: AstExpression*) -> byte[200]:
             snprintf(result, sizeof result, "address of %s", inner)
             return result
 
-        case AstExpressionKind.GetClassField:
+        case AstExpressionKind.GetClassField | AstExpressionKind.GetClassFieldPtr | AstExpressionKind.DotOperator:
             snprintf(result, sizeof result, "field '%s'", expr->class_field.field_name)
             return result
 
@@ -143,27 +143,24 @@ def ensure_can_take_address(fom: FunctionOrMethodTypes*, expr: AstExpression*, e
     # before type-checking the expression. That's bad because this depends on
     # the results of type checking.
     #
-    # The dependency is a bit surprising. Jou code "foo.bar" can be either an
-    # enum member, or a field on an instance of a class. That is determined
-    # when type checking. Members of instances can be (usually) assigned to,
-    # but enum members cannot.
+    # The dependency is a bit surprising. Jou code "foo.bar" can mean many things:
+    #   - "foo" is an enum, "bar" is an enum member
+    #   - "foo" is an instance of a class, "bar" is a field
+    #   - "foo" is a pointer to an instance of a class, "bar" is a field
     assert expr->types.orig_type != NULL
 
     if (
         expr->kind == AstExpressionKind.Dereference
-        or expr->kind == AstExpressionKind.Indexing  # &foo[bar]
-        or (
-            # &foo->bar = foo + offset (it doesn't use &foo)
-            expr->kind == AstExpressionKind.GetClassField
-            and expr->class_field.uses_arrow_operator
-        )
+        # &pointer[index] = pointer + itemsize*index (doesn't use &pointer)
+        or expr->kind == AstExpressionKind.Indexing
+        # &pointer.field = pointer + offset (doesn't use &pointer)
+        or expr->kind == AstExpressionKind.GetClassFieldPtr
     ):
         return
 
     if expr->kind == AstExpressionKind.GetClassField:
         # &foo.bar = &foo + offset
-        assert not expr->class_field.uses_arrow_operator
-
+        #
         # Turn "cannot assign to %s" into "cannot assign to a field of %s".
         # This assumes that errmsg_template is relatively simple, i.e. it only contains one %s somewhere.
         newtemplate: byte*
@@ -833,17 +830,17 @@ def cast_ternary_values_to_a_common_type(
 
 # The AST "foo.bar" may be:
 #   - field "bar" of an instance of some class stored to variable "foo"
+#   - field "bar" of an instance where pointer "foo" points
 #   - member "bar" of enum "foo"
 #
-# The parser assumes it is always a field on an instance, because it's more
-# general: "foo" can be any expression, not necessarily enum name.
+# This function recognizes enum members and modifies the AST accordingly.
+# It does not distinguish between fields that use a pointer vs access
+# directly. This cannot be done in the parser because it doesn't know what
+# enums exist (they may be e.g. imported from other files).
 #
-# This function modifies the AST so that it sometimes changes from accessing
-# class fields to accessing enum members. This cannot be done in the parser
-# because it doesn't know what enums exist (they may be e.g. imported from
-# other files). Feels like a hack, but works great :)
-def handle_conflicting_class_field_and_enum_member_syntax(state: State*, expr: AstExpression*) -> None:
-    if expr->kind != AstExpressionKind.GetClassField:
+# Feels like a hack, but works great :)
+def detect_enum_member_syntax(state: State*, expr: AstExpression*) -> None:
+    if expr->kind != AstExpressionKind.DotOperator:
         # not foo.bar
         return
 
@@ -879,9 +876,6 @@ def handle_conflicting_class_field_and_enum_member_syntax(state: State*, expr: A
             )
             fail(expr->location, msg)
 
-    if expr->class_field.uses_arrow_operator:
-        fail(expr->location, "the '->' operator cannot be used to look up enum members")
-
     free(expr->class_field.instance)
     expr->kind = AstExpressionKind.GetEnumMember
     expr->enum_member = AstEnumMember{
@@ -894,7 +888,7 @@ def typecheck_expression(state: State*, expr: AstExpression*, type_hint: Type*) 
     msg: byte[500]
     result: Type* = NULL
 
-    handle_conflicting_class_field_and_enum_member_syntax(state, expr)
+    detect_enum_member_syntax(state, expr)
 
     match expr->kind:
         case AstExpressionKind.IntegerConstant:
@@ -965,74 +959,69 @@ def typecheck_expression(state: State*, expr: AstExpression*, type_hint: Type*) 
             membertype = cast_array_members_to_a_common_type(state->fom_types, expr->location, expr->array, item_type_hint)
             result = membertype->array_type(expr->array.len as int)
 
-        case AstExpressionKind.GetClassField:
-            if expr->class_field.uses_arrow_operator:
-                temptype = typecheck_expression_not_void(state, expr->class_field.instance, NULL)
-                if temptype->kind != TypeKind.Pointer or temptype->value_type->kind != TypeKind.Class:
-                    snprintf(
-                        msg, sizeof(msg),
-                        "left side of '->' operator must be a pointer to an instance of a class, not %s",
-                        temptype->name)
-                    if temptype->kind == TypeKind.Class and strlen(msg) + 50 < sizeof(msg):
-                        strcat(msg, " (try . instead of ->)")
-                    fail(expr->location, msg)
+        case AstExpressionKind.DotOperator:
+            # Not enum, that is handled already.
+            # It is either instance.field or pointer_to_instance.field.
+            temptype = typecheck_expression_not_void(state, expr->class_field.instance, NULL)
+            if temptype->kind == TypeKind.Class:
+                expr->kind = AstExpressionKind.GetClassField
+                result = typecheck_class_field(temptype, expr->class_field.field_name, expr->location)->type
+            elif temptype->kind == TypeKind.Pointer and temptype->value_type->kind == TypeKind.Class:
+                expr->kind = AstExpressionKind.GetClassFieldPtr
                 result = typecheck_class_field(temptype->value_type, expr->class_field.field_name, expr->location)->type
             else:
-                temptype = typecheck_expression_not_void(state, expr->class_field.instance, NULL)
-                if temptype->kind != TypeKind.Class:
-                    snprintf(
-                        msg, sizeof(msg),
-                        "left side of '.' operator must be an instance of a class, not %s",
-                        temptype->name)
-                    if (
-                        temptype->kind == TypeKind.Pointer
-                        and temptype->value_type->kind == TypeKind.Class
-                        and strlen(msg) + 50 < sizeof(msg)
-                    ):
-                        strcat(msg, " (try -> instead of .)")
-                    fail(expr->location, msg)
-                result = typecheck_class_field(temptype, expr->class_field.field_name, expr->location)->type
+                snprintf(
+                    msg, sizeof(msg),
+                    "left side of '.' operator must be an instance of a class or a pointer to an instance, not %s",
+                    temptype->name)
+                fail(expr->location, msg)
+
+        case AstExpressionKind.GetClassField:
+            temptype = typecheck_expression_not_void(state, expr->class_field.instance, NULL)
+            if temptype->kind != TypeKind.Class:
+                snprintf(
+                    msg, sizeof(msg),
+                    "left side of '.' operator must be an instance of a class or a pointer to an instance, not %s",
+                    temptype->name)
+                fail(expr->location, msg)
+            result = typecheck_class_field(temptype, expr->class_field.field_name, expr->location)->type
+
+        case AstExpressionKind.GetClassFieldPtr:
+            temptype = typecheck_expression_not_void(state, expr->class_field.instance, NULL)
+            if temptype->kind != TypeKind.Pointer or temptype->value_type->kind != TypeKind.Class:
+                snprintf(
+                    msg, sizeof(msg),
+                    "left side of '.' operator must be a pointer to an instance of a class, not %s",
+                    temptype->name)
+                fail(expr->location, msg)
+            result = typecheck_class_field(temptype->value_type, expr->class_field.field_name, expr->location)->type
 
         case AstExpressionKind.Call:
             if expr->call.method_call_self == NULL:
                 result = typecheck_function_or_method_call(state, &expr->call, NULL, expr->location)
-            elif expr->call.uses_arrow_operator:
-                temptype = typecheck_expression_not_void(state, expr->call.method_call_self, NULL)
-                if temptype->kind != TypeKind.Pointer or temptype->value_type->kind != TypeKind.Class:
-                    snprintf(msg, sizeof(msg),
-                        "left side of '->' operator must be a pointer to an instance of a class, not %s",
-                        temptype->name)
-                    if temptype->kind == TypeKind.Class and strlen(msg) + 50 < sizeof(msg):
-                        strcat(msg, " (try . instead of ->)")
-                    fail(expr->location, msg)
-                result = typecheck_function_or_method_call(state, &expr->call, temptype->value_type, expr->location)
             else:
                 temptype = typecheck_expression_not_void(state, expr->call.method_call_self, NULL)
-                if temptype->kind != TypeKind.Class:
+                if temptype->kind == TypeKind.Class:
+                    result = typecheck_function_or_method_call(state, &expr->call, temptype, expr->location)
+                elif temptype->kind == TypeKind.Pointer and temptype->value_type->kind == TypeKind.Class:
+                    result = typecheck_function_or_method_call(state, &expr->call, temptype->value_type, expr->location)
+                else:
                     snprintf(msg, sizeof(msg),
-                        "left side of '.' operator must be an instance of a class, not %s",
+                        "left side of '.' operator must be an instance of a class or a pointer to an instance, not %s",
                         temptype->name)
-                    if (
-                        temptype->kind == TypeKind.Pointer
-                        and temptype->value_type->kind == TypeKind.Class
-                        and strlen(msg) + 50 < sizeof(msg)
-                    ):
-                        strcat(msg, " (try -> instead of .)")
                     fail(expr->location, msg)
 
-                result = typecheck_function_or_method_call(state, &expr->call, temptype, expr->location)
-
-                # If self argument is passed by pointer, make sure we can create that pointer
-                assert temptype->kind == TypeKind.Class
-                signature = temptype->find_method(expr->call.name)
-                assert signature != NULL
-                if signature->args.ptr[0].type->is_pointer_type():
-                    assert strstr(expr->call.name, "%") == NULL
-                    snprintf(
-                        msg, sizeof msg,
-                        "cannot take address of %%s, needed for calling the %s() method",
-                        expr->call.name)
-                    ensure_can_take_address(state->fom_types, expr->call.method_call_self, msg)
+                # If self argument must be passed by pointer, make sure we can create that pointer
+                if temptype->kind == TypeKind.Class:
+                    signature = temptype->find_method(expr->call.name)
+                    assert signature != NULL
+                    if signature->args.ptr[0].type->is_pointer_type():
+                        assert strstr(expr->call.name, "%") == NULL
+                        snprintf(
+                            msg, sizeof msg,
+                            "cannot take address of %%s, needed for calling the %s() method",
+                            expr->call.name)
+                        ensure_can_take_address(state->fom_types, expr->call.method_call_self, msg)
 
             if result == NULL:
                 # no return value produced

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -976,25 +976,9 @@ def typecheck_expression(state: State*, expr: AstExpression*, type_hint: Type*) 
                     temptype->name)
                 fail(expr->location, msg)
 
-        case AstExpressionKind.GetClassField:
-            temptype = typecheck_expression_not_void(state, expr->class_field.instance, NULL)
-            if temptype->kind != TypeKind.Class:
-                snprintf(
-                    msg, sizeof(msg),
-                    "left side of '.' operator must be an instance of a class or a pointer to an instance, not %s",
-                    temptype->name)
-                fail(expr->location, msg)
-            result = typecheck_class_field(temptype, expr->class_field.field_name, expr->location)->type
-
-        case AstExpressionKind.GetClassFieldPtr:
-            temptype = typecheck_expression_not_void(state, expr->class_field.instance, NULL)
-            if temptype->kind != TypeKind.Pointer or temptype->value_type->kind != TypeKind.Class:
-                snprintf(
-                    msg, sizeof(msg),
-                    "left side of '.' operator must be a pointer to an instance of a class, not %s",
-                    temptype->name)
-                fail(expr->location, msg)
-            result = typecheck_class_field(temptype->value_type, expr->class_field.field_name, expr->location)->type
+        case AstExpressionKind.GetClassField | AstExpressionKind.GetClassFieldPtr:
+            # Constructed above, should not already be like this when we get here
+            assert False
 
         case AstExpressionKind.Call:
             if expr->call.method_call_self == NULL:

--- a/doc/classes.md
+++ b/doc/classes.md
@@ -8,8 +8,9 @@ import "stdlib/io.jou"
 class Person:
     name: byte*
 
+    # self is a pointer (Person*)
     def greet(self) -> None:
-        printf("Hello %s\n", self->name)   # self is a pointer (Person*)
+        printf("Hello %s\n", self.name)
 
 def main() -> int:
     instance = Person{name="world"}
@@ -127,7 +128,7 @@ class Point:
     y: int
 
 def increment_y(ptr: Point*) -> None:
-    ptr->y++
+    ptr.y++
 
 def main() -> int:
     p = Point{x = 12, y = 34}
@@ -136,11 +137,9 @@ def main() -> int:
     return 0
 ```
 
-Here `ptr->y` does the same thing as `(*ptr).y`:
+Here `ptr.y` does the same thing as `(*ptr).y`:
 it accesses the `y` member of the instance located wherever the pointer `ptr` is pointing.
-This arrow syntax feels weird at first,
-but it's convenient once you get used to it,
-and the C programming language uses the same syntax.
+For convenience, the `.` operator can also be applied to a pointer to an instance of a class.
 
 
 ## Methods
@@ -156,7 +155,7 @@ class Point:
     y: int
 
     def increment_y(self) -> None:
-        self->y++
+        self.y++
 
 def main() -> int:
     p = Point{x=12, y=34}
@@ -170,7 +169,7 @@ In the above example, the type of `self` is `Point*`,
 which means that `self` is a pointer to an instance of `Point`.
 
 To call a method on a pointer (such as `self`),
-use `->`, just like with accessing fields:
+you can simply `.`, just like with accessing fields:
 
 ```python
 import "stdlib/io.jou"
@@ -180,14 +179,14 @@ class Point:
     y: int
 
     def increment_x(self) -> None:
-        self->x++
+        self.x++
 
     def increment_y(self) -> None:
-        self->y++
+        self.y++
 
     def increment_both(self) -> None:
-        self->increment_x()
-        self->increment_y()
+        self.increment_x()
+        self.increment_y()
 
 def main() -> int:
     p = Point{x=12, y=34}
@@ -195,6 +194,9 @@ def main() -> int:
     printf("%d %d\n", p.x, p.y)  # Output: 13 35
     return 0
 ```
+
+Here `self.increment_x()` is a shorthand for `(*self).increment_x()`:
+it accesses the instance through the `self` pointer and calls its `increment_x()` method.
 
 If, for some reason, you want to pass the instance by value instead of a pointer,
 so that the method gets a copy of it,
@@ -236,10 +238,10 @@ class Person:
     country: byte[50]
 
     def introduce(self) -> None:
-        if self->name == NULL:
-            printf("I'm an anonymous person from '%s'\n", self->country)
+        if self.name == NULL:
+            printf("I'm an anonymous person from '%s'\n", self.country)
         else:
-            printf("I'm %s from '%s'\n", self->name, self->country)
+            printf("I'm %s from '%s'\n", self.name, self.country)
 
 
 def main() -> int:
@@ -280,10 +282,10 @@ class Person:
     country: byte[50]
 
     def introduce(self) -> None:
-        if self->name == NULL:
-            printf("I'm an anonymous person from '%s'\n", self->country)
+        if self.name == NULL:
+            printf("I'm an anonymous person from '%s'\n", self.country)
         else:
-            printf("I'm %s from '%s'\n", self->name, self->country)
+            printf("I'm %s from '%s'\n", self.name, self.country)
 
 
 def main() -> int:

--- a/doc/classes.md
+++ b/doc/classes.md
@@ -169,7 +169,7 @@ In the above example, the type of `self` is `Point*`,
 which means that `self` is a pointer to an instance of `Point`.
 
 To call a method on a pointer (such as `self`),
-you can simply `.`, just like with accessing fields:
+you can simply use `.`, just like with accessing fields:
 
 ```python
 import "stdlib/io.jou"

--- a/doc/lists.md
+++ b/doc/lists.md
@@ -277,7 +277,7 @@ import "stdlib/list.jou"
 import "stdlib/mem.jou"
 
 def add_one(list: List[int]*) -> None:
-    list->append(1)
+    list.append(1)
 
 def main() -> int:
     numbers = List[int]{}
@@ -302,7 +302,7 @@ Even worse, if the list contents need to be moved to a new memory location,
 the `main()` function will see the old location of the list and probably crash the program.
 
 However, if the length of the list won't change,
-you can simply pass it by value (that is, without a pointer):
+you can simply pass the list by value (that is, without a pointer):
 
 ```python
 def print_items(list: List[int]) -> None:

--- a/tests/other_errors/enum_arrow.jou
+++ b/tests/other_errors/enum_arrow.jou
@@ -1,7 +1,0 @@
-enum Foo:
-    Bar
-    Baz
-
-def main() -> int:
-    x = Foo->Bar  # Error: the '->' operator cannot be used to look up enum members
-    return 0

--- a/tests/wrong_type/arrow_instead_of_dot.jou
+++ b/tests/wrong_type/arrow_instead_of_dot.jou
@@ -1,7 +1,0 @@
-class Foo:
-    n: int
-
-
-def blah() -> None:
-    f = Foo{}
-    f->n++  # Error: left side of '->' operator must be a pointer to an instance of a class, not Foo (try . instead of ->)

--- a/tests/wrong_type/arrow_instead_of_dot_call.jou
+++ b/tests/wrong_type/arrow_instead_of_dot_call.jou
@@ -1,7 +1,0 @@
-class Foo:
-    n: int
-
-
-def blah() -> None:
-    f = Foo{}
-    f->do_stuff()  # Error: left side of '->' operator must be a pointer to an instance of a class, not Foo (try . instead of ->)

--- a/tests/wrong_type/arrow_operator_int.jou
+++ b/tests/wrong_type/arrow_operator_int.jou
@@ -1,3 +1,0 @@
-def foo() -> None:
-    num = 1
-    x = num->lol  # Error: left side of '->' operator must be a pointer to an instance of a class, not int

--- a/tests/wrong_type/arrow_operator_int_call.jou
+++ b/tests/wrong_type/arrow_operator_int_call.jou
@@ -1,3 +1,0 @@
-def foo() -> None:
-    num = 1
-    x = num->lol()  # Error: left side of '->' operator must be a pointer to an instance of a class, not int

--- a/tests/wrong_type/arrow_operator_intptr.jou
+++ b/tests/wrong_type/arrow_operator_intptr.jou
@@ -1,4 +1,0 @@
-def foo() -> None:
-    num = 1
-    pointer = &num
-    x = pointer->lol  # Error: left side of '->' operator must be a pointer to an instance of a class, not int*

--- a/tests/wrong_type/arrow_operator_intptr_call.jou
+++ b/tests/wrong_type/arrow_operator_intptr_call.jou
@@ -1,4 +1,0 @@
-def foo() -> None:
-    num = 1
-    pointer = &num
-    x = pointer->lol()  # Error: left side of '->' operator must be a pointer to an instance of a class, not int*

--- a/tests/wrong_type/dot_instead_of_arrow.jou
+++ b/tests/wrong_type/dot_instead_of_arrow.jou
@@ -1,6 +1,0 @@
-class Foo:
-    n: int
-
-
-def blah(ptr: Foo*) -> None:
-    ptr.n++  # Error: left side of '.' operator must be an instance of a class, not Foo* (try -> instead of .)

--- a/tests/wrong_type/dot_instead_of_arrow_call.jou
+++ b/tests/wrong_type/dot_instead_of_arrow_call.jou
@@ -1,6 +1,0 @@
-class Foo:
-    n: int
-
-
-def blah(ptr: Foo*) -> None:
-    ptr.foo()  # Error: left side of '.' operator must be an instance of a class, not Foo* (try -> instead of .)

--- a/tests/wrong_type/dot_operator_int.jou
+++ b/tests/wrong_type/dot_operator_int.jou
@@ -1,3 +1,3 @@
 def foo() -> None:
     x = 123
-    y = x.lolwat  # Error: left side of '.' operator must be an instance of a class, not int
+    y = x.lolwat  # Error: left side of '.' operator must be an instance of a class or a pointer to an instance, not int

--- a/tests/wrong_type/dot_operator_int_call.jou
+++ b/tests/wrong_type/dot_operator_int_call.jou
@@ -1,3 +1,3 @@
 def foo() -> None:
     x = 123
-    y = x.lolwat()  # Error: left side of '.' operator must be an instance of a class, not int
+    y = x.lolwat()  # Error: left side of '.' operator must be an instance of a class or a pointer to an instance, not int

--- a/tests/wrong_type/dot_operator_intptr.jou
+++ b/tests/wrong_type/dot_operator_intptr.jou
@@ -1,4 +1,4 @@
 def foo() -> None:
     x = 123
     y = &x
-    z = y.lolwat  # Error: left side of '.' operator must be an instance of a class, not int*
+    z = y.lolwat  # Error: left side of '.' operator must be an instance of a class or a pointer to an instance, not int*

--- a/tests/wrong_type/dot_operator_intptr_call.jou
+++ b/tests/wrong_type/dot_operator_intptr_call.jou
@@ -1,4 +1,4 @@
 def foo() -> None:
     x = 123
     y = &x
-    z = y.lolwat()  # Error: left side of '.' operator must be an instance of a class, not int*
+    z = y.lolwat()  # Error: left side of '.' operator must be an instance of a class or a pointer to an instance, not int*


### PR DESCRIPTION
Example:

```python
import "stdlib/io.jou"

class Foo:
    x: int

def move(f: Foo*) -> None:
    #f->x++  # old syntax
    f.x++
```

Before this PR, there were two ways to access attributes: `foo.bar` and `foo->bar`. You used `foo.bar` if `foo` is an instance and `foo->bar` if `foo` is a pointer to an instance.

This PR modifies `.` to work for both use cases. For backwards compatibility, `foo->bar` will do the same thing as `foo.bar` for a few hours. Then I will remove the `foo->bar` syntax.

Todo:
- [x] update docs

Part of #749 