### PR TITLE
Fix `DirIter` on 32-bit ARM linux

### DIFF
--- a/stdlib/fs.jou
+++ b/stdlib/fs.jou
@@ -260,5 +260,5 @@ class DirIter:
                     if starts_with(u.machine, "arm"):
                         name = &name[-8]
 
-                if self.set_name(entry.d_name):
+                if self.set_name(name):
                     return True


### PR DESCRIPTION
Previously `DirIter` from `stdlib/fs.jou` didn't work on 32-bit ARM linux. This PR fixes that.

The problem is a bit complicated. 32-bit ARM linux, there are two versions of `readdir()`, named `readdir()` and `readdir64()`. In C, you get `readdir64()` when you try to call `readdir()` due to magic in header files.

We can't always call `readdir64()` on 32-bit linux, because it doesn't exist on 32-bit x86 linux and you get a linker error. I'll try to get some kind of workaround to work here.

Fixes #1283