### PR TITLE
Bootstrap script improvements

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,7 @@ numbered_commits=(
     026_eeb1a89b82c9bdee5c8942604b3f8b2b9a2e786d  # <--- "./windows_setup.sh --small" starts from here! (release 2025-12-23-0400)
     027_3f878188ab2f5784514bb0c19057bee37c98bd60  # accept @public decorator on methods
     028_cb88ac4b437db34545d1249c93ff61605ae59644  # <--- bootstrap_transpiler.py starts here!
-    029_95e29106b13cda7ef33c7e934ed67158463a88e9  # INFINITY and NAN constants, array_end() built-in
+    029_95e29106b13cda7ef33c7e934ed67158463a88e9  # support for INFINITY and NAN constants, array_end() built-in
 )
 
 # This should be an item of the above list according to what


### PR DESCRIPTION
I updated the bootstrap compiler to support `1.0 / 0.0` and `0.0 / 0.0` in `const` (#1267). This also means that I will get better error messages when developing Jou compiler, most notably #1206.

I also deleted a bunch of special-casing for old Jou versions that are no longer used in bootstrapping.

It turned out that BSD make doesn't have `--old-file` or equivalent flag, so I decided to just not invoke `make` during bootstrapping. The `--old-file` flag was needed to prevent getting a bootstrap inside a bootstrap due to `make` deciding that it needs to bootstrap for whatever reason.