### PR TITLE
Update VM workflow to run all VMs on scheduled runs

### DIFF
--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -76,8 +76,8 @@ jobs:
                 echo "No recent commits, run nothing"
                 touch what_to_run.txt
               else
-                echo "Scheduled run, run only slow VMs because they don't run on every pull request"
-                printf '%s\n' $slow > what_to_run.txt
+                echo "Scheduled run, run all VMs"
+                printf '%s\n' $fast $slow > what_to_run.txt
               fi
               ;;
             *)


### PR DESCRIPTION
Previously scheduled runs only ran the slow VMs (Raspberry Pi OS and aarch64). This PR changes them to also run the fast VMs.

I noticed that when I make a new PR, the alpine linux x86 VM (fast) always reinstalls itself from scratch even though it should cached. I think the caches become PR-specific for security reasons. But I think caches created by things running from main branch are accessible in PRs too, so this should fix that.