### PR TITLE
Change return type of monotonic_ns to int64 in stdlib/time.jou

### DIFF
--- a/stdlib/time.jou
+++ b/stdlib/time.jou
@@ -40,13 +40,13 @@ else:
 # so the start point in time is irrelevant in most use cases. Please create an
 # issue on GitHub if you want to rely on it.
 @public
-def monotonic_ns() -> uint64:
+def monotonic_ns() -> int64:
     if MACOS:
-        return clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+        return clock_gettime_nsec_np(CLOCK_UPTIME_RAW) as int64
     else:
         ts = timespec{}
         clock_gettime(CLOCK_MONOTONIC, &ts)
-        return ts.tv_sec * (1_000_000_000 as uint64) + ts.tv_nsec
+        return ts.tv_sec * (1_000_000_000 as int64) + ts.tv_nsec
 
 
 # time(result_ptr) returns the number of seconds since January 1st, 1970.

--- a/tests/should_succeed/time_test.jou
+++ b/tests/should_succeed/time_test.jou
@@ -26,7 +26,7 @@ def test_time() -> None:
 
 def test_monotonic_ns() -> None:
     # Retry a few times, this test is sometimes a bit unreliable on GitHub Actions
-    results: uint64[5]
+    results: int64[5]
 
     for i = 0; i < array_count(results); i++:
         # Wait 1 second with time(), measure with monotonic_ns()
@@ -48,7 +48,7 @@ def test_monotonic_ns() -> None:
 
     # Did not work
     for i = 0; i < array_count(results); i++:
-        printf("one second for time() somehow became %llu nanoseconds\n", results[i])
+        printf("one second for time() somehow became %lld nanoseconds\n", results[i])
 
 
 def main() -> int:


### PR DESCRIPTION
The return values are often subtracted, so distinguishing negative values could be useful.