### PR TITLE
runtests.sh: Fix showing number of failed tests on NetBSD

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -335,7 +335,7 @@ fi
 echo ""
 echo ""
 
-failed=$( (ls -1 tmp/tests/diff*.txt 2>/dev/null || true) | wc -l)
+failed=$( (ls -1 tmp/tests/diff*.txt 2>/dev/null || true) | wc -l | tr -d ' ')
 succeeded=$((counter - failed - skipped))
 
 if [ $failed != 0 ]; then


### PR DESCRIPTION
Before:

<img width="322" height="110" alt="screenshot-1766335598" src="https://github.com/user-attachments/assets/9521d5d8-f273-47b5-82c7-1052646050b2" />

After:

<img width="250" height="85" alt="screenshot-1766335615" src="https://github.com/user-attachments/assets/cb64f84d-c9c0-4c1a-a636-a4d10a03b09c" />

Not really a big deal, but I thought I might as well fix this.