### PR TITLE
Fix vm/netbsd.sh race condition

### DIFF
--- a/vm/netbsd.sh
+++ b/vm/netbsd.sh
@@ -97,7 +97,7 @@ if ! [ -f key ] || ! timeout 5 $ssh echo hello; then
     # We consider the VM started when it shows login prompt on serial port.
     # At that point it has also started ssh.
     echo "Waiting for VM to boot..."
-    echo | ../wait_for_string.sh 'login:' nc localhost 4444
+    until echo | ../wait_for_string.sh 'login:' nc localhost 4444; do sleep 1; done
     echo "Checking again if ssh works..."
     if ! [ -f key ] || ! timeout 5 $ssh echo hello; then
         echo "ssh doesn't work. Let's set it up using serial port."


### PR DESCRIPTION
In another unrelated PR, vm/netbsd.sh failed in GitHub Actions with the following error:

<img width="531" height="200" alt="Image" src="https://github.com/user-attachments/assets/41770f6d-bd8b-4967-9fe5-8e1947fd57a0" />

The reason is that just after starting qemu, it does this:

```sh
    echo "Waiting for VM to boot..."
    echo | ../wait_for_string.sh 'login:' nc localhost 4444
```

If qemu starts slower than the commands in `netbsd.sh`, this runs before qemu listens on port 4444, and fails because netcat is already trying to connect.

Unfortunately it's hard to test this fix, because I've seen the race condition only once, and it was not locally on my computer. So I'll just hope that my fix is right :)