### PR TITLE
Delete strncmp() function from stdlib/str.jou

### DIFF
--- a/stdlib/str.jou
+++ b/stdlib/str.jou
@@ -55,11 +55,6 @@ declare strlen(s: byte*) -> int64
 @public
 declare strcmp(s1: byte*, s2: byte*) -> int
 
-# Similar to strcmp(), but imagines the strings are at most n bytes long.
-# In other words, if s1 or s2 is more than n bytes long, the rest is not compared.
-@public
-declare strncmp(s1: byte*, s2: byte*, n: int64) -> int
-
 # Returns true if the string s starts with the given prefix.
 @public
 @inline


### PR DESCRIPTION
As far as I can tell, this function was never used for anything other than implementing `starts_with()` which works much better when done without it (#1063).