### PR TITLE
`JSONBuilder`: Assert that values in an object have keys

### DIFF
--- a/stdlib/json.jou
+++ b/stdlib/json.jou
@@ -55,6 +55,7 @@ class JSONBuilder:
         if self.key_added:
             self.key_added = False
         else:
+            self.add_comma_if_needed()
             self.new_line()
 
     @public


### PR DESCRIPTION
Fixes #1234 

The code in #1234 now produces:

```
Assertion 'self.key_added' failed in file "/home/akuli/jou/stdlib/json.jou", line 53.
```