### PR TITLE
Fix memory leak in TOML parser

### DIFF
--- a/stdlib/toml.jou
+++ b/stdlib/toml.jou
@@ -808,6 +808,7 @@ class TOMLParser:
         while *self.ptr != ']':
             if *self.ptr == '\0':
                 self.error = "missing ']' to end the array"
+                result.free()
                 return False
 
             if not self.check_depth(depth_of_array + 1):


### PR DESCRIPTION
Given an inline array with unexpected end of file, like `parse_toml("foo = [1, 2, 3")`, the TOML parser leaked memory. This PR fixes it.

Fixes #1274