### PR TITLE
Require parentheses in sizeof(x)

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -157,10 +157,10 @@ class TreePrinter:
         subprinter = TreePrinter{}
         if is_last_child:
             printf("%s`--- ", self.prefix)
-            snprintf(subprinter.prefix, sizeof subprinter.prefix, "%s  ", self.prefix)
+            snprintf(subprinter.prefix, sizeof(subprinter.prefix), "%s  ", self.prefix)
         else:
             printf("%s|--- ", self.prefix)
-            snprintf(subprinter.prefix, sizeof subprinter.prefix, "%s| ", self.prefix)
+            snprintf(subprinter.prefix, sizeof(subprinter.prefix), "%s| ", self.prefix)
         return subprinter
 
 
@@ -254,7 +254,7 @@ enum AstExpressionKind:
     As
     EnumCount
     # unary operators
-    SizeOf          # sizeof x
+    SizeOf          # sizeof(x)
     ArrayCount      # array_count x
     EmbedFile       # embed_file("./foo.bar")
     AddressOf       # &x

--- a/compiler/evaluate.jou
+++ b/compiler/evaluate.jou
@@ -73,7 +73,7 @@ def read_embedded_file(jou_file: JouFile*, specified_path: byte*, location: Loca
     file_content = List[byte]{}
     buf: byte[4096]
     while True:
-        num_read = fread(buf, 1, sizeof buf, file)
+        num_read = fread(buf, 1, sizeof(buf), file)
         if num_read == 0:
             if ferror(file) != 0:
                 # TODO: include errno in the error message?

--- a/compiler/main.jou
+++ b/compiler/main.jou
@@ -39,7 +39,7 @@ def warn_about_unused(jou_file: JouFile*) -> None:
 
     for stmt = jou_file.ast.ptr; stmt < jou_file.ast.end(); stmt++:
         if stmt.kind == AstStatementKind.Import and not stmt.import_statement.used:
-            snprintf(msg, sizeof msg, "\"%s\" imported but not used", stmt.import_statement.specified_path)
+            snprintf(msg, sizeof(msg), "\"%s\" imported but not used", stmt.import_statement.specified_path)
             show_warning(stmt.location, msg)
 
     for sym_stmt = jou_file.symbol_statements.ptr; sym_stmt < jou_file.symbol_statements.end(); sym_stmt++:
@@ -280,7 +280,7 @@ def make_imported_statements_available() -> None:
 
             for i = 0; i < seen_before.len; i++:
                 if seen_before.ptr[i] == imported:
-                    snprintf(msg, sizeof msg, "file \"%s\" is imported twice", the_import.import_statement.specified_path)
+                    snprintf(msg, sizeof(msg), "file \"%s\" is imported twice", the_import.import_statement.specified_path)
                     fail(the_import.location, msg)
             seen_before.append(imported)
 

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -25,7 +25,7 @@ declare atof(string: byte*) -> double
 # just the token (e.g. ++ could mean pre-increment or post-increment).
 def build_operator_expression(t: Token*, arity: int, operands: AstExpression*) -> AstExpression:
     assert arity == 1 or arity == 2 or arity == 3
-    nbytes = arity * sizeof operands[0]
+    nbytes = arity * sizeof(operands[0])
     ptr = malloc(nbytes)
     memcpy(ptr, operands, nbytes)
 
@@ -524,7 +524,7 @@ class Parser:
 
             # Now let's just assume it's an array, e.g. int[10]
             self.tokens = old_tokens_ptr
-            len_expression: AstExpression* = malloc(sizeof *len_expression)
+            len_expression: AstExpression* = malloc(sizeof(*len_expression))
             *len_expression = self.parse_expression()
             self.eat_operator("]", True, "a ']' to end the array size")
             temp_ptr = malloc(sizeof(*temp_ptr))
@@ -559,7 +559,7 @@ class Parser:
         value: AstExpression* = NULL
         if self.tokens.is_operator("="):
             self.eat_operator("=", False, NULL)
-            value = malloc(sizeof *value)
+            value = malloc(sizeof(*value))
             *value = self.parse_expression()
 
         return AstNameTypeValue{name = name.short_string, name_location = name.location, type = type, value = value}
@@ -607,7 +607,7 @@ class Parser:
                 for p = result.args.ptr; p < result.args.end(); p++:
                     if strcmp(p.name, arg.name) == 0:
                         snprintf(
-                            message, sizeof message,
+                            message, sizeof(message),
                             "there are multiple arguments named '%s'", arg.name)
                         fail(arg.name_location, message)
 
@@ -630,7 +630,7 @@ class Parser:
         self.eat_operator("->", True, "a '->'")
 
         if not used_self and is_method:
-            snprintf(message, sizeof message, "missing self, should be 'def %s(self, ...)'", result.name)
+            snprintf(message, sizeof(message), "missing self, should be 'def %s(self, ...)'", result.name)
             fail(self.tokens.location, message)
 
         result.return_type = self.parse_type()
@@ -645,11 +645,11 @@ class Parser:
             for f = result.fields.ptr; f < result.fields.end(); f++:
                 if strcmp(f.name, fname.short_string) == 0:
                     error: byte[500]
-                    snprintf(error, sizeof error, "multiple values were given for field '%s'", fname.short_string)
+                    snprintf(error, sizeof(error), "multiple values were given for field '%s'", fname.short_string)
                     fail(fname.location, error)
 
             msg: byte[300]
-            snprintf(msg, sizeof msg, "'=' followed by a value for field '%s'", fname.short_string)
+            snprintf(msg, sizeof(msg), "'=' followed by a value for field '%s'", fname.short_string)
             self.eat_operator("=", True, msg)
 
             result.fields.append(AstInstantiationField{name = fname.short_string, value = self.parse_expression()})
@@ -730,6 +730,16 @@ class Parser:
                 elif self.tokens.is_operator("["):
                     expr.kind = AstExpressionKind.Array
                     expr.array = self.parse_array()
+                elif self.tokens.is_keyword("sizeof"):
+                    expr.kind = AstExpressionKind.SizeOf
+                    self.eat_keyword("sizeof", False, NULL)
+                    if not self.tokens.is_operator("("):
+                        fail(self.tokens.location, "value after sizeof must be in parentheses, e.g. sizeof(thing)")
+                    self.tokens++
+                    expr.operands = malloc(sizeof(expr.operands[0]))
+                    assert expr.operands != NULL
+                    *expr.operands = self.parse_expression()
+                    self.eat_operator(")", True, "a ')'")
                 elif self.tokens.is_keyword("enum_count"):
                     expr.kind = AstExpressionKind.EnumCount
                     self.tokens++
@@ -773,7 +783,7 @@ class Parser:
         self.eat_operator(".", False, NULL)
         field_name_token = self.eat_by_kind(TokenKind.Name, True, "a field or method name")
 
-        instance: AstExpression* = malloc(sizeof *instance)
+        instance: AstExpression* = malloc(sizeof(*instance))
         *instance = obj
         return AstExpression{
             location = field_name_token.location,
@@ -835,7 +845,6 @@ class Parser:
             or self.tokens.is_operator("&")
             or self.tokens.is_operator("*")
             or self.tokens.is_operator("~")
-            or self.tokens.is_keyword("sizeof")
             or self.tokens.is_keyword("embed_file")
             or self.tokens.is_keyword("array_count")
         ):
@@ -874,8 +883,6 @@ class Parser:
                     kind = AstExpressionKind.AddressOf
                 elif token.is_operator("~"):
                     kind = AstExpressionKind.BitNot
-                elif token.is_keyword("sizeof"):
-                    kind = AstExpressionKind.SizeOf
                 elif token.is_keyword("embed_file"):
                     kind = AstExpressionKind.EmbedFile
                 elif token.is_keyword("array_count"):
@@ -1043,7 +1050,7 @@ class Parser:
             self.tokens++
             result.kind = AstStatementKind.Return
             if self.tokens.kind != TokenKind.Newline:
-                result.return_value = malloc(sizeof *result.return_value)
+                result.return_value = malloc(sizeof(*result.return_value))
                 *result.return_value = self.parse_expression()
         elif self.tokens.is_keyword("assert"):
             assert_keyword = self.tokens++
@@ -1195,7 +1202,7 @@ class Parser:
         if self.tokens.is_operator(";"):
             init = NULL
         else:
-            init = malloc(sizeof *init)
+            init = malloc(sizeof(*init))
             *init = self.parse_oneline_statement()
 
         self.eat_operator(";", True, "a ';'")
@@ -1204,7 +1211,7 @@ class Parser:
         if self.tokens.is_operator(";"):
             cond = NULL
         else:
-            cond = malloc(sizeof *cond)
+            cond = malloc(sizeof(*cond))
             *cond = self.parse_expression()
 
         self.eat_operator(";", True, "a ';'")
@@ -1213,7 +1220,7 @@ class Parser:
         if self.tokens.is_operator(":"):
             incr = NULL
         else:
-            incr = malloc(sizeof *incr)
+            incr = malloc(sizeof(*incr))
             *incr = self.parse_oneline_statement()
 
         if (
@@ -1598,7 +1605,7 @@ class Parser:
 
             for p = result.members.ptr; p < result.members.end(); p++:
                 if strcmp(*p, member_name.short_string) == 0:
-                    assert sizeof member_name.short_string == 100
+                    assert sizeof(member_name.short_string) == 100
                     error: byte[200]
                     sprintf(error, "the enum has two members named '%s'", member_name.short_string)
                     fail(member_name.location, error)

--- a/compiler/paths.jou
+++ b/compiler/paths.jou
@@ -237,7 +237,7 @@ def hash_of_compiler() -> Hash:
 @public
 def find_stdlib() -> byte*:
     checked: byte*[3]
-    memset(&checked, 0, sizeof checked)
+    memset(&checked, 0, sizeof(checked))
 
     exedir = find_current_executable()
     while WINDOWS and strstr(exedir, "\\") != NULL:

--- a/compiler/target.jou
+++ b/compiler/target.jou
@@ -86,11 +86,11 @@ def init_global_target() -> None:
 
     if JOU_TARGET[0] != '\0':
         triple = JOU_TARGET
-        assert strlen(triple) < sizeof global_compiler_state.target.triple
+        assert strlen(triple) < sizeof(global_compiler_state.target.triple)
         strcpy(global_compiler_state.target.triple, triple)
     else:
         triple = LLVMGetDefaultTargetTriple()
-        assert strlen(triple) < sizeof global_compiler_state.target.triple
+        assert strlen(triple) < sizeof(global_compiler_state.target.triple)
         strcpy(global_compiler_state.target.triple, triple)
         LLVMDisposeMessage(triple)
 
@@ -113,7 +113,7 @@ def init_global_target() -> None:
     # corner cases where either the compiler or the program crashes...
     dummy_target = init_thread_local_target()
     tmp = LLVMCopyStringRepOfTargetData(dummy_target.data)
-    assert strlen(tmp) < sizeof global_compiler_state.target.data_layout
+    assert strlen(tmp) < sizeof(global_compiler_state.target.data_layout)
     strcpy(global_compiler_state.target.data_layout, tmp)
     LLVMDisposeMessage(tmp)
     dummy_target.free()

--- a/compiler/token.jou
+++ b/compiler/token.jou
@@ -117,9 +117,9 @@ class Token:
             case TokenKind.Decorator:
                 got = "a decorator"
             case TokenKind.Name:
-                snprintf(got, sizeof got, "a variable name '%s'", self.short_string)
+                snprintf(got, sizeof(got), "a variable name '%s'", self.short_string)
             case TokenKind.Keyword:
-                snprintf(got, sizeof got, "the '%s' keyword", self.short_string)
+                snprintf(got, sizeof(got), "the '%s' keyword", self.short_string)
             case TokenKind.Newline:
                 got = "end of line"
             case TokenKind.Indent:
@@ -127,7 +127,7 @@ class Token:
             case TokenKind.Dedent:
                 got = "less indentation"
             case TokenKind.Operator:
-                snprintf(got, sizeof got, "'%s'", self.short_string)
+                snprintf(got, sizeof(got), "'%s'", self.short_string)
             case TokenKind.EndOfFile:
                 got = "end of file"
 

--- a/compiler/tokenizer.jou
+++ b/compiler/tokenizer.jou
@@ -612,7 +612,7 @@ def handle_indentations(raw_tokens: Token*) -> Token*:
     # indent tokens and parsing will fail. If the file doesn't have any blank/comment
     # lines in the beginning, it has a newline token anyway to avoid special casing.
     assert tokens.ptr[0].kind == TokenKind.Newline
-    memmove(&tokens.ptr[0], &tokens.ptr[1], sizeof tokens.ptr[0] * --tokens.len)
+    memmove(&tokens.ptr[0], &tokens.ptr[1], sizeof(tokens.ptr[0]) * --tokens.len)
 
     return tokens.ptr
 
@@ -626,7 +626,7 @@ def read_file_to_string(path: byte*, import_statement: AstStatement*) -> byte*:
         message: byte[200]
         if import_statement == NULL:
             # File is not imported
-            snprintf(message, sizeof message, "cannot open file: %s", strerror(get_errno()))
+            snprintf(message, sizeof(message), "cannot open file: %s", strerror(get_errno()))
             fail(Location{path=path}, message)
         if not ends_with(path, ".jou"):
             # e.g. import "stdlib/io"
@@ -637,13 +637,13 @@ def read_file_to_string(path: byte*, import_statement: AstStatement*) -> byte*:
             if file != NULL:
                 snprintf(
                     message,
-                    sizeof message,
+                    sizeof(message),
                     "use \"%s.jou\" instead of \"%s\"",
                     import_statement.import_statement.specified_path,
                     import_statement.import_statement.specified_path,
                 )
                 fail(import_statement.location, message)
-        snprintf(message, sizeof message, "cannot import from \"%s\": %s", path, strerror(get_errno()))
+        snprintf(message, sizeof(message), "cannot import from \"%s\": %s", path, strerror(get_errno()))
         fail(import_statement.location, message)
 
     bytes_list = List[byte]{}
@@ -658,7 +658,7 @@ def read_file_to_string(path: byte*, import_statement: AstStatement*) -> byte*:
 
     buf: byte[4096]
     while True:
-        num_read = fread(buf, 1, sizeof buf, file)
+        num_read = fread(buf, 1, sizeof(buf), file)
         if num_read == 0:
             if ferror(file) != 0:
                 # TODO: include errno in the error message?

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -130,11 +130,11 @@ def short_expression_description(expr: AstExpression*) -> byte[200]:
 
         case AstExpressionKind.AddressOf:
             inner = short_expression_description(&expr.operands[0])
-            snprintf(result, sizeof result, "address of %s", inner)
+            snprintf(result, sizeof(result), "address of %s", inner)
             return result
 
         case AstExpressionKind.GetClassField | AstExpressionKind.GetClassFieldPtr | AstExpressionKind.DotOperator:
-            snprintf(result, sizeof result, "field '%s'", expr.class_field.field_name)
+            snprintf(result, sizeof(result), "field '%s'", expr.class_field.field_name)
             return result
 
 
@@ -801,7 +801,7 @@ def typecheck_call(state: State*, call: AstCall*, location: Location) -> Type*:
         ):
             assert strstr(method_name, "%") == NULL
             snprintf(
-                msg, sizeof msg,
+                msg, sizeof(msg),
                 "cannot take address of %%s, needed for calling the %s() method",
                 method_name,
             )
@@ -864,7 +864,7 @@ def typecheck_call(state: State*, call: AstCall*, location: Location) -> Type*:
         # This is a common error, so worth spending some effort to get a good error message.
         which_arg = nth(i+1)
         snprintf(
-            msg, sizeof msg,
+            msg, sizeof(msg),
             "%s argument of %s should have type <to>, not <from>", which_arg, what_we_calling
         )
         typecheck_expression_with_implicit_cast(state, &call.args.ptr[i], param_type, msg)
@@ -913,7 +913,7 @@ def typecheck_instantiation(state: State*, inst: AstInstantiation*, location: Lo
     for f = inst.fields.ptr; f < inst.fields.end(); f++:
         field = typecheck_class_field(state, t, f.name, f.value.location)
 
-        snprintf(msg, sizeof msg,
+        snprintf(msg, sizeof(msg),
             "value for field '%s' of class %s must be of type <to>, not <from>",
             f.name, t.name)
         typecheck_expression_with_implicit_cast(state, &f.value, field.type, msg)
@@ -1570,7 +1570,7 @@ def typecheck_statement(state: State*, stmt: AstStatement*) -> None:
                     msg = "cannot place a value of type <from> into a pointer of type <to>*"
                 else:
                     desc = short_expression_description(targetexpr)
-                    snprintf(msg, sizeof msg, "cannot assign a value of type <from> to %s of type <to>", desc)
+                    snprintf(msg, sizeof(msg), "cannot assign a value of type <from> to %s of type <to>", desc)
                 typecheck_expression_with_implicit_cast(state, valueexpr, targettype, msg)
 
         case (
@@ -1636,7 +1636,7 @@ def typecheck_statement(state: State*, stmt: AstStatement*) -> None:
             t = check_binop(state.fom, op, stmt.location, targetexpr, valueexpr)
             if t != targetexpr.types.orig_type:
                 snprintf(
-                    msg, sizeof msg,
+                    msg, sizeof(msg),
                     "%s produced a value of type %s which cannot be assigned back to %s",
                     opname, t.name, targetexpr.types.orig_type.name
                 )
@@ -1671,7 +1671,7 @@ def typecheck_statement(state: State*, stmt: AstStatement*) -> None:
                 fail(stmt.location, msg)
 
             if stmt.return_value != NULL:
-                snprintf(msg, sizeof msg,
+                snprintf(msg, sizeof(msg),
                     "attempting to return a value of type <from> from %s '%s' defined with '-> <to>'",
                     function_or_method, state.fom.symbol.signature.name)
                 typecheck_expression_with_implicit_cast(state, stmt.return_value, return_type, msg)

--- a/compiler/types.jou
+++ b/compiler/types.jou
@@ -172,12 +172,12 @@ class Type:
     def pointer_type(self) -> Type*:
         info = cast_type_to_typeinfo(self)
         if info.pointer == NULL:
-            ptr: TypeInfo* = calloc(1, sizeof *ptr)
+            ptr: TypeInfo* = calloc(1, sizeof(*ptr))
             ptr.type = Type{kind=TypeKind.Pointer, value_type=self}
             if self.kind == TypeKind.FuncPtr:
-                snprintf(ptr.type.name, sizeof ptr.type.name, "(%s)*", self.name)
+                snprintf(ptr.type.name, sizeof(ptr.type.name), "(%s)*", self.name)
             else:
-                snprintf(ptr.type.name, sizeof ptr.type.name, "%s*", self.name)
+                snprintf(ptr.type.name, sizeof(ptr.type.name), "%s*", self.name)
             info.pointer = ptr
         return &info.pointer.type
 
@@ -196,12 +196,12 @@ class Type:
             ):
                 return &(*t).type
 
-        arr: TypeInfo* = calloc(1, sizeof *arr)
+        arr: TypeInfo* = calloc(1, sizeof(*arr))
         arr.type = Type{kind = TypeKind.Array, array = ArrayType{item_type = self, count = count}}
         if self.kind == TypeKind.FuncPtr:
-            snprintf(arr.type.name, sizeof arr.type.name, "(%s)[%d]", self.name, count)
+            snprintf(arr.type.name, sizeof(arr.type.name), "(%s)[%d]", self.name, count)
         else:
-            snprintf(arr.type.name, sizeof arr.type.name, "%s[%d]", self.name, count)
+            snprintf(arr.type.name, sizeof(arr.type.name), "%s[%d]", self.name, count)
 
         info.related_types.append(arr)
         return &arr.type
@@ -515,7 +515,7 @@ def funcptr_type(argtypes: Type**, nargs: intnative, takes_varargs: bool, return
         assert not is_noreturn
         ret_name = return_type.name
 
-    info: TypeInfo* = calloc(1, sizeof *info)
+    info: TypeInfo* = calloc(1, sizeof(*info))
     assert info != NULL
 
     fptype = FuncPtrType{
@@ -591,10 +591,10 @@ def satisfy_valgrind(ti: TypeInfo*) -> None:
 
 
 def create_simple_type(name: byte*, kind: TypeKind) -> Type*:
-    result: TypeInfo* = calloc(1, sizeof *result)
+    result: TypeInfo* = calloc(1, sizeof(*result))
     result.type = Type{kind = kind}
 
-    assert strlen(name) < sizeof result.type.name
+    assert strlen(name) < sizeof(result.type.name)
     strcpy(result.type.name, name)
 
     satisfy_valgrind(result)
@@ -618,10 +618,10 @@ def create_enum(name: byte*, members: List[byte[100]]) -> Type*:
     copied_members = List[byte[100]]{}
     copied_members.extend(members)
 
-    result: TypeInfo* = calloc(1, sizeof *result)
+    result: TypeInfo* = calloc(1, sizeof(*result))
     result.type = Type{kind = TypeKind.Enum, enum_members = copied_members}
 
-    assert strlen(name) < sizeof result.type.name
+    assert strlen(name) < sizeof(result.type.name)
     strcpy(result.type.name, name)
 
     satisfy_valgrind(result)
@@ -706,8 +706,8 @@ class Signature:
             if strcmp(arg.name, "self") == 0 and not include_self:
                 continue
 
-            assert sizeof arg.name == 100
-            assert sizeof arg.type.name == 500
+            assert sizeof(arg.name) == 100
+            assert sizeof(arg.type.name) == 500
             result = realloc(result, strlen(result) + 1000)
             assert result != NULL
             strcat(result, arg.name)

--- a/examples/aoc2023/day07/part2.jou
+++ b/examples/aoc2023/day07/part2.jou
@@ -107,7 +107,7 @@ class Hand:
             if self.letters[i] == 'J':
                 # Duplicate each existing variation 13 times
                 nvariations *= 13
-                variations = realloc(variations, sizeof(variations)[0] * nvariations)
+                variations = realloc(variations, sizeof(variations[0]) * nvariations)
                 for isrc = nvariations/13 - 1; isrc >= 0; isrc--:
                     for idest = 13*isrc; idest < 13*(isrc+1); idest++:
                         variations[idest] = variations[isrc]

--- a/tests/should_succeed/file.jou
+++ b/tests/should_succeed/file.jou
@@ -31,7 +31,7 @@ def read_hello_123() -> None:
 
     rewind(f)
     text: byte[100]
-    fgets(&text[0], sizeof text, f)
+    fgets(&text[0], sizeof(text), f)
     printf("got %s", &text[0])  # Output: got hello 123
 
     fclose(f)

--- a/tests/should_succeed/linked_list.jou
+++ b/tests/should_succeed/linked_list.jou
@@ -13,7 +13,7 @@ class Node:
             putchar('\n')
 
 def prepend(list: Node**, value: byte) -> None:
-    new_first: Node* = malloc(sizeof *new_first)
+    new_first: Node* = malloc(sizeof(*new_first))
     *new_first = Node{value = value, next = *list}
     *list = new_first
 

--- a/tests/should_succeed/printf.jou
+++ b/tests/should_succeed/printf.jou
@@ -26,7 +26,7 @@ def main() -> int:
 
     string: byte[50]
     snprintf(
-        &string[0], sizeof string,
+        &string[0], sizeof(string),
         "blah blah. Int %d, float %f, string %s.",
         12345, 12.34, "hello")
     puts(&string[0])  # Output: blah blah. Int 12345, float 12.340000, string hel

--- a/tests/should_succeed/sizeof.jou
+++ b/tests/should_succeed/sizeof.jou
@@ -15,7 +15,7 @@ def ensure_sizeof_isnt_too_small_in_a_weird_corner_case() -> None:
     value = Foo{a=1, b=2, c='x'}
     # We need the heap allocation, because otherwise the optimizer happens to make things work.
     ptr = malloc(50) as Foo*
-    memcpy(ptr, &value, sizeof value)
+    memcpy(ptr, &value, sizeof(value))
     # If sizeof is too small, this prints garbage.
     printf("%c\n", ptr.c)  # Output: x
     free(ptr)
@@ -27,20 +27,20 @@ def main() -> int:
     by: byte
     n: int
     m: int64
-    printf("%d %d %d %d\n", sizeof bo, sizeof by, sizeof n, sizeof m)  # Output: 1 1 4 8
+    printf("%d %d %d %d\n", sizeof(bo), sizeof(by), sizeof(n), sizeof(m))  # Output: 1 1 4 8
 
-    # test that operator precedence works
-    printf("%d\n", sizeof by + sizeof n + sizeof m)  # Output: 13
+    # Test that operator precedence works
+    printf("%d\n", sizeof(by) + sizeof(n) + sizeof(m))  # Output: 13
 
     arr: int64[100]
-    printf("%d\n", sizeof arr)  # Output: 800
+    printf("%d\n", sizeof(arr))  # Output: 800
 
-    # The "array length trick"
-    printf("%d\n", sizeof arr / sizeof arr[0])  # Output: 100
+    # The "array length trick" that was used before array_count() existed
+    printf("%d\n", sizeof(arr) / sizeof(arr[0]))  # Output: 100
     printf("%d\n", array_count arr)  # Output: 100
 
     # Evaluating a sizeof has no side effects.
-    printf("%d\n", sizeof side_effect())  # Output: 4
+    printf("%d\n", sizeof(side_effect()))  # Output: 4
 
     # Size of strings. Size of byte* is expected to be 4 or 8.
     # Output: 6 100 <pointersize>

--- a/tests/should_succeed/union.jou
+++ b/tests/should_succeed/union.jou
@@ -27,6 +27,6 @@ def main() -> int:
 
     # Union is typically just large enough to hold its biggest element.
     f: Foo
-    printf("max(%d, %d) = %d\n", sizeof f.small, sizeof f.big, sizeof f)  # Output: max(4, 8) = 8
+    printf("max(%d, %d) = %d\n", sizeof(f.small), sizeof(f.big), sizeof(f))  # Output: max(4, 8) = 8
 
     return 0

--- a/tests/syntax_error/sizeof_parens.jou
+++ b/tests/syntax_error/sizeof_parens.jou
@@ -1,0 +1,2 @@
+def blah() -> None:
+    x = sizeof 1  # Error: value after sizeof must be in parentheses, e.g. sizeof(thing)


### PR DESCRIPTION
Previously it was possible to write e.g. `sizeof 1` or `sizeof foo[0]`. You now need e.g. `sizeof(1)` or `sizeof(foo[0])`.

This is an improvement, because in Advent of Code 2023, I accidentally wrote `sizeof(variations)[0]` when I meant `sizeof(variations[0])`. That worked despite looking very misleading. I didn't even know that this was possible until I made this PR :)