### PR TITLE
Do not implicitly compile with stdlib/_jou_startup.jou

### DIFF
--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -474,8 +474,6 @@ def main(argc: int, argv: byte**) -> int:
 
     # This part recursively finds and parses imported files.
     compst.parse_from_stdlib("_assert_fail.jou")
-    if WINDOWS or MACOS or NETBSD:
-        compst.parse_from_stdlib("_jou_startup.jou")
     compst.parse(command_line_args.infile, NULL)
 
     compst.typecheck_all_files()

--- a/tests/should_succeed/compiler_cli.jou
+++ b/tests/should_succeed/compiler_cli.jou
@@ -27,9 +27,6 @@ def print_reusing_compiled_file_lines(path: byte*) -> None:
 
     line: byte[500]
     while fgets(line, sizeof(line) as int, f) != NULL:
-        if strstr(line, "_jou_startup") != NULL:
-            continue  # platform-specific
-
         if starts_with(line, "Reusing"):
             p = &line[0]
             while *p != '\0':


### PR DESCRIPTION
This is a small technical thing that doesn't affect using Jou.

Nowadays `stdlib/_jou_startup.jou` is used for nothing. Before #910 it was used to set up global `stdin`, `stdout` and `stderr` variables, but they no longer exist.

We can delete `stdlib/_jou_startup.jou` when the bootstrap compiler has been updated to a version that doesn't require it.