### PR TITLE
bootstrap.sh improvements

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -82,7 +82,7 @@ function transpile_with_python_and_compile() {
         # Avoid the "python.exe" launcher that opens app store for installing python.
         python=$( (command -v py python || true) | (grep -v Microsoft/WindowsApps || true) | head -1)
     else
-        python=$( (command -v python3 python || true) | head -1)
+        python=$( (command -v python3 python python3.{10..20} || true) | head -1)
     fi
     echo "$python"
 


### PR DESCRIPTION
- Add an error message that is shown when clang (C compiler) is not found.
- Do not hard-code Python 3.13 specifically, so other Python versions will also work on NetBSD.
- Silence most `stdlib/assert.jou` unused import warnings.