### PR TITLE
Fix valgrind error in compiler

### DIFF
--- a/compiler/paths.jou
+++ b/compiler/paths.jou
@@ -196,7 +196,7 @@ def find_current_executable() -> byte*:
                 if ret < 0:
                     break  # error
                 if ret < size:
-                    buf[ret] = '\0'  # Work around valgrind bug: https://github.com/Akuli/jou/issues/1190
+                    buf[ret] = '\0'  # Work around valgrind bug: https://bugs.kde.org/show_bug.cgi?id=514094
                     return buf  # success, it fits
 
     # TODO: show os error message? (GetLastError / errno)


### PR DESCRIPTION
Fixes #1190 

This turned out to be a valgrind bug. I reported it to valgrind developers: https://bugs.kde.org/show_bug.cgi?id=514094

This PR adds a simple workaround that shouldn't be necessary, but on valgrind it is.