### PR TITLE
bootstrap.sh: Delete old aarch64 hack

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -238,15 +238,6 @@ function compile_next_jou_compiler() {
         echo "Deleting version check..."
         sed -i -e "/Found unsupported LLVM version/d" Makefile.*
 
-        if [ $number -le 23 ] && ! [[ "$OS" =~ Windows ]]; then
-            echo "Patching Jou code to use or not use aarch64 depending on config..."
-            sed -i -e s/'if MACOS:'/'if LLVM_HAS_AARCH64:'/g compiler/target.jou
-            sed -i -e s/'if not WINDOWS:'/'if LLVM_HAS_AARCH64:'/g compiler/target.jou
-            grep LLVM_HAS_AARCH64 compiler/target.jou  # fail if it replaced nothing
-            sed -i -e '1i\
-import "../config.jou"'$'\n' compiler/target.jou
-        fi
-
         echo "Running make..."
 
         # The jou_bootstrap(.exe) file should never be rebuilt.


### PR DESCRIPTION
This PR removes handling for a special case that is no longer possible.

Previously bootstrapping started from an older commit that did not support aarch64 without some modifications, so if you were on aarch64 platform (e.g. mac M1), the `bootstrap.sh` script modified its copy of the compiler to support aarch64. But now that old compiler version is used only when bootstrapping on Windows with `./windows_setup.sh --small`, and on windows we always assume x86_64.