### PR TITLE
Remove support for `foo->bar` syntax

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -126,7 +126,7 @@ class AstEnumMember:
     member_name: byte[100]
 
 
-# foo.bar, foo->bar
+# foo.bar
 @public
 class AstClassField:
     instance: AstExpression*
@@ -240,7 +240,7 @@ class AstExpression:
         printf("[line %d", self.location.lineno)
         if self.types.orig_type != NULL:
             printf(", type %s", self.types.orig_type.name)
-            # TODO: print casts and other stuff under self->types?
+            # TODO: print casts and other stuff under self.types?
         printf("] ")
 
         match self.kind:
@@ -431,7 +431,6 @@ class AstAs:
 
 # foo(arg1, arg2, arg3)
 # foo.bar(arg1, arg2, arg3)
-# foo->bar(arg1, arg2, arg3)
 @public
 class AstCall:
     location: Location
@@ -1077,7 +1076,7 @@ class AstFile:
 
     def free(self) -> None:
         free_body(self.body)
-        self.types.free()  # also works if self->types is zero-initialized
+        self.types.free()  # also works if self.types is zero-initialized
 
 
 # def foo() -> bar:

--- a/compiler/builders/any_builder.jou
+++ b/compiler/builders/any_builder.jou
@@ -120,7 +120,7 @@ class AnyBuilder:
             result.hvalue = self.hbuilder.indexed_pointer(ptr.hvalue, index.hvalue)
         return result
 
-    # Returns &ptr->field
+    # Returns &ptr.field
     def class_field_pointer(self, ptr: AnyBuilderValue, field_name: byte*) -> AnyBuilderValue:
         result = AnyBuilderValue{}
         if self.lbuilder != NULL:

--- a/compiler/builders/hash_builder.jou
+++ b/compiler/builders/hash_builder.jou
@@ -130,7 +130,7 @@ class HBuilder:
         self.hash.add_int64(index.id)
         return self.new_value(ptr.type)
 
-    # Returns &ptr->field
+    # Returns &ptr.field
     def class_field_pointer(self, ptr: HBuilderValue, field_name: byte*) -> HBuilderValue:
         # Do not hash field name, renaming fields should not cause recompiling
         assert ptr.type.kind == TypeKind.Pointer

--- a/compiler/builders/llvm_builder.jou
+++ b/compiler/builders/llvm_builder.jou
@@ -304,7 +304,7 @@ class LBuilder:
         )
         return LBuilderValue{type = ptr.type, llvm_value = llvm_result}
 
-    # Returns &ptr->field
+    # Returns &ptr.field
     def class_field_pointer(self, ptr: LBuilderValue, field_name: byte*) -> LBuilderValue:
         assert ptr.type.kind == TypeKind.Pointer
         classtype = ptr.type.value_type
@@ -339,8 +339,8 @@ class LBuilder:
         for i = 0; i < nargs; i++:
             if i < sig.args.len:
                 # not a vararg
-                # TODO: this assertion fails with generics when calling self->method() inside inline function
-                #assert args[i].type == sig->args.ptr[i].type
+                # TODO: this assertion fails with generics when calling self.method() inside inline function
+                #assert args[i].type == sig.args.ptr[i].type
                 pass
             llvm_args[i] = args[i].llvm_value
 

--- a/compiler/evaluate.jou
+++ b/compiler/evaluate.jou
@@ -205,7 +205,7 @@ def choose_if_elif_branch(if_stmt: AstIfStatement*) -> List[AstStatement]*:
     return &if_stmt.else_body
 
 
-# Replaces the statement body->ptr[i] with statements from a given list.
+# Replaces the statement body.ptr[i] with statements from a given list.
 def replace(body: List[AstStatement]*, i: int, new: List[AstStatement]) -> None:
     body.ptr[i].free()
     body.grow(body.len + new.len)
@@ -213,7 +213,7 @@ def replace(body: List[AstStatement]*, i: int, new: List[AstStatement]) -> None:
     # How many statements after index i we want to preserve
     nkeep = body.len - (i+1)
 
-    # Delete body->ptr[i] and shift everything after it to their new place
+    # Delete body.ptr[i] and shift everything after it to their new place
     memmove(&body.ptr[i + new.len], &body.ptr[i+1], nkeep * sizeof(body.ptr[0]))
 
     # Put the new statements to their place.

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -698,7 +698,7 @@ class Parser:
     def parse_expression_with_fields_and_methods_and_indexing(self) -> AstExpression:
         result = self.parse_elementary_expression()
 
-        while True:
+        while self.tokens.is_operator("[") or self.tokens.is_operator("."):
             if self.tokens.is_operator("["):
                 open_bracket = self.tokens++
                 operands = [result, self.parse_expression()]
@@ -707,10 +707,7 @@ class Parser:
                 self.tokens++
                 result = build_operator_expression(open_bracket, 2, operands)
 
-            elif self.tokens.is_operator("->"):
-                fail(self.tokens.location, "use . instead of ->")
-
-            elif self.tokens.is_operator("."):
+            else:
                 start_op = self.tokens++
                 if self.tokens.kind != TokenKind.Name:
                     self.tokens.fail_expected_got("a field or method name")
@@ -737,8 +734,10 @@ class Parser:
                     }
                     self.tokens++
 
