### PR TITLE
Rename `embed_file` to `embed_binary_file`

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -257,7 +257,7 @@ enum AstExpressionKind:
     SizeOf          # sizeof(x)
     ArrayCount      # array_count(x)
     ArrayEnd        # array_end(x)
-    EmbedFile       # embed_file("./foo.bar")
+    EmbedBinaryFile # embed_binary_file("./foo.bar")
     AddressOf       # &x
     Dereference     # *x
     Negate          # -x
@@ -365,8 +365,8 @@ class AstExpression:
                 self.enumcount.print()
             case AstExpressionKind.SizeOf:
                 printf("sizeof\n")
-            case AstExpressionKind.EmbedFile:
-                printf("embed_file\n")
+            case AstExpressionKind.EmbedBinaryFile:
+                printf("embed_binary_file\n")
             case AstExpressionKind.ArrayCount:
                 printf("array_count\n")
             case AstExpressionKind.ArrayEnd:
@@ -467,7 +467,7 @@ class AstExpression:
         match self.kind:
             case (
                 AstExpressionKind.SizeOf
-                | AstExpressionKind.EmbedFile
+                | AstExpressionKind.EmbedBinaryFile
                 | AstExpressionKind.ArrayCount
                 | AstExpressionKind.ArrayEnd
                 | AstExpressionKind.AddressOf

--- a/compiler/ast_to_builder.jou
+++ b/compiler/ast_to_builder.jou
@@ -449,7 +449,7 @@ class AstToBuilder:
 
     def build_expression_without_implicit_cast(self, expr: AstExpression*) -> BuilderValue:
         match expr.kind:
-            case AstExpressionKind.IntegerConstant | AstExpressionKind.EnumCount | AstExpressionKind.EmbedFile:
+            case AstExpressionKind.IntegerConstant | AstExpressionKind.EnumCount | AstExpressionKind.EmbedBinaryFile:
                 # should be turned into Constant during type checking
                 assert False
             case AstExpressionKind.Constant:

--- a/compiler/constants.jou
+++ b/compiler/constants.jou
@@ -33,8 +33,8 @@ enum ConstantKind:
     Bool
     # ArrayOfBytes is a special case of Array for arrays of bytes. It is
     # needed for performance. For example, if a huge file is embedded with
-    # embed_file(), we don't want to construct one Constant object for each
-    # byte of the file.
+    # embed_binary_file(), we don't want to construct one Constant object
+    # for each byte of the file.
     ArrayOfBytes
     Array
 

--- a/compiler/evaluate.jou
+++ b/compiler/evaluate.jou
@@ -121,7 +121,7 @@ def evaluate_constant_expression(jou_file: JouFile*, expr: AstExpression*, resul
             *result = expr.constant.copy()
             return True
 
-        case AstExpressionKind.EmbedFile:
+        case AstExpressionKind.EmbedBinaryFile:
             filename_constant: Constant
             if not evaluate_constant_expression(jou_file, expr.operands, &filename_constant, uint_type(8).pointer_type()):
                 fail(expr.location, "failed to evaluate file name at compile time")

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -687,9 +687,9 @@ class Parser:
             case "array_end":
                 expr.kind = AstExpressionKind.ArrayEnd
                 error = "value after array_end must be in parentheses, e.g. array_end(foo)"
-            case "embed_file":
-                expr.kind = AstExpressionKind.EmbedFile
-                error = "file name after embed_file must be in parentheses, e.g. embed_file(\"foo.txt\")"
+            case "embed_binary_file":
+                expr.kind = AstExpressionKind.EmbedBinaryFile
+                error = "file name after embed_binary_file must be in parentheses, e.g. embed_binary_file(\"image.png\")"
             case "enum_count":
                 expr.kind = AstExpressionKind.EnumCount
                 error = "enum type after enum_count must be in parentheses, e.g. enum_count(Foo)"
@@ -764,7 +764,7 @@ class Parser:
                     self.tokens.is_keyword("sizeof")
                     or self.tokens.is_keyword("array_count")
                     or self.tokens.is_keyword("array_end")
-                    or self.tokens.is_keyword("embed_file")
+                    or self.tokens.is_keyword("embed_binary_file")
                     or self.tokens.is_keyword("enum_count")
                 ):
                     expr = self.parse_special_function_like_expression()

--- a/compiler/tokenizer.jou
+++ b/compiler/tokenizer.jou
@@ -63,7 +63,7 @@ def is_keyword(word: byte*) -> bool:
                 or strcmp(word, "else") == 0
                 or strcmp(word, "enum") == 0
                 or strcmp(word, "enum_count") == 0
-                or strcmp(word, "embed_file") == 0
+                or strcmp(word, "embed_binary_file") == 0
             )
         case 'f':
             return (
@@ -661,7 +661,7 @@ def read_file_to_string(path: byte*, import_statement: AstStatement*) -> byte*:
             if ferror(file) != 0:
                 # TODO: include errno in the error message?
                 # TODO: test this?
-                # If you change this, you might also want to change embed_file() handling.
+                # If you change this, you might also want to change embed_binary_file() handling.
                 fail(Location{path = path}, "cannot read file")
             break
         bytes_list.extend_from_ptr(buf, num_read)

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -62,8 +62,8 @@ def short_expression_description(expr: AstExpression*) -> byte[200]:
             return "an array_count expression"
         case AstExpressionKind.ArrayEnd:
             return "an array_end expression"
-        case AstExpressionKind.EmbedFile:
-            return "an embed_file expression"
+        case AstExpressionKind.EmbedBinaryFile:
+            return "an embed_binary_file expression"
         case AstExpressionKind.EnumCount:
             return "an enum_count expression"
         case AstExpressionKind.Instantiate:
@@ -1116,7 +1116,7 @@ def typecheck_expression(state: State*, expr: AstExpression*, type_hint: Type*) 
     detect_enum_member_syntax(state, expr)
 
     match expr.kind:
-        case AstExpressionKind.IntegerConstant | AstExpressionKind.EnumCount | AstExpressionKind.EmbedFile:
+        case AstExpressionKind.IntegerConstant | AstExpressionKind.EnumCount | AstExpressionKind.EmbedBinaryFile:
             # The expression can be evaluated as a constant
             c: Constant
             ok = evaluate_constant_expression(state.jou_file, expr, &c, type_hint)

--- a/doc/keywords.md
+++ b/doc/keywords.md
@@ -363,7 +363,7 @@ import "stdlib/io.jou"
 global meme = embed_binary_file("images/64bit-meme.jpg")
 
 def main() -> int:
-    printf("%d bytes\n", sizeof(meme))  # Output: 1 bytes
+    printf("%d bytes\n", sizeof(meme))  # Output: 59939 bytes
     return 0
 ```
 

--- a/doc/keywords.md
+++ b/doc/keywords.md
@@ -328,9 +328,9 @@ It is also used in the ternary expression:
 **See also:** [if](#if), [elif](#elif)
 
 
-## `embed_file`
+## `embed_binary_file`
 
-Use `embed_file("filename")` to include the contents a file into the executable.
+Use `embed_binary_file("filename")` to include the contents a file into the executable.
 This evaluates to an array of `byte` that is the file's content.
 The file name is relative to the location of the Jou file, but you can use `..`,
 just like with [`import` statements that start with a dot](imports.md).
@@ -340,7 +340,7 @@ For example:
 ```python
 import "stdlib/io.jou"
 
-global readme = embed_file("../README.md")
+global readme = embed_binary_file("../README.md")
 
 def main() -> int:
     # Output: Jou programming language
@@ -360,10 +360,10 @@ Instead, use [`sizeof`](#sizeof) or [`array_count`](#array_count) to get the fil
 ```python
 import "stdlib/io.jou"
 
-global readme = embed_file("../../README.md")
+global meme = embed_binary_file("images/64bit-meme.jpg")
 
 def main() -> int:
-    printf("%d bytes\n", sizeof(readme))
+    printf("%d bytes\n", sizeof(meme))  # Output: 1 bytes
     return 0
 ```
 

--- a/tests/404/embed_binary_file.jou
+++ b/tests/404/embed_binary_file.jou
@@ -1,0 +1,1 @@
+global thing = embed_binary_file("./does_not_exist.txt")  # Error: cannot open file "tests/404/does_not_exist.txt": No such file or directory

--- a/tests/404/embed_file.jou
+++ b/tests/404/embed_file.jou
@@ -1,1 +1,0 @@
-global thing = embed_file("./does_not_exist.txt")  # Error: cannot open file "tests/404/does_not_exist.txt": No such file or directory

--- a/tests/other_errors/embed_binary_file_cannot_evaluate.jou
+++ b/tests/other_errors/embed_binary_file_cannot_evaluate.jou
@@ -1,0 +1,4 @@
+def runtime_thing() -> byte*:
+    return "lol"
+
+global lol = embed_binary_file(runtime_thing())  # Error: failed to evaluate file name at compile time

--- a/tests/other_errors/embed_binary_file_empty.jou
+++ b/tests/other_errors/embed_binary_file_empty.jou
@@ -1,0 +1,1 @@
+global lol = embed_binary_file("../data/empty_file")  # Error: file "tests/data/empty_file" is empty

--- a/tests/other_errors/embed_file_cannot_evaluate.jou
+++ b/tests/other_errors/embed_file_cannot_evaluate.jou
@@ -1,4 +1,0 @@
-def runtime_thing() -> byte*:
-    return "lol"
-
-global lol = embed_file(runtime_thing())  # Error: failed to evaluate file name at compile time

--- a/tests/other_errors/embed_file_empty.jou
+++ b/tests/other_errors/embed_file_empty.jou
@@ -1,1 +1,0 @@
-global lol = embed_file("../data/empty_file")  # Error: file "tests/data/empty_file" is empty

--- a/tests/should_succeed/embed_binary_file.jou
+++ b/tests/should_succeed/embed_binary_file.jou
@@ -1,8 +1,8 @@
 import "stdlib/assert.jou"
 import "stdlib/io.jou"
 
-global hello3 = embed_file("../data/hellohellohello.txt")
-global zeros = embed_file("../data/zeros.bin")
+global hello3 = embed_binary_file("../data/hellohellohello.txt")
+global zeros = embed_binary_file("../data/zeros.bin")
 
 def main() -> int:
     # Type of hello3 should be byte[15]
@@ -14,7 +14,7 @@ def main() -> int:
     printf("%.15s\n", hello3)  # Output: hellohellohello
 
     # Also possible to read it like this (not recommended for large files)
-    hello3_on_stack = embed_file("../data/hellohellohello.txt")
+    hello3_on_stack = embed_binary_file("../data/hellohellohello.txt")
     printf("%.15s\n", hello3_on_stack)  # Output: hellohellohello
 
     # This file should contain 100 zero bytes

--- a/tests/syntax_error/parentheses_embed_binary_file.jou
+++ b/tests/syntax_error/parentheses_embed_binary_file.jou
@@ -1,0 +1,1 @@
+global thing = embed_binary_file "data.bin"  # Error: file name after embed_binary_file must be in parentheses, e.g. embed_binary_file("foo.txt")

--- a/tests/syntax_error/parentheses_embed_binary_file.jou
+++ b/tests/syntax_error/parentheses_embed_binary_file.jou
@@ -1,1 +1,1 @@
-global thing = embed_binary_file "data.bin"  # Error: file name after embed_binary_file must be in parentheses, e.g. embed_binary_file("foo.txt")
+global thing = embed_binary_file "data.bin"  # Error: file name after embed_binary_file must be in parentheses, e.g. embed_binary_file("image.png")

--- a/tests/syntax_error/parentheses_embed_file.jou
+++ b/tests/syntax_error/parentheses_embed_file.jou
@@ -1,1 +1,0 @@
-global thing = embed_file "data.bin"  # Error: file name after embed_file must be in parentheses, e.g. embed_file("foo.txt")

--- a/tests/wrong_type/embed_binary_file_1.jou
+++ b/tests/wrong_type/embed_binary_file_1.jou
@@ -1,0 +1,1 @@
+global foo = embed_binary_file(1)  # Error: file name must be a string, not int

--- a/tests/wrong_type/embed_file_1.jou
+++ b/tests/wrong_type/embed_file_1.jou
@@ -1,1 +1,0 @@
-global foo = embed_file(1)  # Error: file name must be a string, not int


### PR DESCRIPTION
`embed_file` does not add a `\0` terminator to the end of the file, so it's quite inconvenient to use for files that are supposed to be text. This includes things like JSON or source code. Next I'm going to add another built-in `embed_text_file` for files that are supposed to be treated as strings.