### PR TITLE
Fix parameter types of `strchr()` and `strrchr()`

### DIFF
--- a/stdlib/str.jou
+++ b/stdlib/str.jou
@@ -36,10 +36,9 @@ declare asprintf(dest: byte**, pattern: byte*, ...) -> int
 declare strstr(haystack: byte*, needle: byte*) -> byte*
 
 # Find a byte from a string. Return a pointer to the occurrence, or NULL if not found.
-# The `needle` parameter is declared as `int` to match the C declarations
-# (`int` is used so callers can pass EOF-like sentinel values); in
-# practice only the low 8 bits are significant and it should be
-# considered a byte for all practical purposes.
+#
+# The type of `needle` parameter is int for compatibility/historical reasons
+# (C uses int), but for all practical purposes, think of it as byte.
 @public
 declare strchr(haystack: byte*, needle: int) -> byte*  # finds first occurrence
 @public

--- a/tests/should_succeed/strlibtest.jou
+++ b/tests/should_succeed/strlibtest.jou
@@ -34,14 +34,9 @@ def main() -> int:
     puts(full_text)
     free(full_text)
 
-    # strchr and strrchr basic checks
-    s = "abacada"
-    printf("%d\n", strchr(s, 'a') != NULL)  # Output: 1
-    printf("%c\n", *strchr(s, 'a'))  # Output: a
-    printf("%c\n", *strchr(s, 'b'))  # Output: b
-    printf("%d\n", strchr(s, 'x') != NULL)  # Output: 0
-    printf("%d\n", strrchr(s, 'a') != NULL)  # Output: 1
-    printf("%c\n", *strrchr(s, 'a'))  # Output: a
-    printf("%d\n", strrchr(s, 'a') > strchr(s, 'a'))  # Output: 1
+    printf("%s\n", strchr("hello world", 'o'))  # Output: o world
+    printf("%s\n", strrchr("hello world", 'o'))  # Output: orld
+    printf("%d\n", strchr("hello world", 'x') == NULL)  # Output: 1
+    printf("%d\n", strrchr("hello world", 'x') == NULL)  # Output: 1
 
     return 0


### PR DESCRIPTION
Fixes #1114 