### PR TITLE
Delete nan() function from stdlib/math.jou

### DIFF
--- a/stdlib/math.jou
+++ b/stdlib/math.jou
@@ -151,11 +151,6 @@ declare atan2(y: double, x: double) -> double
 @public
 declare atan2f(y: float, x: float) -> float
 
-# Use nan("") to get a quiet NaN (Not-A-Number) value.
-# The argument must be an empty string.
-@public
-declare nan(tagp: byte*) -> double
-
 # Hyperbolic versions of the trig functions
 @public
 declare sinh(x: double) -> double


### PR DESCRIPTION
I never used this function. To get a NaN, you can simply do `0.0 / 0.0` anyway.