### PR TITLE
Use intnative instead of int64 for array lengths in stdlib/sort.jou

### DIFF
--- a/stdlib/sort.jou
+++ b/stdlib/sort.jou
@@ -52,31 +52,31 @@ def compare_strings(a: byte**, b: byte**) -> int:
 
 
 @public
-def sort_int8(ptr: int8*, len: int64) -> None:
+def sort_int8(ptr: int8*, len: intnative) -> None:
     Sorter[int8]{}.sort(ptr, len, compare_int8)
 @public
-def sort_int16(ptr: int16*, len: int64) -> None:
+def sort_int16(ptr: int16*, len: intnative) -> None:
     Sorter[int16]{}.sort(ptr, len, compare_int16)
 @public
-def sort_int32(ptr: int32*, len: int64) -> None:
+def sort_int32(ptr: int32*, len: intnative) -> None:
     Sorter[int32]{}.sort(ptr, len, compare_int32)
 @public
-def sort_int64(ptr: int64*, len: int64) -> None:
+def sort_int64(ptr: int64*, len: intnative) -> None:
     Sorter[int64]{}.sort(ptr, len, compare_int64)
 
 @public
-def sort_uint8(ptr: uint8*, len: int64) -> None:
+def sort_uint8(ptr: uint8*, len: intnative) -> None:
     Sorter[uint8]{}.sort(ptr, len, compare_uint8)
 @public
-def sort_uint16(ptr: uint16*, len: int64) -> None:
+def sort_uint16(ptr: uint16*, len: intnative) -> None:
     Sorter[uint16]{}.sort(ptr, len, compare_uint16)
 @public
-def sort_uint32(ptr: uint32*, len: int64) -> None:
+def sort_uint32(ptr: uint32*, len: intnative) -> None:
     Sorter[uint32]{}.sort(ptr, len, compare_uint32)
 @public
-def sort_uint64(ptr: uint64*, len: int64) -> None:
+def sort_uint64(ptr: uint64*, len: intnative) -> None:
     Sorter[uint64]{}.sort(ptr, len, compare_uint64)
 
 @public
-def sort_strings(ptr: byte**, len: int64) -> None:
+def sort_strings(ptr: byte**, len: intnative) -> None:
     Sorter[byte*]{}.sort(ptr, len, compare_strings)


### PR DESCRIPTION
Now `jou --check tests/should_succeed/sort_test.jou` passes with no errors if `intnative` is `int`.

Once this is merged, there should be no (or very little) need for patches in #1124.