### PR TITLE
Add embed_text_file() built-in

### DIFF
--- a/compiler/ast.jou
+++ b/compiler/ast.jou
@@ -257,7 +257,8 @@ enum AstExpressionKind:
     SizeOf          # sizeof(x)
     ArrayCount      # array_count(x)
     ArrayEnd        # array_end(x)
-    EmbedBinaryFile # embed_binary_file("./foo.bar")
+    EmbedBinaryFile # embed_binary_file("./foo.png")
+    EmbedTextFile   # embed_text_file("./foo.txt")
     AddressOf       # &x
     Dereference     # *x
     Negate          # -x
@@ -367,6 +368,8 @@ class AstExpression:
                 printf("sizeof\n")
             case AstExpressionKind.EmbedBinaryFile:
                 printf("embed_binary_file\n")
+            case AstExpressionKind.EmbedTextFile:
+                printf("embed_text_file\n")
             case AstExpressionKind.ArrayCount:
                 printf("array_count\n")
             case AstExpressionKind.ArrayEnd:
@@ -468,6 +471,7 @@ class AstExpression:
             case (
                 AstExpressionKind.SizeOf
                 | AstExpressionKind.EmbedBinaryFile
+                | AstExpressionKind.EmbedTextFile
                 | AstExpressionKind.ArrayCount
                 | AstExpressionKind.ArrayEnd
                 | AstExpressionKind.AddressOf

--- a/compiler/ast_to_builder.jou
+++ b/compiler/ast_to_builder.jou
@@ -449,7 +449,12 @@ class AstToBuilder:
 
     def build_expression_without_implicit_cast(self, expr: AstExpression*) -> BuilderValue:
         match expr.kind:
-            case AstExpressionKind.IntegerConstant | AstExpressionKind.EnumCount | AstExpressionKind.EmbedBinaryFile:
+            case (
+                AstExpressionKind.IntegerConstant
+                | AstExpressionKind.EnumCount
+                | AstExpressionKind.EmbedBinaryFile
+                | AstExpressionKind.EmbedTextFile
+            ):
                 # should be turned into Constant during type checking
                 assert False
             case AstExpressionKind.Constant:

--- a/compiler/evaluate.jou
+++ b/compiler/evaluate.jou
@@ -99,7 +99,9 @@ def read_embedded_file(
         file_content.extend_from_ptr(buf, num_read)
     fclose(file)
 
-    if file_content.len == 0:
+    # Embedding empty binary file would create array of size zero which is disallowed.
+    # Embedding empty text file creates an array of size 1 (for '\0' at end) which is fine.
+    if file_content.len == 0 and not embed_as_text:
         simplify_path(full_path)
         snprintf(msg, sizeof(msg), "file \"%s\" is empty", full_path)
         fail(location, msg)
@@ -112,7 +114,7 @@ def read_embedded_file(
                 fail(location, msg)
         file_content.append('\0')
         crlf_to_lf(file_content.ptr)
-        file_content.len = strlen(file_content.ptr)
+        file_content.len = strlen(file_content.ptr) + 1
 
     free(full_path)
     return file_content
@@ -162,10 +164,8 @@ def evaluate_constant_expression(jou_file: JouFile*, expr: AstExpression*, resul
             )
             filename_constant.free()
 
+            assert file_content.len > 0
             assert file_content.len <= INT32_MAX  # TODO
-            if file_content.len == 0:
-                # In Jou, empty array like byte[0] is not a valid type
-                fail(expr.location, "file is empty")
 
             *result = Constant{kind = ConstantKind.ArrayOfBytes, array_of_bytes = file_content}
             return True

--- a/compiler/evaluate.jou
+++ b/compiler/evaluate.jou
@@ -52,7 +52,22 @@ def evaluate_boolean_and_or(jou_file: JouFile*, expr: AstExpression*, and_or: by
     return value.boolean as int
 
 
-def read_embedded_file(jou_file: JouFile*, specified_path: byte*, location: Location) -> List[byte]:
+# Replaces \r\n with \n in-place
+def crlf_to_lf(s: byte*) -> None:
+    out = s
+    while *s != '\0':
+        if starts_with(s, "\r\n"):
+            s++
+        *out++ = *s++
+    *out = '\0'
+
+
+def read_embedded_file(
+    jou_file: JouFile*,
+    specified_path: byte*,
+    location: Location,
+    embed_as_text: bool,
+) -> List[byte]:
     msg: byte[500]
 
     # If I remember correctly, dirname() may modify the given path
@@ -89,6 +104,16 @@ def read_embedded_file(jou_file: JouFile*, specified_path: byte*, location: Loca
         snprintf(msg, sizeof(msg), "file \"%s\" is empty", full_path)
         fail(location, msg)
 
+    if embed_as_text:
+        for p = file_content.ptr; p < file_content.end(); p++:
+            if *p == '\0':
+                simplify_path(full_path)
+                snprintf(msg, sizeof(msg), "file \"%s\" contains a zero byte", full_path)
+                fail(location, msg)
+        file_content.append('\0')
+        crlf_to_lf(file_content.ptr)
+        file_content.len = strlen(file_content.ptr)
+
     free(full_path)
     return file_content
 
@@ -121,7 +146,7 @@ def evaluate_constant_expression(jou_file: JouFile*, expr: AstExpression*, resul
             *result = expr.constant.copy()
             return True
 
-        case AstExpressionKind.EmbedBinaryFile:
+        case AstExpressionKind.EmbedBinaryFile | AstExpressionKind.EmbedTextFile:
             filename_constant: Constant
             if not evaluate_constant_expression(jou_file, expr.operands, &filename_constant, uint_type(8).pointer_type()):
                 fail(expr.location, "failed to evaluate file name at compile time")
@@ -129,7 +154,12 @@ def evaluate_constant_expression(jou_file: JouFile*, expr: AstExpression*, resul
                 snprintf(msg, sizeof(msg), "file name must be a string, not %s", filename_constant.get_type().name)
                 fail(expr.location, msg)
 
-            file_content = read_embedded_file(jou_file, filename_constant.pointer_string, expr.location)
+            file_content = read_embedded_file(
+                jou_file,
+                filename_constant.pointer_string,
+                expr.location,
+                expr.kind == AstExpressionKind.EmbedTextFile,
+            )
             filename_constant.free()
 
             assert file_content.len <= INT32_MAX  # TODO

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -690,6 +690,9 @@ class Parser:
             case "embed_binary_file":
                 expr.kind = AstExpressionKind.EmbedBinaryFile
                 error = "file name after embed_binary_file must be in parentheses, e.g. embed_binary_file(\"image.png\")"
+            case "embed_text_file":
+                expr.kind = AstExpressionKind.EmbedTextFile
+                error = "file name after embed_text_file must be in parentheses, e.g. embed_binary_file(\"file.txt\")"
             case "enum_count":
                 expr.kind = AstExpressionKind.EnumCount
                 error = "enum type after enum_count must be in parentheses, e.g. enum_count(Foo)"
@@ -765,6 +768,7 @@ class Parser:
                     or self.tokens.is_keyword("array_count")
                     or self.tokens.is_keyword("array_end")
                     or self.tokens.is_keyword("embed_binary_file")
+                    or self.tokens.is_keyword("embed_text_file")
                     or self.tokens.is_keyword("enum_count")
                 ):
                     expr = self.parse_special_function_like_expression()

--- a/compiler/parser.jou
+++ b/compiler/parser.jou
@@ -692,7 +692,7 @@ class Parser:
                 error = "file name after embed_binary_file must be in parentheses, e.g. embed_binary_file(\"image.png\")"
             case "embed_text_file":
                 expr.kind = AstExpressionKind.EmbedTextFile
-                error = "file name after embed_text_file must be in parentheses, e.g. embed_binary_file(\"file.txt\")"
+                error = "file name after embed_text_file must be in parentheses, e.g. embed_text_file(\"file.txt\")"
             case "enum_count":
                 expr.kind = AstExpressionKind.EnumCount
                 error = "enum type after enum_count must be in parentheses, e.g. enum_count(Foo)"

--- a/compiler/tokenizer.jou
+++ b/compiler/tokenizer.jou
@@ -64,6 +64,7 @@ def is_keyword(word: byte*) -> bool:
                 or strcmp(word, "enum") == 0
                 or strcmp(word, "enum_count") == 0
                 or strcmp(word, "embed_binary_file") == 0
+                or strcmp(word, "embed_text_file") == 0
             )
         case 'f':
             return (

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -64,6 +64,8 @@ def short_expression_description(expr: AstExpression*) -> byte[200]:
             return "an array_end expression"
         case AstExpressionKind.EmbedBinaryFile:
             return "an embed_binary_file expression"
+        case AstExpressionKind.EmbedTextFile:
+            return "an embed_text_file expression"
         case AstExpressionKind.EnumCount:
             return "an enum_count expression"
         case AstExpressionKind.Instantiate:
@@ -1116,7 +1118,12 @@ def typecheck_expression(state: State*, expr: AstExpression*, type_hint: Type*) 
     detect_enum_member_syntax(state, expr)
 
     match expr.kind:
-        case AstExpressionKind.IntegerConstant | AstExpressionKind.EnumCount | AstExpressionKind.EmbedBinaryFile:
+        case (
+            AstExpressionKind.IntegerConstant
+            | AstExpressionKind.EnumCount
+            | AstExpressionKind.EmbedBinaryFile
+            | AstExpressionKind.EmbedTextFile
+        ):
             # The expression can be evaluated as a constant
             c: Constant
             ok = evaluate_constant_expression(state.jou_file, expr, &c, type_hint)

--- a/doc/keywords.md
+++ b/doc/keywords.md
@@ -375,14 +375,14 @@ Please [create an issue on GitHub](https://github.com/Akuli/jou/issues/new)
 if you want to embed a larger file.
 Also, empty files are not supported, because arrays cannot be empty in Jou.
 
-**See also:** [sizeof](#sizeof), [array_count](#array_count)
+**See also:** [sizeof](#sizeof), [array_count](#array_count), [embed_text_file](#embed_text_file)
 
 
 ## `embed_text_file`
 
-This is just like `embed_binary_file()`, except that:
+This is just like [`embed_binary_file()`](#embed_binary_file), except that:
 - a zero byte is always added to the end
-- it is a compiler error if the file must not contain zero bytes
+- it is a compiler error if the file contains zero bytes
 - `\r\n` (also known as CRLF) in the file content is replaced with `\n`.
 
 For example:
@@ -400,6 +400,8 @@ def main() -> int:
 
 This wouldn't work as is with `embed_binary_file()`,
 because `%s` expects [a string with a zero byte to mark the end](tutorial.md#more-about-strings).
+
+**See also:** [embed_binary_file](#embed_binary_file)
 
 
 ## `enum`

--- a/doc/keywords.md
+++ b/doc/keywords.md
@@ -381,20 +381,25 @@ Also, empty files are not supported, because arrays cannot be empty in Jou.
 ## `embed_text_file`
 
 This is just like `embed_binary_file()`, except that:
-- a zero byte is always added to the end, and the file must not contain zero bytes
+- a zero byte is always added to the end
+- it is a compiler error if the file must not contain zero bytes
 - `\r\n` (also known as CRLF) in the file content is replaced with `\n`.
 
-For example, the following program prints this documentation:
+For example:
 
 ```python
 import "stdlib/io.jou"
 
-global keywords_doc = embed_text_file("keywords.md")
+global file_content = embed_text_file("../tests/data/hellohellohello.txt")
 
 def main() -> int:
-    printf("%s", keywords_doc)
+    # Output: File content is hellohellohello
+    printf("File content is %s\n", file_content)
     return 0
 ```
+
+This wouldn't work as is with `embed_binary_file()`,
+because `%s` expects [a string with a zero byte to mark the end](tutorial.md#more-about-strings).
 
 
 ## `enum`

--- a/doc/keywords.md
+++ b/doc/keywords.md
@@ -382,7 +382,7 @@ Also, empty files are not supported, because arrays cannot be empty in Jou.
 
 This is just like [`embed_binary_file()`](#embed_binary_file), except that:
 - a zero byte is always added to the end
-- it is a compiler error if the file contains zero bytes
+- it is a compiler error if the file contains a zero byte
 - `\r\n` (also known as CRLF) in the file content is replaced with `\n`.
 
 For example:

--- a/doc/keywords.md
+++ b/doc/keywords.md
@@ -378,6 +378,25 @@ Also, empty files are not supported, because arrays cannot be empty in Jou.
 **See also:** [sizeof](#sizeof), [array_count](#array_count)
 
 
+## `embed_text_file`
+
+This is just like `embed_binary_file()`, except that:
+- a zero byte is always added to the end, and the file must not contain zero bytes
+- `\r\n` (also known as CRLF) in the file content is replaced with `\n`.
+
+For example, the following program prints this documentation:
+
+```python
+import "stdlib/io.jou"
+
+global keywords_doc = embed_text_file("keywords.md")
+
+def main() -> int:
+    printf("%s", keywords_doc)
+    return 0
+```
+
+
 ## `enum`
 
 Used to define an enum. See [enums.md](enums.md).

--- a/tests/404/embed_text_file.jou
+++ b/tests/404/embed_text_file.jou
@@ -1,0 +1,1 @@
+global thing = embed_text_file("./does_not_exist.txt")  # Error: cannot open file "tests/404/does_not_exist.txt": No such file or directory

--- a/tests/other_errors/embed_text_file_cannot_evaluate.jou
+++ b/tests/other_errors/embed_text_file_cannot_evaluate.jou
@@ -1,0 +1,4 @@
+def runtime_thing() -> byte*:
+    return "lol"
+
+global lol = embed_text_file(runtime_thing())  # Error: failed to evaluate file name at compile time

--- a/tests/other_errors/embed_text_file_zero_byte.jou
+++ b/tests/other_errors/embed_text_file_zero_byte.jou
@@ -1,0 +1,1 @@
+global thing = embed_text_file("../data/hellohellohello.xz")  # Error: file "tests/data/hellohellohello.xz" contains a zero byte

--- a/tests/should_succeed/embed_text_file.jou
+++ b/tests/should_succeed/embed_text_file.jou
@@ -1,7 +1,7 @@
 import "stdlib/assert.jou"
 import "stdlib/io.jou"
 
-global hello3 = embed_binary_file("../data/hellohellohello.txt")
+global hello3 = embed_text_file("../data/hellohellohello.txt")
 
 def main() -> int:
     # Type of hello3 should be byte[16]
@@ -11,7 +11,7 @@ def main() -> int:
     puts(hello3)  # Output: hellohellohello
 
     # Also possible to read it like this (not recommended for large files)
-    hello3_on_stack = embed_binary_file("../data/hellohellohello.txt")
+    hello3_on_stack = embed_text_file("../data/hellohellohello.txt")
     puts(hello3_on_stack)  # Output: hellohellohello
 
     # Unlike with embed_binary_file(), it's possible to embed an empty file

--- a/tests/should_succeed/embed_text_file.jou
+++ b/tests/should_succeed/embed_text_file.jou
@@ -1,0 +1,22 @@
+import "stdlib/assert.jou"
+import "stdlib/io.jou"
+
+global hello3 = embed_binary_file("../data/hellohellohello.txt")
+
+def main() -> int:
+    # Type of hello3 should be byte[16]
+    assert array_count(hello3) == 16
+    assert sizeof(hello3) == 16
+    assert sizeof(hello3[0]) == 1
+    puts(hello3)  # Output: hellohellohello
+
+    # Also possible to read it like this (not recommended for large files)
+    hello3_on_stack = embed_binary_file("../data/hellohellohello.txt")
+    puts(hello3_on_stack)  # Output: hellohellohello
+
+    # Unlike with embed_binary_file(), it's possible to embed an empty file
+    empty = embed_text_file("../data/empty_file")
+    assert array_count(empty) == 1
+    assert empty[0] == '\0'
+
+    return 0

--- a/tests/syntax_error/parentheses_embed_text_file.jou
+++ b/tests/syntax_error/parentheses_embed_text_file.jou
@@ -1,0 +1,1 @@
+global thing = embed_text_file "data.bin"  # Error: file name after embed_text_file must be in parentheses, e.g. embed_text_file("file.txt")

--- a/tests/wrong_type/embed_text_file_1.jou
+++ b/tests/wrong_type/embed_text_file_1.jou
@@ -1,0 +1,1 @@
+global foo = embed_text_file(1)  # Error: file name must be a string, not int


### PR DESCRIPTION
`embed_text_file()` is just like `embed_binary_file()`, except:
- `\r\n` is replaced with `\n` (on all platforms, this is primarily an issue on Windows though)
- zero byte (`\0`) is added to the end
- file cannot contain zero bytes

Example:

```python
import "stdlib/io.jou"

global readme = embed_text_file("README.md")

def main() -> int:
    puts(readme)
    return 0
```

This wouldn't work as is with `embed_binary_file()` (was `embed_file()` before #1370), because `puts()` expects a string with a zero byte to mark the end.