### PR TITLE
Disallow casting between int64 and pointer on 32-bit systems

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,6 +18,7 @@ set -e -o pipefail
 # just before the original compiler written in C was deleted.
 numbered_commits=(
     030_bb3dc7d925fa28ce405fda5a4fc3c428f6f7c2b1  # <--- "./windows_setup.sh --small" starts from here! (release 2026-03-16-0500)
+    031_03b1e1e19d97777ff3e06deebd090d8618eb4287
 )
 
 # This should be an item of the above list according to what

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -153,7 +153,7 @@ def skip_string_or_byte(s: byte*) -> byte*:
 
 def get_assertion_code_as_string(start: Token*, end: Token*) -> byte*:
     # TODO: "pointer as intnative" cast should be allowed
-    len = ((end.file_content_ptr as int64) - (start.file_content_ptr as int64)) as intnative
+    len = (end.file_content_ptr as intnative) - (start.file_content_ptr as intnative)
     assert len > 0
 
     s: byte* = malloc(len + 1)

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -261,9 +261,7 @@ def can_cast_explicitly(from: Type*, to: Type*) -> bool:
         or (from.kind == TypeKind.Enum and to.is_integer_type())
         or (from == bool_type() and to.is_integer_type())
         or (from.is_pointer_type() and to == int_type(32 if IS_32BIT else 64))
-        or (from.is_pointer_type() and to == int_type(64))  # TODO: remove this
         or (from == int_type(32 if IS_32BIT else 64) and to.is_pointer_type())
-        or (from == int_type(64) and to.is_pointer_type())  # TODO: remove this
     )
 
 

--- a/tests/wrong_type/pointer_to_integer_32bit.jou
+++ b/tests/wrong_type/pointer_to_integer_32bit.jou
@@ -1,0 +1,13 @@
+import "stdlib/intnative.jou"
+
+assert IS_32BIT  # This test should be ran only on 32-bit systems
+
+def foo() -> None:
+    x = 1
+
+    # int64 is not the correct type to hold a pointer, so compiler errors.
+    #
+    # It would work, but if you really want your number to always have half of
+    # its bits set to zero, you need to explicitly say so.
+    y = (&x as intnative) as int64
+    z = &x as int64  # Error: cannot cast from type int* to int64


### PR DESCRIPTION
See also: #1356

After this PR, code that must work on 32-bit systems must use e.g. `some_pointer as intnative` instead of `some_pointer as int64`.