### PR TITLE
joutest: Ignore SIGPIPE

### DIFF
--- a/tools/joutest/step6_run_tests.jou
+++ b/tools/joutest/step6_run_tests.jou
@@ -789,6 +789,10 @@ if not WINDOWS:
     declare setenv(name: byte*, value: byte*, overwrite: int) -> int
     declare dirname(path: byte*) -> byte*
 
+    const SIGPIPE: int = 13       # same on MacOS, Linux, NetBSD
+    const SIG_IGN: intnative = 1  # same on MacOS, Linux, NetBSD
+    declare signal(signum: int, handler: intnative) -> intnative
+
     # Adds the directory containing joutest to PATH. It usually contains the
     # Jou compiler.
     #
@@ -815,21 +819,15 @@ if not WINDOWS:
         setenv("PATH", new_path, True as int)
         free(new_path)
 
-    const SIGPIPE: int = 13       # same on MacOS, Linux, NetBSD
-    const SIG_IGN: intnative = 1  # same on MacOS, Linux, NetBSD
-    declare signal(signum: int, handler: intnative) -> intnative
-
-    # By default, it is possible to accidentally kill the whole test runner
-    # with SIGPIPE by simply not consuming input from stdin.
-    def ignore_sigpipe() -> None:
-        signal(SIGPIPE, SIG_IGN)
-
 
 @public
 def step6_run_tests(tests: List[Test], args: CommandLineArgs*) -> None:
     if not WINDOWS:
         add_joutest_dir_to_PATH()
-        ignore_sigpipe()
+
+        # By default, it is possible to accidentally kill the whole test runner
+        # with SIGPIPE by simply not consuming input from stdin.
+        signal(SIGPIPE, SIG_IGN)
 
     for test = tests.ptr; test < tests.end(); test++:
         match test.skip:

--- a/tools/joutest/step6_run_tests.jou
+++ b/tools/joutest/step6_run_tests.jou
@@ -829,7 +829,7 @@ if not WINDOWS:
 def step6_run_tests(tests: List[Test], args: CommandLineArgs*) -> None:
     if not WINDOWS:
         add_joutest_dir_to_PATH()
-    #    ignore_sigpipe()
+        ignore_sigpipe()
 
     for test = tests.ptr; test < tests.end(); test++:
         match test.skip:

--- a/tools/joutest/step6_run_tests.jou
+++ b/tools/joutest/step6_run_tests.jou
@@ -803,23 +803,33 @@ if not WINDOWS:
         if strstr(joutest_dir, ":") != NULL:
             fail("directory containing joutest contains ':' and hence cannot be added to PATH")
 
+        old_path = getenv("PATH")
+        if old_path == NULL:
+            fail("no PATH environment variable")
+
         new_path: byte* = NULL
-        asprintf(&new_path, "%s:%s", joutest_dir, getenv("PATH"))
+        asprintf(&new_path, "%s:%s", joutest_dir, old_path)
         assert new_path != NULL
         free(joutest_exe)
 
         setenv("PATH", new_path, True as int)
         free(new_path)
 
+    const SIGPIPE: int = 13       # same on MacOS, Linux, NetBSD
+    const SIG_IGN: intnative = 1  # same on MacOS, Linux, NetBSD
+    declare signal(signum: int, handler: intnative) -> intnative
+
+    # By default, it is possible to accidentally kill the whole test runner
+    # with SIGPIPE by simply not consuming input from stdin.
+    def ignore_sigpipe() -> None:
+        signal(SIGPIPE, SIG_IGN)
+
 
 @public
 def step6_run_tests(tests: List[Test], args: CommandLineArgs*) -> None:
     if not WINDOWS:
-        old_path = getenv("PATH")
-        if old_path == NULL:
-            fail("no PATH environment variable")
-        old_path = strdup(old_path)
         add_joutest_dir_to_PATH()
+    #    ignore_sigpipe()
 
     for test = tests.ptr; test < tests.end(); test++:
         match test.skip:
@@ -829,7 +839,3 @@ def step6_run_tests(tests: List[Test], args: CommandLineArgs*) -> None:
                 print_skip(test, args.verbose)
             case SkipMode.SkipSilently:
                 pass
-
-    if not WINDOWS:
-        setenv("PATH", old_path, True as int)
-        free(old_path)


### PR DESCRIPTION
At some point I managed to crash `joutest` with a child process that does not read any input, although I don't remember how I did it and cannot reproduce it now. In any case, this PR should fix that by ignoring SIGPIPE in joutest.