### PR TITLE
runtests.sh: skip slow Advent of Code file

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -225,6 +225,11 @@ function should_skip()
         fi
     fi
 
+    # This file is very slow compared to other advent of codes
+    if [ $joufile = examples/aoc2023/day24/part2.jou ]; then
+        return 0
+    fi
+
     return 1  # false, don't skip
 }
 


### PR DESCRIPTION
My solution to Advent of Code 2023 day 24 part 2 is much slower than any of the other Advent of Code solutions. On my computer, it is about 12 times slower than any other Advent of Code solution (2.015 seconds vs 0.167 seconds). This is especially annoying when valgrinding.