### PR TITLE
Clean up weird union usages in compiler

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -1005,6 +1005,7 @@ class AstNameTypeValue:
 
 
 # declare global foo: int
+@public
 class AstGlobalVarDeclare:
     name: byte[100]
     type: AstType

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -1305,7 +1305,7 @@ class Parser:
                     result = AstStatement{
                         location = self.tokens.location,
                         kind = AstStatementKind.MethodDef,
-                        function = self.parse_function_or_method(True),
+                        method = self.parse_function_or_method(True),
                     }
                 case WhatAreWeParsing.FunctionBody | WhatAreWeParsing.MethodBody:
                     fail(self.tokens.location, "nested functions are not supported")
@@ -1323,7 +1323,7 @@ class Parser:
                 result = AstStatement{
                     location = location,
                     kind = AstStatementKind.GlobalVariableDeclare,
-                    global_var_def = AstGlobalVarDef{name = ntv.name, type = ntv.type},
+                    global_var_declare = AstGlobalVarDeclare{name = ntv.name, type = ntv.type},
                 }
             else:
                 result = AstStatement{

--- a/compiler/typecheck/common.jou
+++ b/compiler/typecheck/common.jou
@@ -122,7 +122,7 @@ def type_from_ast(ft: FileTypes*, containing_class: Type*, asttype: AstType*) ->
             return type_from_ast(ft, containing_class, asttype.value_type).pointer_type()
 
         case AstTypeKind.Array:
-            tmp = type_from_ast(ft, containing_class, asttype.value_type)
+            tmp = type_from_ast(ft, containing_class, asttype.array.member_type)
             len = evaluate_array_length(asttype.array.length)
             if len <= 0:
                 fail(asttype.array.length.location, "array length must be positive")

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -168,7 +168,7 @@ def ensure_can_take_address(fom: FunctionOrMethodTypes*, expr: AstExpression*, e
         newtemplate: byte*
         asprintf(&newtemplate, errmsg_template, "a field of %s")
 
-        ensure_can_take_address(fom, &expr.operands[0], newtemplate)
+        ensure_can_take_address(fom, expr.class_field.instance, newtemplate)
         free(newtemplate)
         return
 
@@ -1572,7 +1572,10 @@ def typecheck_statement(state: State*, stmt: AstStatement*) -> None:
             typecheck_expression(state, &stmt.expression, NULL)
 
         case AstStatementKind.Assert:
-            typecheck_expression_with_implicit_cast(state, &stmt.expression, boolType, "assertion must be a bool, not <from>")
+            typecheck_expression_with_implicit_cast(
+                state, &stmt.assertion.condition, boolType,
+                "assertion must be a bool, not <from>",
+            )
 
         case (
             AstStatementKind.FunctionDeclare


### PR DESCRIPTION
In Jou (and in C), if you have multiple union members with similar structure, it is possible to access the fields of one through another.

For example, the compiler has basically this:

```python
@public
class AstClassField:
    instance: AstExpression*
    field_name: byte[100]

@public
class AstExpression:
    ...
    union:
        class_field: AstClassField
        operands: AstExpression*
        ...
```

The first member of `AstClassField` is a pointer to an `AstExpression`. But `operands` is also a pointer to an `AstExpression`. This means that if you assign something to `class_field`, you can access its instance through `operands`.

Turns out that I had done this in a number of places by accident. This PR cleans up all that.

I noticed these when working on my Jou to C converter script (#890).