### PR TITLE
Remove outdated info about global variable initialization in documentation

### DIFF
--- a/doc/keywords.md
+++ b/doc/keywords.md
@@ -459,8 +459,7 @@ def main() -> int:
 Note that unlike in Python,
 you don't need to use `global` inside a function to modify the global variable.
 
-By default, global variables are always initialized to zero memory,
-and it is not possible to specify any other initializing.
+By default, global variables are always initialized to zero memory.
 For example, numbers are initialized to zero, booleans are initialized to `False` and pointers are initialized to `NULL`.
 It is possible to specify a different initial value:
 


### PR DESCRIPTION
It is now possible to define an initial value. This was previously not possible, and the documentation still said so just before showing how to do it.