### PR TITLE
Improve stdlib/math.jou

### DIFF
--- a/examples/perlin_noise.jou
+++ b/examples/perlin_noise.jou
@@ -32,18 +32,13 @@ def rand_0to1() -> float:
     return (rand() % 12345) / (12345 as float)
 
 
-# TODO: add pi to math library
-def pi() -> float:
-    return acosf(-1)
-
-
 # Generates a random 2D vector of length 1 for each corner of a cell.
 # We have SIZE^2 cells, (SIZE+1)^2 corners and hence (SIZE+1)^2 unit vectors.
 def generate_unit_vectors() -> float[2]*:
     num_corners = (SIZE + 1) * (SIZE + 1)
     result: float[2]* = malloc(sizeof(result[0]) * num_corners)
     for i = 0; i < num_corners; i++:
-        angle = rand_0to1() * 2 * pi()
+        angle = rand_0to1() * 2 * (M_PI as float)
         result[i] = [cosf(angle), sinf(angle)]
     return result
 

--- a/stdlib/math.jou
+++ b/stdlib/math.jou
@@ -193,12 +193,6 @@ declare exp(x: double) -> double
 @public
 declare expf(x: float) -> float
 
-# Computes 10^x (10 to the power of x).
-@public
-declare exp10(x: double) -> double
-@public
-declare exp10f(x: float) -> float
-
 # Computes x^y (x to the power of y).
 @public
 declare pow(x: double, y: double) -> double

--- a/stdlib/math.jou
+++ b/stdlib/math.jou
@@ -240,3 +240,28 @@ declare cbrtf(x: float) -> float
 declare hypot(x: double, y: double) -> double
 @public
 declare hypotf(x: float, y: float) -> float
+
+# Computes the error function, defined by the following integral:
+#
+#                           x
+#                          |\
+#   erf(x) = 2/sqrt(pi) *  |  exp(-t^2) dt
+#                         \|
+#                          0
+#
+# The scaling factor in front is chosen such that:
+#
+#   erf(infinity) == 1
+#   erf(-infinity) == -1
+#
+# This can be used to calculate probabilities that follow the Gaussian
+# distribution. Suppose X is a Gaussian distributed random variable with
+# mean `mu` and standard deviation `sigma`. Then:
+#
+#   P(X <= a) = 0.5 * (1 + erf((a - mu)/(sigma * sqrt(2))))
+#
+# where `a` is any number and `P(X <= a)` denotes the probability of `X <= a`.
+@public
+declare erf(double x) -> double
+@public
+declare erff(double x) -> double

--- a/stdlib/math.jou
+++ b/stdlib/math.jou
@@ -262,6 +262,6 @@ declare hypotf(x: float, y: float) -> float
 #
 # where `a` is any number and `P(X <= a)` denotes the probability of `X <= a`.
 @public
-declare erf(double x) -> double
+declare erf(x: double) -> double
 @public
-declare erff(double x) -> double
+declare erff(x: float) -> float

--- a/stdlib/math.jou
+++ b/stdlib/math.jou
@@ -1,4 +1,24 @@
-# Defines the math functions in math.h
+# Constants are prefixed with M_ to avoid confusing them with anything else.
+# For example, as a Jou user, it should be possible to make a class named E,
+# so we define M_E, not E.
+
+# The famous circle constant :)
+@public
+const M_PI: double = 3.14159265358979323846264338327950288419716939937510
+
+# This is the `e` constant, also known as:
+#   - Euler's number
+#   - Napier's constant
+#   - The base of the natural logarithm (see `log` function)
+#
+# This is a less widely known constant that comes up when analyzing exponential
+# growth: the derivative of e^x is the function e^x itself.
+#
+# Note: Usually, instead of `pow(M_E, foo)`, it is better to use `exp(foo)`.
+# It is just as readable (if not better) and may be faster or more accurate.
+@public
+const M_E: double = 2.71828182845904523536028747135266249775724709369995
+
 
 # Choose bigger/smaller
 @public
@@ -16,27 +36,27 @@ def max(a: int, b: int) -> int:
         return b
 
 @public
-declare fmin(a: double, b: double) -> double
-@public
-declare fminf(a: float, b: float) -> float
-@public
-declare fmax(a: double, b: double) -> double
-@public
-declare fmaxf(a: float, b: float) -> float
-
-@public
 def llmin(a: long, b: long) -> long:
     if a < b:
         return a
     else:
         return b
