### PR TITLE
Improve compiler error message for Python-style type conversions like `int(foo)`

### DIFF
--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -723,6 +723,30 @@ class Parser:
                     self.tokens++
                     expr.enumcount.enum_type_ast = self.parse_type()
                 else:
+                    # Special error message for e.g. int(x)
+                    msg: byte[300]
+                    if self.tokens.kind == TokenKind.Keyword and self.tokens[1].is_operator("("):
+                        keyword = self.tokens.short_string
+                        match keyword with strcmp:
+                            case "byte" | "int" | "int8" | "uint8" | "int16" | "uint16" | "int32" | "uint32":
+                                snprintf(
+                                    msg,
+                                    sizeof(msg),
+                                    "%s is not a function, use 'as %s' to convert between numbers or e.g. atoi() from \"stdlib/str.jou\" to convert a string to int",
+                                    keyword,
+                                    keyword,
+                                )
+                                fail(self.tokens.location, msg)
+                            case "int64" | "uint64":
+                                snprintf(
+                                    msg,
+                                    sizeof(msg),
+                                    "%s is not a function, use 'as %s' to convert between numbers or e.g. atoll() from \"stdlib/str.jou\" to convert a string to int64",
+                                    keyword,
+                                    keyword,
+                                )
+                                fail(self.tokens.location, msg)
+
                     self.tokens.fail_expected_got("an expression")
 
         return expr

--- a/tests/syntax_error/python_cast_byte.jou
+++ b/tests/syntax_error/python_cast_byte.jou
@@ -1,0 +1,2 @@
+def blah() -> None:
+    x = byte("123")  # Error: byte is not a function, use 'as byte' to convert between numbers or e.g. atoi() from "stdlib/str.jou" to convert a string to int

--- a/tests/syntax_error/python_cast_int.jou
+++ b/tests/syntax_error/python_cast_int.jou
@@ -1,0 +1,2 @@
+def blah() -> None:
+    x = int("123")  # Error: int is not a function, use 'as int' to convert between numbers or e.g. atoi() from "stdlib/str.jou" to convert a string to int

--- a/tests/syntax_error/python_cast_int64.jou
+++ b/tests/syntax_error/python_cast_int64.jou
@@ -1,0 +1,2 @@
+def blah() -> None:
+    x = int64("123")  # Error: int64 is not a function, use 'as int64' to convert between numbers or e.g. atoll() from "stdlib/str.jou" to convert a string to int64

--- a/tests/syntax_error/python_cast_uint64.jou
+++ b/tests/syntax_error/python_cast_uint64.jou
@@ -1,0 +1,2 @@
+def blah() -> None:
+    x = uint64("123")  # Error: uint64 is not a function, use 'as uint64' to convert between numbers or e.g. atoll() from "stdlib/str.jou" to convert a string to int64


### PR DESCRIPTION
Example:

```python
def blah() -> None:
    return int(thing)
```

Before: `compiler error in file "a.jou", line 2: expected an expression, got the 'int' keyword`

After: `compiler error in file "a.jou", line 2: int is not a function, use 'as int' to convert between numbers or e.g. atoi() from "stdlib/str.jou" to convert a string to int`

Fixes #1086