### PR TITLE
Fix TOML test failure

### DIFF
--- a/tests/should_succeed/toml_test.jou
+++ b/tests/should_succeed/toml_test.jou
@@ -46,7 +46,7 @@ def test_basic_parsing() -> None:
     printf("%d\n", toml_get(toml_get(&toml, "languages"), "toml").lineno)
 
     # Output: 123
-    printf("%d\n", toml_get(toml_get(&toml, "languages"), "number").integer)
+    printf("%lld\n", toml_get(toml_get(&toml, "languages"), "number").integer)
     # Output: 0.000000
     printf("%f\n", toml_get(toml_get(&toml, "languages"), "number").floating)
 


### PR DESCRIPTION
The test was printing a TOML integer with `%d`, but it should be `%lld` because TOML integers are `int64`.

This was a bug in the test, not in the TOML parser itself.

Fixes #1275 