### PR TITLE
tests/liblzma: run without pkg-config and use `intnative`

### DIFF
--- a/tests/should_succeed/imported/simple_lzma_decode.jou
+++ b/tests/should_succeed/imported/simple_lzma_decode.jou
@@ -2,14 +2,15 @@
 
 import "stdlib/assert.jou"
 import "stdlib/io.jou"
+import "stdlib/intnative.jou"
 
 class lzma_stream:
     next_in: byte*
-    avail_in: int64
+    avail_in: intnative
     total_in: int64
 
     next_out: byte*
-    avail_out: int64
+    avail_out: intnative
     total_out: int64
 
     dummy: byte[1000]  # should be big enough, currently the whole struct 136 bytes on my system

--- a/vm/alpine.sh
+++ b/vm/alpine.sh
@@ -134,7 +134,7 @@ done
 echo "Checking if repo needs to be copied over..."
 if [ "$($ssh 'cd jou && git rev-parse HEAD' || true)" != "$(git rev-parse HEAD)" ]; then
     echo "Installing packages (if not already installed)..."
-    $ssh 'which git || apk add bash clang llvm-dev make git grep'
+    $ssh 'which git || apk add bash clang llvm-dev make git grep xz-static'
 
     echo "Copying repository to VM..."
     git bundle create jou.bundle --all


### PR DESCRIPTION
Doesn’t yet quite work:

```patch
$ uname -spr && git show -s --oneline && ./runtests.sh --verbose lz
NetBSD 11.0_BETA earmv6hf
e1fc38d (HEAD -> liblzma-netbsd-32bit) wip
<joudir> in expected output will be replaced with /home/taahol/jou.
<jouexe> in expected output will be replaced with ./jou.
<intnative> in expected output will be replaced with int.
<pointersize> in expected output will be replaced with 4.
gmake: 'jou' is up to date.
run: jou tests/should_succeed/link_with_liblzma_dynamic.jou
FAIL jou tests/should_succeed/link_with_liblzma_dynamic.jou
run: cp '/usr/lib/liblzma.a' tmp/tests/ && jou tests/should_succeed/link_with_liblzma_relative_path.jou
skip tests/should_succeed/link_with_liblzma_system_path.jou
FAIL cp '/usr/lib/liblzma.a' tmp/tests/ && jou tests/should_succeed/link_with_liblzma_relative_path.jou


------- FAILURES -------


*** Command: jou tests/should_succeed/link_with_liblzma_dynamic.jou ***

--- /dev/fd/63  2025-12-23 20:48:38.000000000 +0200
+++ /dev/fd/62  2025-12-23 20:48:38.000000000 +0200
@@ -1,2 +1 @@
-hellohellohello
-Exit code: 0
+Exit code: 1


*** Command: cp '/usr/lib/liblzma.a' tmp/tests/ && jou tests/should_succeed/link_with_liblzma_relative_path.jou ***

--- /dev/fd/63  2025-12-23 20:48:38.000000000 +0200
+++ /dev/fd/62  2025-12-23 20:48:38.000000000 +0200
@@ -1,2 +1 @@
-hellohellohello
-Exit code: 0
+Exit code: 1
0 succeeded, 2 failed, 1 skipped
```