-
 @public
 def llmax(a: long, b: long) -> long:
     if a > b:
         return a
     else:
         return b
+
+@public
+declare fmin(a: double, b: double) -> double
+@public
+declare fmax(a: double, b: double) -> double
+
+@public
+declare fminf(a: float, b: float) -> float
+@public
+declare fmaxf(a: float, b: float) -> float
 
 # Returns the absolute value of x: |x|.
 @public
@@ -48,57 +68,81 @@ declare fabsf(x: float) -> float
 @public
 declare llabs(x: long) -> long
 
-# Rounding and remainder functions
-
-# Rounds x upward, returning the smallest integral value that is not less than x.
+# Rounds x upward, returning the smallest integer >= x.
+# Example: ceil(3.14) == 4.0
 @public
 declare ceil(x: double) -> double
 @public
 declare ceilf(x: float) -> float
-# Rounds x downward, returning the largest integral value that is not greater than x.
+
+# Rounds x downward, returning the largest integer <= x.
+# Example: floor(3.14) == 3.0
 @public
 declare floor(x: double) -> double
 @public
 declare floorf(x: float) -> float
-# Returns the integral value that is nearest to x, with halfway cases rounded away from zero.
+
+# Returns the integer that is nearest to x.
+# Examples: round(3.14) == 3, round(2.71) == 3
 @public
 declare round(x: double) -> double
 @public
 declare roundf(x: float) -> float
 
-# Trigonometric functions
-
-# These functions use radians as the angle unit.
-# One radian is the angle of a circle slice with equal radius and arc length, about 57 degrees.
+# ==========================
+#   Note about angle units
+# ==========================
+#
+# If not otherwise mentioned, all angles are in radians. One radian is the
+# angle of a circle slice with equal radius and arc length, about 57 degrees.
 # A full turn (360 degrees) is 2pi (about 6.28) radians.
-@public
-declare cos(x: double) -> double
-@public
-declare cosf(x: float) -> float
+#
+# Use the following formulas to convert between radians and degrees:
+#
+#   radians = degrees / 360.0 * (2*M_PI)
+#   degrees = radians / (2*M_PI) * 360
+#
+# Examples:
+#
+#   90 degrees = pi/2 radians
+#   180 degrees = pi radians
+#   360 degrees = 2*pi radians
+
 @public
 declare sin(x: double) -> double
 @public
 declare sinf(x: float) -> float
 @public
+declare cos(x: double) -> double
+@public
+declare cosf(x: float) -> float
+@public
 declare tan(x: double) -> double
 @public
 declare tanf(x: float) -> float
-# The 'a' prefixed functions are inverse functions.
-# For example, asin is also known as arcsin and sin^-1.
-@public
-declare acos(x: double) -> double
-@public
-declare acosf(x: float) -> float
+
+# Returns an angle between -pi/2 and pi/2 so that `sin(angle) == x`.
+# x should be between -1 and 1.
 @public
 declare asin(x: double) -> double
 @public
 declare asinf(x: float) -> float
+
+# Returns an angle between 0 and pi so that `cos(angle) == x`.
+# x should be between -1 and 1.
+@public
+declare acos(x: double) -> double
+@public
+declare acosf(x: float) -> float
+
+# Returns an angle between -pi/2 and pi/2 so that `tan(angle) == x`.
 @public
 declare atan(x: double) -> double
 @public
 declare atanf(x: float) -> float
-# Returns the angle of a point (x, y).
-# Note the reversed order of the arguments.
+
+# Returns an angle between -pi and +pi so that if you go from (0,0) in the
+# direction of the angle, you eventually arrive at (x,y).
 @public
 declare atan2(y: double, x: double) -> double
 @public
@@ -111,55 +155,53 @@ declare nan(tagp: byte*) -> double
 
 # Hyperbolic versions of the trig functions
 @public
-declare cosh(x: double) -> double
-@public
-declare coshf(x: float) -> float
-@public
 declare sinh(x: double) -> double
 @public
 declare sinhf(x: float) -> float
+@public
+declare cosh(x: double) -> double
+@public
+declare coshf(x: float) -> float
 @public
 declare tanh(x: double) -> double
 @public
 declare tanhf(x: float) -> float
 @public
-declare acosh(x: double) -> double
-@public
-declare acoshf(x: float) -> float
-@public
 declare asinh(x: double) -> double
 @public
 declare asinhf(x: float) -> float
