### PR TITLE
Fix unwanted implicit integer conversion behavior

### DIFF
--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -409,6 +409,8 @@ def cast_type_of_integer_binop(ltype: Type*, rtype: Type*, op: AstExpressionKind
                 if ltype.size_in_bits == rtype.size_in_bits:
                     return uint_type(bigger_size)
                 return int_type(bigger_size)
+            else:
+                return uint_type(bigger_size)
 
 
 def check_binop(


### PR DESCRIPTION
Fixes #1214.
Note: when running 'make' in the repository with this change, the compiler issues a warning:
```
compiler warning for file "compiler/typecheck/step3_function_and_method_bodies.jou", line 352: 
    function 'cast_type_of_integer_binop' doesn't seem to return a value in all cases
```