### PR TITLE
CI: avoid `apt update` if `apt install` works without it

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,8 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt update
-      - run: sudo apt install -y codespell
+      - run: sudo apt install -y codespell || (sudo apt update && sudo apt install -y codespell)
       - run: codespell --enable-colors -L ot,bu,hel,fom,olt $(git ls-files)
 
   # For consistency, Jou code in markdown files should use ```python, not ```python3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,11 @@ jobs:
           key: bootstrap-${{ runner.os }}-${{ matrix.params.llvm-version }}-${{ matrix.params.opt-level }}-${{ hashFiles('bootstrap.sh') }}
       - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
         run: touch -c jou_bootstrap
-      - run: sudo apt update
+      - name: "Install apt packages"
+        run: |
+          PACKAGES="llvm-${{ matrix.params.llvm-version }}-dev clang-${{ matrix.params.llvm-version }} make valgrind liblzma-dev"
+          # Usually `sudo apt update` is unnecessary, but sometimes it helps
+          sudo apt install -y $PACKAGES || (sudo apt update && sudo apt install -y $PACKAGES)
       # liblzma-dev is for testing the `link` keyword, there is a test that decompresseses .xz file
       - run: sudo apt install -y llvm-${{ matrix.params.llvm-version }}-dev clang-${{ matrix.params.llvm-version }} make valgrind liblzma-dev
       - name: "Select LLVM version"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,7 +37,6 @@ jobs:
       - name: "Install apt packages"
         run: |
           PACKAGES="llvm-${{ matrix.params.llvm-version }}-dev clang-${{ matrix.params.llvm-version }} make valgrind liblzma-dev"
-          # Usually `sudo apt update` is unnecessary, but sometimes it helps
           sudo apt install -y $PACKAGES || (sudo apt update && sudo apt install -y $PACKAGES)
       # liblzma-dev is for testing the `link` keyword, there is a test that decompresseses .xz file
       - run: sudo apt install -y llvm-${{ matrix.params.llvm-version }}-dev clang-${{ matrix.params.llvm-version }} make valgrind liblzma-dev

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -62,8 +62,10 @@ jobs:
           key: bootstrap-valgrind-${{ runner.os }}-${{ matrix.params.llvm-version }}-${{ matrix.params.opt-level }}-${{ hashFiles('bootstrap.sh') }}
       - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
         run: touch -c jou_bootstrap
-      - run: sudo apt update
-      - run: sudo apt install -y llvm-${{ matrix.params.llvm-version }}-dev clang-${{ matrix.params.llvm-version }} make valgrind
+      - name: "Install apt packages"
+        run: |
+          PACKAGES="llvm-${{ matrix.params.llvm-version }}-dev clang-${{ matrix.params.llvm-version }} make valgrind"
+          sudo apt install -y $PACKAGES || (sudo apt update && sudo apt install -y $PACKAGES)
       - run: LLVM_CONFIG=llvm-config-${{ matrix.params.llvm-version }} make
       - name: "Test compiler with valgrind"
         run: ./runtests.sh --verbose --valgrind --jou-flags "${{ matrix.params.opt-level }}"


### PR DESCRIPTION
Sometimes `sudo apt update` is needed to avoid weird apt errors in `sudo apt install`. This PR changes the 11 Linux CI jobs to first try without it, and if that fails, run `sudo apt install` and try again.