### PR TITLE
Fix occasional error in release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -82,7 +82,7 @@ echo "  Status: $(jq -r .status < run.json)"
 echo "  Artifacts URL: $(jq -r .artifacts_url < run.json)"
 echo ""
 
-if [ $(jq -r .status < run.json) != completed ]; then
+if [ "$(jq -r .status < run.json)" != "completed" ]; then
     echo "Seems like CI is still running. Not releasing."
     exit 0
 fi


### PR DESCRIPTION
I noticed that the release dry-run was red in CI. Here's why:

<img width="652" height="595" alt="screenshot-1772542369" src="https://github.com/user-attachments/assets/f3c6cc2c-5b2e-4bd9-9916-221fab70db88" />