### PR TITLE
Enable a test wrongly commented out as "not working"

### DIFF
--- a/tests/should_succeed/global.jou
+++ b/tests/should_succeed/global.jou
@@ -5,7 +5,7 @@ global y: int = 100
 global z = 200
 
 global int_array = [10, 20, 30]
-#global int16_array: int16 = [40, 50, 60]  # TODO: doesn't work
+global int16_array: int16[3] = [40, 50, 60]
 global string_array = ["hello", "world"]
 #global arraystring_array: byte[10][2] = ["hello", "world"]  # TODO: doesn't work
 
@@ -13,7 +13,7 @@ def increment_all() -> None:
     x++
     y++
     z++
-#    int16_array[0]++  # TODO
+    int16_array[0]++  # TODO
     int_array[0]++
     string_array[1]++
     #arraystring_array[1][2]++  # TODO
@@ -26,7 +26,7 @@ def main() -> int:
     printf("%d %d %d\n", x, y, z)  # Output: 2 102 202
 
     printf("%d %d %d\n", int_array[0], int_array[1], int_array[2])  # Output: 12 20 30
-    #printf("%d %d %d\n", int16_array[0], int16_array[1], int16_array[2])  # TODO
+    printf("%d %d %d\n", int16_array[0], int16_array[1], int16_array[2])  # Output: 42 50 60
     printf("%s %s\n", string_array[0], string_array[1])  # Output: hello rld
     #printf("%s %s\n", arraystring_array[0], arraystring_array[1])  # TODO
 


### PR DESCRIPTION
In #1223 I added tests and commented out a part of them, thinking that some compiler bug prevents it from working. Turns out I just wrote the test wrong. This PR fixes and uncomments that test.

There is also another test case that I won't fix in this PR:

```python
#global arraystring_array: byte[10][2] = ["hello", "world"]  # TODO: doesn't work
```

The problem with this one is that string constants become pointer strings in the parser, so I would need to add another pointer string to array string conversion. Doable, but slightly more work.