### PR TITLE
Fix compiler error on MacOS

### DIFF
--- a/stdlib/fs.jou
+++ b/stdlib/fs.jou
@@ -266,7 +266,7 @@ class DirIter:
 if WINDOWS:
     declare GetModuleFileNameA(hModule: void*, lpFilename: byte*, nSize: int) -> int
 elif MACOS:
-    declare _NSGetExecutablePath(buf: byte*, bufsize: int32*) -> int
+    declare _NSGetExecutablePath(buf: byte*, bufsize: uint32*) -> int
 elif NETBSD:
     declare sysctl(
         name: int*,


### PR DESCRIPTION
Fixes #1330 

The problem was that we used a mix of int and uint32 for a thing that is uint32_t in MacOS documentation. 