### PR TITLE
Try to fix apt install problems in github actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,8 +52,9 @@ jobs:
           # changes for any reason, e.g. new version of package is available,
           # then the cache is not reused.
           #
-          # This shows output with a bunch of "Inst" lines, but they don't mean
-          # installing. They represent packages that apt would install.
+          # This shows output with a bunch of "Inst" lines, but nothing is
+          # actually installed here. Each "Inst" line represents a package that
+          # apt would install.
           apt-get --dry-run install $(cat apt-gonna-install.txt) | grep ^Inst | tee apt-cache-key-input.txt
 
       - name: Cache apt packages


### PR DESCRIPTION
This PR hacks around apt's downloads being very unreliable on GitHub Actions. I don't know the root cause for that.