### PR TITLE
Fix warning about -j2 being experimental

### DIFF
--- a/compiler/command_line_args.jou
+++ b/compiler/command_line_args.jou
@@ -128,7 +128,7 @@ def check_args(args: CommandLineArgs*, optlevel_set: bool) -> None:
     if args.parallelism != 0 and args.mode != CompilingMode.Run and args.mode != CompilingMode.CompileToFile:
         sprintf(flag, "-j%d", args.parallelism)
         warn_about_meaningless_arg(args, flag)
-    elif args.parallelism > 2:
+    elif args.parallelism >= 2:
         sprintf(flag, "-j%d", args.parallelism)
         fprintf(get_stderr(), "%s: warning: parallel compiling (%s) is experimental and doesn't always work\n", args.argv0, flag)
 


### PR DESCRIPTION
The compiler has a new `-j` flag to enable parallelism. It is off by default and the compiler prints a warning if you try to use it, because it does not always work.

Previously, a warning was shown for -j3, -j4 etc. This PR adds the same warning for `-j2` as I intended originally.