### PR TITLE
Compiler command-line improvements

### DIFF
--- a/compiler/command_line_args.jou
+++ b/compiler/command_line_args.jou
@@ -10,7 +10,6 @@ import "./update.jou"
 enum CompilingMode:
     Run             # default mode (must be first)
     CompileToFile   # -o
-    Check           # --check
     TokenizeOnly    # --tokenize-only
     ParseOnly       # --parse-only
     UvgOnly         # --uvg-only
@@ -40,7 +39,6 @@ def print_help(argv0: byte*) -> None:
     printf("Options for compiling:\n")
     printf("  -o OUTFILE           output an executable file, don't run the code\n")
     printf("  -O0/-O1/-O2/-O3      set optimization level (0 = no optimization, 1 = default, 3 = runs fastest)\n")
-    printf("  --check              do not output or run anything, just check for errors in code\n")
     printf("  --valgrind           use valgrind when running the code\n")
     printf("  --fail-on-warnings   fail compiling if there were any compiler warnings\n")
     printf("  --linker-flags \"...\" appended to the linker command, just like 'link' statements in code\n")
@@ -60,8 +58,6 @@ def mode_to_flag(m: CompilingMode) -> byte*:
             return ""  # hopefully this never runs...
         case CompilingMode.CompileToFile:
             return "-o"
-        case CompilingMode.Check:
-            return "--check"
         case CompilingMode.TokenizeOnly:
             return "--tokenize-only"
         case CompilingMode.ParseOnly:
@@ -152,9 +148,6 @@ def parse_command_line_args(argc: int, argv: byte**) -> CommandLineArgs:
             case "-O0" | "-O1" | "-O2" | "-O3":
                 args.optlevel = argv[i][2] - '0'
                 optlevel_set = True
-                i++
-            case "--check":
-                set_mode(&args, CompilingMode.Check)
                 i++
             case "--valgrind":
                 args.valgrind = True

--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -499,8 +499,6 @@ def main(argc: int, argv: byte**) -> int:
             compile_to_jou_compiled_and_run()
         case CompilingMode.CompileToFile:
             compile_to_outfile()
-        case CompilingMode.Check:
-            assert False  # TODO: implement
 
     fail_if_warnings_and_flag()
 

--- a/tests/should_succeed/compiler_cli.jou
+++ b/tests/should_succeed/compiler_cli.jou
@@ -95,7 +95,6 @@ def main() -> int:
     # Output: Options for compiling:
     # Output:   -o OUTFILE           output an executable file, don't run the code
     # Output:   -O0/-O1/-O2/-O3      set optimization level (0 = no optimization, 1 = default, 3 = runs fastest)
-    # Output:   --check              do not output or run anything, just check for errors in code
     # Output:   --valgrind           use valgrind when running the code
     # Output:   --fail-on-warnings   fail compiling if there were any compiler warnings
     # Output:   --linker-flags "..." appended to the linker command, just like 'link' statements in code


### PR DESCRIPTION
- Add all flags to the help message.
- Add warnings for passing command-line arguments that do nothing.
- Clean up the code.

Preparation for #1046.