### PR TITLE
Disable valgrind for compiler unit tests

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -198,6 +198,12 @@ function should_skip()
         return 0
     fi
 
+    # When running valgrind, skip compiler unit tests. They link with LLVM and
+    # LLVM leaks memory when the program starts, even if it is never called.
+    if [ $valgrind = yes ] &&  [ $joufile = tests/should_succeed/compiler_unit_tests.jou ]; then
+        return 0
+    fi
+
     # Skip special programs that don't interact nicely with automated tests
     if [ $joufile = examples/x11_window.jou ] || [ $joufile = examples/memory_leak.jou ]; then
         return 0


### PR DESCRIPTION
When the unit tests start, they now import the global state thing, which links with LLVM. And when a program dynamically links with LLVM, for some reason LLVM allocates a bunch of memory that it doesn't free, even if you don't use LLVM. Valgrind sees this and complains.

I don't think valgrinding the compiler unit tests is necessary in the first place. In the past, all compiler memory bugs have been covered by something else than unit tests.

Fixes #1006 