### PR TITLE
Require less accuracy in test of monotonic_ns()

### DIFF
--- a/tests/should_succeed/time_test.jou
+++ b/tests/should_succeed/time_test.jou
@@ -35,7 +35,7 @@ def test_monotonic_ns() -> None:
     end = monotonic_ns()
 
     seconds = (end - start)*1e-9
-    if fabs(seconds - 1.0) < 0.01:
+    if fabs(seconds - 1.0) < 0.05:
         # Output: time() vs monotonic_ns() ok
         printf("time() vs monotonic_ns() ok\n")
     else:


### PR DESCRIPTION
Because Windows is being Windows, the test failed on an unrelated PR:

<img width="625" height="349" alt="screenshot-1773577087" src="https://github.com/user-attachments/assets/58d442f4-77b6-41ab-b699-e3637d62d76d" />
