### PR TITLE
Add a couple more tests for octal numbers

### DIFF
--- a/tests/syntax_error/number_underscore_prefix_oct.jou
+++ b/tests/syntax_error/number_underscore_prefix_oct.jou
@@ -1,0 +1,2 @@
+def main() -> int:
+    return 0o_777  # Error: invalid number or variable name "0o_777"

--- a/tests/syntax_error/number_underscore_suffix_oct.jou
+++ b/tests/syntax_error/number_underscore_suffix_oct.jou
@@ -1,0 +1,2 @@
+def main() -> int:
+    return 0o777_  # Error: invalid number or variable name "0o777_"


### PR DESCRIPTION
I noticed that these tests existed for hexadecimal numbers but not for octal.