### PR TITLE
Fix `windows_setup.sh --small` and update the bootstrap compiler

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,10 +17,9 @@ set -e -o pipefail
 # The numbering does not start from 0 for historical reasons. Commit 001 was
 # just before the original compiler written in C was deleted.
 numbered_commits=(
-    026_eeb1a89b82c9bdee5c8942604b3f8b2b9a2e786d  # <--- "./windows_setup.sh --small" starts from here! (release 2025-12-23-0400)
-    027_3f878188ab2f5784514bb0c19057bee37c98bd60  # accept @public decorator on methods
     028_cb88ac4b437db34545d1249c93ff61605ae59644  # <--- bootstrap_transpiler.py starts here!
     029_95e29106b13cda7ef33c7e934ed67158463a88e9  # support for INFINITY and NAN constants, array_end() built-in
+    030_bb3dc7d925fa28ce405fda5a4fc3c428f6f7c2b1  # <--- "./windows_setup.sh --small" starts from here! (release 2026-03-16-0500)
 )
 
 # This should be an item of the above list according to what

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -16,8 +16,7 @@ offline_zip=
 while [ $# != 0 ]; do
     case "$1" in
         --small)
-            echo "WARNING: The --small flag is currently not supported! Ignoring."
-            #small=yes
+            small=yes
             shift
             ;;
         --offline-zip)
@@ -57,13 +56,13 @@ else
     if [ $small = yes ]; then
         # User has slow internet and doesn't want to download the whole mingw64.
         # Instead, download a release of Jou, and extract mingw and Jou compiler from there.
-        url=https://github.com/Akuli/jou/releases/download/2025-12-23-0400/jou_windows_64bit_2025-12-23-0400.zip
-        filename=jou_windows_64bit_2025-12-23-0400.zip
-        sha=2dcfe26a7bb127f436f0df193387a1ecaaf7a83b15833928810ae8ebe0633cd4
+        url=https://github.com/Akuli/jou/releases/download/2026-03-16-0500/jou_windows_64bit_2026-03-16-0500.zip
+        filename=jou_windows_64bit_2026-03-16-0500.zip
+        sha=e1d62b64fac1798c41077f8b97902947d3430cc4b9b8cb988c7b56a75df7d697
         # This is the folder where the downloaded Jou compiler (jou.exe) will go.
         # Placing it here makes bootstrap.sh use our downloaded Jou compiler
         # instead of starting from scratch.
-        jou_exe_folder=tmp/bootstrap_cache/026_eeb1a89b82c9bdee5c8942604b3f8b2b9a2e786d
+        jou_exe_folder=tmp/bootstrap_cache/030_bb3dc7d925fa28ce405fda5a4fc3c428f6f7c2b1
     else
         # This is a mingw64 version that comes with LLVM 19.
         url=https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.7-12.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-14.2.0-llvm-19.1.7-mingw-w64msvcrt-12.0.0-r3.zip


### PR DESCRIPTION
This fixes `windows_setup.sh --small`  broken in #1288. I broke it intentionally because there was no released version of Jou that contained the library files I wanted to use, and the whole point of `--small` is to download everything from a release. Now there is. 

A nice side effect is that this also updates the bootstrap compiler, so I will be using a newer Jou compiler when working on the Jou compiler.

Fixes #1293 