### PR TITLE
Improve compiler error message for types like `[10]int` or `*int`

### DIFF
--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -465,6 +465,10 @@ class Parser:
         else:
             if could_be_an_expression:
                 return False
+            elif self.tokens.is_operator("*"):
+                fail(self.tokens.location, "a type cannot start with '*', use e.g. int* instead of *int for pointers")
+            elif self.tokens.is_operator("["):
+                fail(self.tokens.location, "a type cannot start with '[', use e.g. int[10] instead of [10]int for arrays")
             else:
                 self.tokens.fail_expected_got("a type")
 

--- a/tests/syntax_error/zig_array_type.jou
+++ b/tests/syntax_error/zig_array_type.jou
@@ -1,0 +1,2 @@
+def blah() -> None:
+    foo: [100]byte  # Error: a type cannot start with '[', use e.g. int[10] instead of [10]int for arrays

--- a/tests/syntax_error/zig_pointer_type.jou
+++ b/tests/syntax_error/zig_pointer_type.jou
@@ -1,0 +1,2 @@
+def blah() -> None:
+    foo: *byte  # Error: a type cannot start with '*', use e.g. int* instead of *int for pointers


### PR DESCRIPTION
Example:

```python
def blah(thing: *byte) -> None:
    pass
```

Before: `compiler error in file "a.jou", line 1: expected a type, got '*'`

After: `compiler error in file "a.jou", line 1: a type cannot start with '*', use e.g. int* instead of *int for pointers`

I also added a very similar message for `[10]int`.

Fixes #1087 