### PR TITLE
windows_setup.sh: Do not download again if already downloaded

### DIFF
--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -70,12 +70,12 @@ else
         sha=5937a482247bebc2eca8c0b93fa43ddb17d94968adfff3f2e0c63c94608ee76b
     fi
 
-    if [ -n "$offline_zip" ]; then
-        echo "Copying $offline_zip to ./$filename..."
-        cp "$offline_zip" "$filename"
-    else
+    if [ -z "$offline_zip" ]; then
         echo "Downloading $filename..."
         curl -L -C - -o $filename $url
+    else
+        echo "Copying $offline_zip to ./$filename..."
+        cp "$offline_zip" "$filename"
     fi
 
     echo "Verifying $filename..."


### PR DESCRIPTION
This makes developing Jou on Windows slightly nicer. `mingw64.zip` is quite a big download, so if anything goes wrong while extracting it, you might not want to download the whole thing again.

~~I'm not sure if `curl` has something similar to `wget --continue`, but if it does, it would be even better to use it here. Marking as draft until I figure that out.~~