### PR TITLE
Accept and ignore `@public` decorator on methods

### DIFF
--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -199,7 +199,9 @@ def decorate(stmt: AstStatement*, decor: byte*, location: Location) -> None:
                 if strcmp(stmt.function.ast_signature.name, "main") == 0:
                     fail(location, "the main() function cannot be @public")
             case AstStatementKind.MethodDef:
-                fail(location, "methods cannot be decorated with @public, a class is either fully public or fully private")
+                # For now, decorating a method with @public does nothing.
+                # Methods will be private by default in the future.
+                return
             case _:
                 pass
 

--- a/tests/other_errors/public_method.jou
+++ b/tests/other_errors/public_method.jou
@@ -1,4 +1,0 @@
-class Foo:
-    @public  # Error: methods cannot be decorated with @public, a class is either fully public or fully private
-    def bar(self) -> None:
-        pass

--- a/tests/should_succeed/imported/bar.jou
+++ b/tests/should_succeed/imported/bar.jou
@@ -10,6 +10,7 @@ class Point:
     def get_sum(self) -> int:
         return self.x + self.y
 
+    @public
     def increment_y(self) -> None:
         self.y += 1
 


### PR DESCRIPTION
This is the first step of changing how methods are public/private (#1077).

Example:

```python
class Foo:
    @public  # This does nothing (for now)
    def bar(self) -> None:
        pass
```