### PR TITLE
Fix joutest on MacOS

### DIFF
--- a/tools/joutest/step6_run_tests.jou
+++ b/tools/joutest/step6_run_tests.jou
@@ -300,7 +300,7 @@ else:
             snprintf(message, sizeof(message), "pipe() failed: %s", strerror(get_errno()))
             fail(message)
 
-        if fcntl(pipe[0], F_SETFD, FD_CLOEXEC) != 0 or fcntl(pipe[1], F_SETFD, FD_CLOEXEC) != 0:
+        if fcntl(pipefd[0], F_SETFD, FD_CLOEXEC) != 0 or fcntl(pipefd[1], F_SETFD, FD_CLOEXEC) != 0:
             snprintf(message, sizeof(message), "fcntl() failed: %s", strerror(get_errno()))
             fail(message)
 


### PR DESCRIPTION
Fixes #1319 

The problem was that there is no `pipe2` function on MacOS. 