+@public
+declare acosh(x: double) -> double
+@public
+declare acoshf(x: float) -> float
 @public
 declare atanh(x: double) -> double
 @public
 declare atanhf(x: float) -> float
 
-# Exponential and logarithmic functions
-
-# Computes e^x.
-@public
-declare exp(x: double) -> double
-@public
-declare expf(x: float) -> float
-
-# Computes 2^x.
+# Computes 2^x (2 to the power of x).
 @public
 declare exp2(x: double) -> double
 @public
 declare exp2f(x: float) -> float
 
-# Computes 10^x.
+# Computes e^x (e to the power of x).
+@public
+declare exp(x: double) -> double
+@public
+declare expf(x: float) -> float
+
+# Computes 10^x (10 to the power of x).
 @public
 declare exp10(x: double) -> double
 @public
 declare exp10f(x: float) -> float
 
-# Returns the natural (base e) logarithm of x.
+# Computes x^y (x to the power of y).
 @public
-declare log(x: double) -> double
+declare pow(x: double, y: double) -> double
 @public
-declare logf(x: float) -> float
+declare powf(x: float, y: float) -> float
 
 # Returns the base 2 logarithm of x.
 @public
@@ -167,54 +209,34 @@ declare log2(x: double) -> double
 @public
 declare log2f(x: float) -> float
 
+# Returns the natural (base e) logarithm of x.
+# To get a logarithm with some other base `b`, use `log(x) / log(b)`.
+@public
+declare log(x: double) -> double
+@public
+declare logf(x: float) -> float
+
 # Returns the base 10 logarithm of x.
 @public
 declare log10(x: double) -> double
 @public
 declare log10f(x: float) -> float
 
-# Power functions
-
-# Raise to power.
-@public
-declare pow(x: double, y: double) -> double
-@public
-declare powf(x: float, y: float) -> float
 # Returns the square root of x.
 @public
 declare sqrt(x: double) -> double
 @public
 declare sqrtf(x: float) -> float
+
 # Returns the cubic root of x.
 @public
 declare cbrt(x: double) -> double
 @public
 declare cbrtf(x: float) -> float
+
 # Returns the hypotenuse of a right-angled triangle whose legs are x and y.
+# In other words, return the distance between (0, 0) and (x, y).
 @public
 declare hypot(x: double, y: double) -> double
 @public
 declare hypotf(x: float, y: float) -> float
-
-# Error and gamma functions
-
-# Returns the error function value for x.
-@public
-declare erf(x: double) -> double
-@public
-declare erff(x: float) -> float
-# Returns the complementary error function value for x.
-@public
-declare erfc(x: double) -> double
-@public
-declare erfcf(x: float) -> float
-# Returns the gamma function of x.
-@public
-declare tgamma(x: double) -> double
-@public
-declare tgammaf(x: float) -> float
-# Returns the natural logarithm of the absolute value of the gamma.
-@public
-declare lgamma(x: double) -> double
-@public
-declare lgammaf(x: float) -> float

--- a/tests/should_succeed/mathlibtest.jou
+++ b/tests/should_succeed/mathlibtest.jou
@@ -2,6 +2,12 @@ import "stdlib/math.jou"
 import "stdlib/io.jou"
 
 def main() -> int:
+    printf("%f\n", M_PI)  # Output: 3.141593
+    printf("%d\n", M_PI == acos(-1))  # Output: 1
+
+    printf("%f\n", M_E)  # Output: 2.718282
+    printf("%d\n", M_E == exp(1))  # Output: 1
+
     printf("%d\n", min(12, 34))  # Output: 12
     printf("%lld\n", llmin(1000000000000, 2000000000000))  # Output: 1000000000000
     printf("%f\n", fmin(1.2, 3.4))  # Output: 1.200000
@@ -15,10 +21,10 @@ def main() -> int:
     printf("%lld\n", llabs(-(1145141919180 as long))) # Output: 1145141919180
     printf("%f\n", fabs(-114.514)) # Output: 114.514000
 
-    printf("%f\n", ceil(3.14159265358979)) # Output: 4.000000
-    printf("%f\n", floor(3.14159265358979)) # Output: 3.000000
+    printf("%f\n", ceil(3.14)) # Output: 4.000000
+    printf("%f\n", floor(3.14)) # Output: 3.000000
 
