### PR TITLE
Add retrying to test of monotonic_ns() function

### DIFF
--- a/tests/should_succeed/time_test.jou
+++ b/tests/should_succeed/time_test.jou
@@ -25,21 +25,30 @@ def test_time() -> None:
 
 
 def test_monotonic_ns() -> None:
-    # Wait 1 second with time(), measure with monotonic_ns()
-    t = time(NULL)
-    while time(NULL) == t:
-        pass
-    start = monotonic_ns()
-    while time(NULL) == t+1:
-        pass
-    end = monotonic_ns()
+    # Retry a few times, this test is sometimes a bit unreliable on GitHub Actions
+    results: uint64[5]
 
-    seconds = (end - start)*1e-9
-    if fabs(seconds - 1.0) < 0.05:
-        # Output: time() vs monotonic_ns() ok
-        printf("time() vs monotonic_ns() ok\n")
-    else:
-        printf("one second for time() somehow became %llu nanoseconds\n", end - start)
+    for i = 0; i < array_count(results); i++:
+        # Wait 1 second with time(), measure with monotonic_ns()
+        t = time(NULL)
+        while time(NULL) == t:
+            pass
+        start = monotonic_ns()
+        while time(NULL) == t+1:
+            pass
+        end = monotonic_ns()
+
+        seconds = (end - start)*1e-9
+        if fabs(seconds - 1.0) < 0.01:
+            # Output: time() vs monotonic_ns() ok
+            printf("time() vs monotonic_ns() ok\n")
+            return
+
+        results[i] = end - start
+
+    # Did not work
+    for i = 0; i < array_count(results); i++:
+        printf("one second for time() somehow became %llu nanoseconds\n", results[i])
 
 
 def main() -> int:


### PR DESCRIPTION
In the past, and once again here, I've noticed that stuff running on GitHub Actions sometimes experiences small, random delays in the middle of doing some work. That's probably why this test has occasionally failed (#1295, #1312).

Adding just 5 retries should be more than enough. For example, if the test fails 1% of the time, and it runs on average once per minute, it takes an expected time of about 20000 years until all tries fail in the same run.

Fixes #1312