### PR TITLE
Improve compiler error for trying to use char as a type

### DIFF
--- a/compiler/typecheck/common.jou
+++ b/compiler/typecheck/common.jou
@@ -70,7 +70,10 @@ def handle_bad_generic(jou_file: JouFile*, generic: AstGenericType*, location: L
             # User could be attempting generic or array, we don't know. Let's
             # make an error message that is perfectly correct for both arrays
             # and generics.
-            snprintf(msg, sizeof(msg), "there is no type named '%s'", name)
+            if strcmp(name, "char") == 0:
+                msg = "there is no type named 'char', use 'byte' instead"
+            else:
+                snprintf(msg, sizeof(msg), "there is no type named '%s'", name)
         else:
             snprintf(msg, sizeof(msg), "there is no generic class named '%s'", name)
         fail(location, msg)
@@ -134,7 +137,10 @@ def type_from_ast(jou_file: JouFile*, containing_class: Type*, asttype: AstType*
             # At this point we will show an error for sure.
             generic = find_and_typecheck_generic_class(jou_file, asttype.name)
             if generic == NULL:
-                snprintf(msg, sizeof(msg), "there is no type named '%s'", asttype.name)
+                if strcmp(asttype.name, "char") == 0:
+                    msg = "there is no type named 'char', use 'byte' instead"
+                else:
+                    snprintf(msg, sizeof(msg), "there is no type named '%s'", asttype.name)
             else:
                 # Suggest int for all params of the generic class, e.g. List[int]
                 assert generic.classdata.is_generic()

--- a/tests/404/char.jou
+++ b/tests/404/char.jou
@@ -1,0 +1,2 @@
+def foo(x: char) -> None:  # Error: there is no type named 'char', use 'byte' instead
+    pass

--- a/tests/404/char_array_corner_case.jou
+++ b/tests/404/char_array_corner_case.jou
@@ -1,0 +1,5 @@
+const SIZE: int = 10
+
+# This is in a separate test because the error comes from a different place in the compiler.
+def foo(x: char[SIZE]) -> None:  # Error: there is no type named 'char', use 'byte' instead
+    pass


### PR DESCRIPTION
```python
def foo(x: char) -> None:
    pass
```

Before: `compiler error in file "char.jou", line 1: there is no type named 'char'`
After: `compiler error in file "char.jou", line 1: there is no type named 'char', use 'byte' instead`