### PR TITLE
When developing Jou on Windows, allow "make" to be used instead of "mingw32-make"

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
       # Do not use --small because it relies on a previously built zip
       - run: source activate && ./windows_setup.sh
         shell: bash
-      - run: source activate && mingw32-make
+      - run: source activate && make
         shell: bash
       # We don't need to copy all of mingw64. We only need the GNU linker.
       # The less we copy, the smaller the resulting zip becomes.
@@ -156,7 +156,7 @@ jobs:
       - run: source activate && ./doctest.sh
         shell: bash
       - name: "Run the new test runner"
-        run: source activate && mingw32-make joutest.exe && ./joutest.exe --verbose
+        run: source activate && make joutest.exe && ./joutest.exe --verbose
         shell: bash
 
   test-zip:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,15 +39,14 @@ Following the [instructions in the README](README.md#setup) is enough.
 6. Compile Jou:
     ```
     source activate
-    mingw32-make
+    make
     ```
     The `source activate` command adds `C:\Users\YourName\Desktop\jou\mingw64\bin` to your PATH,
     where `C:\Users\YourName\Desktop` is the folder where you cloned Jou.
     If you don't want to run it every time you open a Git Bash window to work on Jou,
     you can instead add it to your PATH permanently with Control Panel.
 
-    When you run `mingw32-make` for the first time, it
-    [bootstraps Jou from Git history](README.md#bootstrapping).
+    When you run `make` for the first time, it [bootstraps Jou from Git history](README.md#bootstrapping).
 7. Compile and run hello world:
     ```
     ./jou.exe examples/hello.jou
@@ -63,8 +62,7 @@ Following the [instructions in the README](README.md#setup) is enough.
 
 </details>
 
-After making changes to the compiler,
-run `mingw32-make` (Windows) or `make` (other systems) to recompile the compiler.
+After making changes to the compiler, run `make` to recompile the compiler.
 
 
 ## How does the compiler work?

--- a/doctest.sh
+++ b/doctest.sh
@@ -19,13 +19,12 @@ fi
 
 if [[ "${OS:=$(uname)}" =~ Windows ]]; then
     source activate
-    mingw32-make
     jou="$PWD/jou.exe"
 else
-    make
     jou="$PWD/jou"
 fi
 
+make
 
 if [[ "${OS:=$(uname)}" =~ NetBSD ]] && command -v gdiff >/dev/null; then
     diff="gdiff"

--- a/runtests.sh
+++ b/runtests.sh
@@ -105,7 +105,7 @@ echo "<pointersize> in expected output will be replaced with $pointersize."
 if [ $run_make = yes ]; then
     if [[ "${OS:=$(uname)}" =~ Windows ]]; then
         source activate
-        mingw32-make jou.exe
+        make jou.exe
     else
         make jou
     fi

--- a/windows_setup.sh
+++ b/windows_setup.sh
@@ -99,6 +99,9 @@ else
     rm $filename
 fi
 
+# For convenience, "make" does the same thing as "mingw32-make"
+[ -f mingw64/bin/make.exe ] || cp -v mingw64/bin/mingw32-make.exe mingw64/bin/make.exe
+
 echo ""
 echo ""
 echo ""
@@ -107,6 +110,6 @@ echo "Your Jou development environment is now ready."
 echo "Next you can compile the Jou compiler and run hello world:"
 echo ""
 echo "    source activate"
-echo "    mingw32-make"
+echo "    make"
 echo "    ./jou.exe examples/hello.jou"
 echo ""


### PR DESCRIPTION
When developing Jou, you can now run `make` on Windows just like on all other platforms.