### PR TITLE
Delete leftovers of the `long` datatype in bootstrap compiler

### DIFF
--- a/bootstrap_transpiler.py
+++ b/bootstrap_transpiler.py
@@ -501,7 +501,6 @@ BASIC_TYPES = {
 }
 BASIC_TYPES["byte"] = BASIC_TYPES["uint8"]
 BASIC_TYPES["int"] = BASIC_TYPES["int32"]
-BASIC_TYPES["long"] = BASIC_TYPES["int64"]
 
 
 # argtypes passed as tuple to make the caching work
@@ -635,7 +634,6 @@ class Parser:
             "void",
             "noreturn",
             "int",
-            "long",
             "byte",
             "float",
             "double",


### PR DESCRIPTION
The `long` type was replaced by `int64` long ago (#948), so I can remove a couple unnecessary lines of code in the bootstrap compiler.

I stumbled across this by accident and I thought I might as well clean it up. But I don't want to spend a lot of time making the bootstrap compiler nice or clean in any way, it just has to work.