### PR TITLE
GitHub Actions: delete old commented-out cache stuff

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,13 +32,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch the whole Git history for bootstrapping
-      # TODO: do we want a cache?
-#      - uses: actions/cache@v4
-#        with:
-#          path: jou_bootstrap
-#          key: bootstrap-${{ runner.os }}-${{ matrix.params.llvm-version }}-${{ matrix.params.opt-level }}-${{ hashFiles('bootstrap.sh') }}
-#      - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
-#        run: touch -c jou_bootstrap
       - name: "Install apt packages"
         # liblzma-dev is for testing the `link` keyword, there is a test that decompresseses .xz file
         run: |

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -60,13 +60,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch the whole Git history for bootstrapping
-      # TODO: do we want a cache?
-#      - uses: actions/cache@v4
-#        with:
-#          path: jou_bootstrap
-#          key: bootstrap-valgrind-${{ runner.os }}-${{ matrix.params.llvm-version }}-${{ matrix.params.opt-level }}-${{ hashFiles('bootstrap.sh') }}
-#      - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
-#        run: touch -c jou_bootstrap
       - name: "Install apt packages"
         run: |
           PACKAGES="llvm-${{ matrix.params.llvm-version }}-dev clang-${{ matrix.params.llvm-version }} make valgrind"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,13 +19,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch the whole Git history for bootstrapping
-      # TODO: do we want a cache?
-#      - uses: actions/cache@v4
-#        with:
-#          path: jou_bootstrap.exe
-#          key: bootstrap-${{ runner.os }}-${{ hashFiles('*.sh') }}
-#      - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
-#        run: touch -c jou_bootstrap.exe
       # Do not use --small because it relies on a previously built zip
       - run: source activate && ./windows_setup.sh
         shell: bash
@@ -142,13 +135,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch the whole Git history for bootstrapping
-      # TODO: do we want a cache?
-#      - uses: actions/cache@v4
-#        with:
-#          path: jou_bootstrap.exe
-#          key: bootstrap-${{ runner.os }}-${{ hashFiles('*.sh') }}
-#      - name: "Mark cached bootstrap compiler as modified so that it is not rebuilt"
-#        run: touch -c jou_bootstrap.exe
       - run: ./windows_setup.sh --small
         shell: bash
       - name: "Compile and test"


### PR DESCRIPTION
About 40 days ago in #960, I commented out cache stuff and ended up with a bunch of `# TODO: do we want a cache?` comments. I can now confidently say that no, we don't want a cache.