### PR TITLE
Fix deleting compiled files on MacOS

### DIFF
--- a/compiler/paths.jou
+++ b/compiler/paths.jou
@@ -1,6 +1,6 @@
 import "stdlib/assert.jou"
 import "stdlib/ascii.jou"
-import "stdlib/list.jou"
+import "stdlib/fs.jou"
 import "stdlib/mem.jou"
 import "stdlib/str.jou"
 import "stdlib/io.jou"
@@ -47,105 +47,6 @@ else:
 
 @public
 declare dirname(path: byte*) -> byte*
-
-if WINDOWS:
-    class WIN32_FIND_DATAA:
-        # WIN32_FIND_DATAA is 320 bytes. We can't fill in the actual members
-        # here because jou adds a lot of padding.
-        dummy: byte[320]
-
-    const INVALID_HANDLE_VALUE: int64 = -1
-
-    declare FindFirstFileA(FileName: byte*, FindFileData: WIN32_FIND_DATAA*) -> int64
-    declare FindNextFileA(hFindFile: int64, FindFileData: WIN32_FIND_DATAA*) -> int
-    declare FindClose(hFindFile: int64) -> int
-
-else:
-    class DIR:
-        pass
-    class dirent:
-        pass
-
-    # I ran the following C program to find the offset of d_name in the dirent struct:
-    #
-    #    #include <dirent.h>
-    #    #include <stddef.h>
-    #    #include <stdio.h>
-    #    int main()
-    #    {
-    #        printf("%d\n", (int) offsetof(struct dirent, d_name));
-    #        return 0;
-    #    }
-    if NETBSD:
-        const DIRENT_NAME_OFFSET: int = 13
-    else:
-        # Assume linux
-        const DIRENT_NAME_OFFSET: int = 19
-
-    if NETBSD:
-        # On NetBSD, "opendir" and "readdir" are legacy functions.
-        # We can't use them because they generate a linker warning.
-        # The dirent.h header magically renames them at compile time to the following names.
-        declare __opendir30(name: byte*) -> DIR*
-        declare __readdir30(dirp: DIR*) -> dirent*
-        def opendir(name: byte*) -> DIR*:
-            return __opendir30(name)
-        def readdir(dirp: DIR*) -> dirent*:
-            return __readdir30(dirp)
-    else:
-        declare opendir(name: byte*) -> DIR*
-        declare readdir(dirp: DIR*) -> dirent*
-
-    declare closedir(dirp: DIR*) -> int
-
-
-# The listdir() function returns a list of names (not full paths) of everything
-# in a given directory, just like os.listdir() in Python. Long names are ignored.
-#
-# TODO: put this to stdlib instead of here?
-def listdir(path: byte*) -> List[byte[100]]:
-    result = List[byte[100]]{}
-
-    if WINDOWS:
-        find_spec: byte*
-        asprintf(&find_spec, "%s\\*", path)  # Find anything
-
-        find_data: WIN32_FIND_DATAA
-        handle = FindFirstFileA(path, &find_data)
-
-        # Seems like there's no easy way to distinguish empty directory and error.
-        if handle != INVALID_HANDLE_VALUE:
-            found_something = True
-            while found_something:
-                cFileName = &(&find_data as byte*)[44]  # cFileName field is at offset 44
-                short_name: byte[100] = ""
-                if strlen(cFileName) < sizeof(short_name):
-                    strcpy(short_name, cFileName)
-                    result.append(short_name)
-                found_something = (FindNextFileA(handle, &find_data) != 0)
-            FindClose(handle)
-
-    else:
-        dir = opendir(path)
-
-        if dir == NULL:
-            fprintf(get_stderr(), "error: cannot list directory '%s'\n", path)
-            exit(1)
-
-        while True:
-            entry = readdir(dir)
-            if entry == NULL:
-                break
-
-            d_name = &(entry as byte*)[DIRENT_NAME_OFFSET]
-            short_name: byte[100] = ""
-            if strlen(d_name) < sizeof(short_name):
-                strcpy(short_name, d_name)
-                result.append(short_name)
-
-        closedir(dir)
-
-    return result
 
 
 def file_exists(path: byte*) -> bool:
@@ -342,24 +243,15 @@ def get_path_to_jou_compiled_subfolder() -> byte*:
 
 # Deletes files in a directory whose name ends with the given suffix.
 def delete_by_suffix(dir: byte*, suffix: byte*) -> None:
-    list = listdir(dir)
-
-    for p = list.ptr; p < list.end(); p++:
-        if ends_with(*p, suffix):
-            full_path: byte*
-            asprintf(&full_path, "%s/%s", dir, *p)
-
+    iter = DirIter{dir = dir}
+    while iter.next():
+        if ends_with(iter.name, suffix):
             if WINDOWS:
-                ret = _unlink(full_path)
+                ret = _unlink(iter.path)
             else:
-                ret = unlink(full_path)
-
+                ret = unlink(iter.path)
             if ret == 0 and global_compiler_state.args.verbosity >= 1:
-                printf("Deleted %s\n", full_path)
-
-            free(full_path)
-
-    free(list.ptr)
+                printf("Deleted %s\n", iter.path)
 
 
 def get_simple_name(jou_file_path: byte*) -> byte[50]:


### PR DESCRIPTION
Fixes #1272

The fix is to throw away the whole `listdir()` function and replace it with `DirIter` from `stdlib/fs.jou`.