### PR TITLE
Fix occasional bootstrapping error

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,9 +74,9 @@ function transpile_with_python_and_compile() {
     echo -n "Finding Python... "
     if [[ "${OS:=$(uname)}" =~ Windows ]]; then
         # Avoid the "python.exe" launcher that opens app store for installing python.
-        python=$( (command -v py python || true) | (grep -v Microsoft/WindowsApps || true) | head -1)
+        python=$(command -v py python | grep -v Microsoft/WindowsApps | head -1 || true)
     else
-        python=$( (command -v python3 python python3.{10..20} || true) | head -1)
+        python=$(command -v python3 python python3.{10..20} | head -1 || true)
     fi
     echo "$python"
 


### PR DESCRIPTION
We have sometimes (very inconsistently) gotten this error when bootstrapping:

```
Finding Python... make: *** [Makefile.posix:52: jou_bootstrap] Error 141
```

Here 141 = 128 + 13, where 13 means SIGPIPE. The problem was that when `head` closes its input after reading one line, the commands being piped into it could still be trying to write, and the whole pipeline would fail due to use of `set -o pipefail`.