-    printf("%f\n", round(3.14159265358979)) # Output: 3.000000
+    printf("%f\n", round(3.14)) # Output: 3.000000
 
     printf("%f\n", cos(1.04719753333333)) # Output: 0.500000
     printf("%f\n", sin(0.785398149999999)) # Output: 0.707107

--- a/tests/should_succeed/mathlibtest.jou
+++ b/tests/should_succeed/mathlibtest.jou
@@ -66,8 +66,6 @@ def main() -> int:
     printf("%f\n", expf(3.0 as float)) # Output: 20.085537
     printf("%f\n", exp2(3.0)) # Output: 8.000000
     printf("%f\n", exp2f(3.0 as float)) # Output: 8.000000
-    printf("%f\n", exp10(3.0)) # Output: 1000.000000
-    printf("%f\n", exp10f(3.0 as float)) # Output: 1000.000000
 
     printf("%f\n", log(114.0)) # Output: 4.736198
     printf("%f\n", logf(114.0 as float)) # Output: 4.736198

--- a/tests/should_succeed/mathlibtest.jou
+++ b/tests/should_succeed/mathlibtest.jou
@@ -53,9 +53,4 @@ def main() -> int:
     printf("%f\n", cbrt(27.0)) # Output: 3.000000
     printf("%f\n", hypot(3.0, 4.0)) # Output: 5.000000
 
-    printf("%f\n", erf(1.0)) # Output: 0.842701
-    printf("%f\n", erfc(1.0)) # Output: 0.157299
-    printf("%f\n", tgamma(6.0)) # Output: 120.000000
-    printf("%f\n", lgamma(6.0)) # Output: 4.787492
-
     return 0

--- a/tests/should_succeed/mathlibtest.jou
+++ b/tests/should_succeed/mathlibtest.jou
@@ -50,8 +50,8 @@ def main() -> int:
 
     printf("%f\n", cosh(3.0)) # Output: 10.067662
     printf("%f\n", coshf(3.0 as float)) # Output: 10.067662
-    printf("%f\n", sinh(4.0)) # Output: 27.289917
-    printf("%f\n", sinhf(4.0 as float)) # Output: 27.289917
+    printf("%f\n", sinh(3.0)) # Output: 10.017875
+    printf("%f\n", sinhf(3.0 as float)) # Output: 10.017875
     printf("%f\n", tanh(0.59)) # Output: 0.529896
     printf("%f\n", tanhf(0.59 as float)) # Output: 0.529896
 

--- a/tests/should_succeed/mathlibtest.jou
+++ b/tests/should_succeed/mathlibtest.jou
@@ -11,46 +11,78 @@ def main() -> int:
     printf("%d\n", min(12, 34))  # Output: 12
     printf("%lld\n", llmin(1000000000000, 2000000000000))  # Output: 1000000000000
     printf("%f\n", fmin(1.2, 3.4))  # Output: 1.200000
+    printf("%f\n", fminf(1.2 as float, 3.4 as float))  # Output: 1.200000
 
     printf("%d\n", max(12, 34))  # Output: 34
     printf("%lld\n", llmax(1000000000000, 2000000000000))  # Output: 2000000000000
     printf("%f\n", fmax(1.2, 3.4))  # Output: 3.400000
+    printf("%f\n", fmaxf(1.2 as float, 3.4 as float))  # Output: 3.400000
 
     printf("%d\n", abs(-1)) # Output: 1
     # TODO: Ideally this wouldn't need "as long"
     printf("%lld\n", llabs(-(1145141919180 as long))) # Output: 1145141919180
     printf("%f\n", fabs(-114.514)) # Output: 114.514000
+    printf("%f\n", fabsf(-114.514 as float)) # Output: 114.514000
 
     printf("%f\n", ceil(3.14)) # Output: 4.000000
+    printf("%f\n", ceilf(3.14 as float)) # Output: 4.000000
     printf("%f\n", floor(3.14)) # Output: 3.000000
-
+    printf("%f\n", floorf(3.14 as float)) # Output: 3.000000
     printf("%f\n", round(3.14)) # Output: 3.000000
+    printf("%f\n", roundf(3.14 as float)) # Output: 3.000000
 
     printf("%f\n", cos(1.04719753333333)) # Output: 0.500000
+    printf("%f\n", cosf(1.04719753333333 as float)) # Output: 0.500000
     printf("%f\n", sin(0.785398149999999)) # Output: 0.707107