-            else:
-                return result
+        if self.tokens.is_operator("->"):
+            fail(self.tokens.location, "use . instead of ->")
+
+        return result
 
     def parse_expression_with_unary_operators(self) -> AstExpression:
         # prefix = sequence of 0 or more unary operator tokens: start,start+1,...,end-1

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -698,7 +698,7 @@ class Parser:
     def parse_expression_with_fields_and_methods_and_indexing(self) -> AstExpression:
         result = self.parse_elementary_expression()
 
-        while self.tokens.is_operator(".") or self.tokens.is_operator(".") or self.tokens.is_operator("["):
+        while True:
             if self.tokens.is_operator("["):
                 open_bracket = self.tokens++
                 operands = [result, self.parse_expression()]
@@ -707,7 +707,10 @@ class Parser:
                 self.tokens++
                 result = build_operator_expression(open_bracket, 2, operands)
 
-            else:
+            elif self.tokens.is_operator("->"):
+                fail(self.tokens.location, "use . instead of ->")
+
+            elif self.tokens.is_operator("."):
                 start_op = self.tokens++
                 if self.tokens.kind != TokenKind.Name:
                     self.tokens.fail_expected_got("a field or method name")
@@ -734,7 +737,8 @@ class Parser:
                     }
                     self.tokens++
 
-        return result
+            else:
+                return result
 
     def parse_expression_with_unary_operators(self) -> AstExpression:
         # prefix = sequence of 0 or more unary operator tokens: start,start+1,...,end-1

--- a/examples/aoc2023/day19/part2.jou
+++ b/examples/aoc2023/day19/part2.jou
@@ -100,7 +100,7 @@ class UnionOfBoxes:
                         if box.contains_box(have.ptr[i]):
                             have.ptr[i] = have.pop()
 
-            # Replace self->boxes[k] with "have"
+            # Replace self.boxes[k] with "have"
             self.boxes.ptr[k] = self.boxes.pop()
             self.boxes.extend(have)
             free(have.ptr)

--- a/examples/aoc2023/day20/part1.jou
+++ b/examples/aoc2023/day20/part1.jou
@@ -80,7 +80,7 @@ def press_button(modules: ModuleList*, high_counter: int*, low_counter: int*) ->
         else:
             ++*low_counter
 
-        #printf("%s -%d-> %s\n", item.from->name, item.value as int, item.to->name)
+        #printf("%s -%d-> %s\n", item.from.name, item.value as int, item.to.name)
 
         match item.to.kind:
             case ModuleKind.Broadcaster:

--- a/examples/aoc2023/day23/part2.jou
+++ b/examples/aoc2023/day23/part2.jou
@@ -198,7 +198,7 @@ def main() -> int:
     graph = create_graph_of_intersections(&grid)
     free(grid.data)
 
-    #graph->visualize_with_graphviz()
+    #graph.visualize_with_graphviz()
 
     assert graph.num_nodes < 50
     avoid: bool[50]

--- a/examples/aoc2023/day24/part1.jou
+++ b/examples/aoc2023/day24/part1.jou
@@ -124,10 +124,10 @@ class Ray:
 
         # Vectors are not parallel. They will intersect somewhere, but where?
         #
-        #   self->start + a*self->dir = other->start + b*other->dir
+        #   self.start + a*self.dir = other.start + b*other.dir
         #
-        #   a*self->dir[0] + b*(-other->dir[0]) = other->start[0] - self->start[0]
-        #   a*self->dir[1] + b*(-other->dir[1]) = other->start[1] - self->start[1]
+        #   a*self.dir[0] + b*(-other.dir[0]) = other.start[0] - self.start[0]
+        #   a*self.dir[1] + b*(-other.dir[1]) = other.start[1] - self.start[1]
         coeff_matrix = [
             [self.dir[0], -other.dir[0]],
             [self.dir[1], -other.dir[1]],

--- a/examples/aoc2023/day24/part2.jou
+++ b/examples/aoc2023/day24/part2.jou
@@ -60,7 +60,7 @@ class EquationSolver:
 
             for dest = self.eqs; dest < &self.eqs[self.neqs]; dest++:
                 if dest != src and dest.has(var):
-                    # Pick c so that dest->coeffs[var] + c*src->coeffs[var] = 0.
+                    # Pick c so that dest.coeffs[var] + c*src.coeffs[var] = 0.
                     # The perfect c isn't necessarily integer, so we pick a close value.
                     c = dest.coeffs[var].div(src.coeffs[var]).neg()
                     assert not c.is_zero()

--- a/tests/should_succeed/method_by_value.jou
+++ b/tests/should_succeed/method_by_value.jou
@@ -23,7 +23,7 @@ def main() -> int:
     f.add_one()
     f.print()  # Output: 100
 
-    # test the '->' operator
+    # test the '.' operator on a pointer
     (&f).print()  # Output: 100
 
     return 0

--- a/tests/syntax_error/arrow_field.jou
+++ b/tests/syntax_error/arrow_field.jou
@@ -1,0 +1,2 @@
+def main() -> None:
+    x = foo->bar  # Error: use . instead of ->

--- a/tests/syntax_error/arrow_method.jou
+++ b/tests/syntax_error/arrow_method.jou
@@ -1,0 +1,2 @@
+def main() -> None:
+    foo->bar()  # Error: use . instead of ->


### PR DESCRIPTION
Turns out that `->` support was already broken since #902. This PR adds a nice error message if you try to use `->`.

Fixes #749 