### PR TITLE
Add better error messages for true, TRUE, false, FALSE, null and Null

### DIFF
--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -1247,6 +1247,12 @@ def typecheck_expression(state: State*, expr: AstExpression*, type_hint: Type*) 
                                 strcat(msg, ", try 'get_stdout()' from \"stdlib/io.jou\"")
                             case "stderr":
                                 strcat(msg, ", try 'get_stderr()' from \"stdlib/io.jou\"")
+                            case "Null" | "null":
+                                strcat(msg, ", try NULL")
+                            case "TRUE" | "true":
+                                strcat(msg, ", try True")
+                            case "FALSE" | "false":
+                                strcat(msg, ", try False")
                         fail(expr.location, msg)
                     name = expr.varname
                     expr.kind = AstExpressionKind.GetFuncPtr

--- a/tests/404/false_lowercase.jou
+++ b/tests/404/false_lowercase.jou
@@ -1,0 +1,3 @@
+def blah() -> None:
+    if false:  # Error: no variable named 'false', try False
+        pass

--- a/tests/404/false_uppercase.jou
+++ b/tests/404/false_uppercase.jou
@@ -1,0 +1,3 @@
+def blah() -> None:
+    if FALSE:  # Error: no variable named 'FALSE', try False
+        pass

--- a/tests/404/null_capitalized.jou
+++ b/tests/404/null_capitalized.jou
@@ -1,0 +1,3 @@
+def blah() -> None:
+    if "hi" == Null:  # Error: no variable named 'Null', try NULL
+        pass

--- a/tests/404/null_lowercase.jou
+++ b/tests/404/null_lowercase.jou
@@ -1,0 +1,3 @@
+def blah() -> None:
+    if "hi" == null:  # Error: no variable named 'null', try NULL
+        pass

--- a/tests/404/true_lowercase.jou
+++ b/tests/404/true_lowercase.jou
@@ -1,0 +1,3 @@
+def blah() -> None:
+    if true:  # Error: no variable named 'true', try True
+        pass

--- a/tests/404/true_uppercase.jou
+++ b/tests/404/true_uppercase.jou
@@ -1,0 +1,3 @@
+def blah() -> None:
+    if TRUE:  # Error: no variable named 'TRUE', try True
+        pass


### PR DESCRIPTION
Fixes #1241 

```python
def foo() -> None:
    x = true
```

Before: `compiler error in file "a.jou", line 2: no variable named 'true'`
After: `compiler error in file "a.jou", line 2: no variable named 'true', try True`