+    printf("%f\n", sinf(0.785398149999999 as float)) # Output: 0.707107
     printf("%f\n", tan(2.45)) # Output: -0.828017
+    printf("%f\n", tanf(2.45 as float)) # Output: -0.828017
+
     printf("%f\n", acos(-1.0)) # Output: 3.141593
+    printf("%f\n", acosf(-1.0 as float)) # Output: 3.141593
     printf("%f\n", asin(-1.0)) # Output: -1.570796
+    printf("%f\n", asinf(-1.0 as float)) # Output: -1.570796
     printf("%f\n", atan(-1.0)) # Output: -0.785398
+    printf("%f\n", atanf(-1.0 as float)) # Output: -0.785398
+
     printf("%f\n", atan2(-1.0, -1.0)) # Output: -2.356194
+    printf("%f\n", atan2f(-1.0 as float, -1.0 as float)) # Output: -2.356194
 
     printf("%f\n", cosh(3.0)) # Output: 10.067662
+    printf("%f\n", coshf(3.0 as float)) # Output: 10.067662
     printf("%f\n", sinh(4.0)) # Output: 27.289917
+    printf("%f\n", sinhf(4.0 as float)) # Output: 27.289917
     printf("%f\n", tanh(0.59)) # Output: 0.529896
+    printf("%f\n", tanhf(0.59 as float)) # Output: 0.529896
+
     printf("%f\n", acosh(13.21)) # Output: 3.272686
+    printf("%f\n", acoshf(13.21 as float)) # Output: 3.272686
     printf("%f\n", asinh(0.5)) # Output: 0.481212
+    printf("%f\n", asinhf(0.5 as float)) # Output: 0.481212
     printf("%f\n", atanh(-0.50)) # Output: -0.549306
+    printf("%f\n", atanhf(-0.50 as float)) # Output: -0.549306
 
     printf("%f\n", exp(3.0)) # Output: 20.085537
+    printf("%f\n", expf(3.0 as float)) # Output: 20.085537
     printf("%f\n", exp2(3.0)) # Output: 8.000000
+    printf("%f\n", exp2f(3.0 as float)) # Output: 8.000000
+    printf("%f\n", exp10(3.0)) # Output: 1000.000000
+    printf("%f\n", exp10f(3.0 as float)) # Output: 1000.000000
 
     printf("%f\n", log(114.0)) # Output: 4.736198
+    printf("%f\n", logf(114.0 as float)) # Output: 4.736198
     printf("%f\n", log2(114.0)) # Output: 6.832890
+    printf("%f\n", log2f(114.0 as float)) # Output: 6.832890
     printf("%f\n", log10(114.0)) # Output: 2.056905
+    printf("%f\n", log10f(114.0 as float)) # Output: 2.056905
 
     printf("%f\n", pow(2.0, 2.0)) # Output: 4.000000
+    printf("%f\n", powf(2.0 as float, 2.0 as float)) # Output: 4.000000
     printf("%f\n", sqrt(5.0)) # Output: 2.236068
+    printf("%f\n", sqrtf(5.0 as float)) # Output: 2.236068
     printf("%f\n", cbrt(27.0)) # Output: 3.000000
+    printf("%f\n", cbrtf(27.0 as float)) # Output: 3.000000
     printf("%f\n", hypot(3.0, 4.0)) # Output: 5.000000
+    printf("%f\n", hypotf(3.0 as float, 4.0 as float)) # Output: 5.000000
 
     return 0

--- a/tests/should_succeed/mathlibtest.jou
+++ b/tests/should_succeed/mathlibtest.jou
@@ -85,4 +85,7 @@ def main() -> int:
     printf("%f\n", hypot(3.0, 4.0)) # Output: 5.000000
     printf("%f\n", hypotf(3.0 as float, 4.0 as float)) # Output: 5.000000
 
+    printf("%f\n", erf(2))  # Output: 0.995322
+    printf("%f\n", erff(2))  # Output: 0.995322
+
     return 0


### PR DESCRIPTION
- Add `M_PI` (3.1415...) and `M_E` (2.71828...) constants.
- Delete functions that don't exist on NetBSD: `exp10`, `exp10f`
- Delete functions that nobody uses: `erfc`, `erfcf`, `tgamma`, `tgammaf`, `lgamma`, `lgammaf`
- Improve documentation comments.
- Rearrange functions (e.g. `sin` before `cos`) to make the file more readable.