### PR TITLE
Add --verbose argument to check-markdown-links.py

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -61,7 +61,7 @@ jobs:
           path: links.json
           key: links-${{ hashFiles('check-markdown-links.py') }}
       - run: pip install requests==2.32.3
-      - run: python check-markdown-links.py
+      - run: python check-markdown-links.py --verbose
 
   # Run the release script to make sure it doesn't error.
   release-dry-run:

--- a/check-markdown-links.py
+++ b/check-markdown-links.py
@@ -172,6 +172,11 @@ def main():
         action="store_true",
         help="don't do HTTP requests, just assume that https:// links are fine",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="also print links that are ok",
+    )
     args = parser.parse_args()
 
     good_links = 0
@@ -180,10 +185,12 @@ def main():
     for path in find_markdown_files():
         for lineno, target in find_links_in_file(path):
             result = check_link(path, target, offline_mode=args.offline)
-            print(f"{path}:{lineno}: {result}")
             if result == "ok" or result.startswith("assume ok"):
+                if args.verbose:
+                    print(f"{path}:{lineno}: {result}")
                 good_links += 1
             else:
+                print(f"{path}:{lineno}: {result}")
                 bad_links += 1
 
     if good_links + bad_links == 0:


### PR DESCRIPTION
Makes local development easier, because it doesn't print all the things that are ok.