### PR TITLE
Use `//` instead of `/` in Advent of Code solutions

### DIFF
--- a/examples/aoc2022/day03/part1.jou
+++ b/examples/aoc2022/day03/part1.jou
@@ -21,7 +21,7 @@ def main() -> int:
     line: byte[200]
     while fgets(line, sizeof(line), f) != NULL:
         trim_ascii_whitespace(line)
-        right = &line[strlen(line) / 2]
+        right = &line[strlen(line) // 2]
 
         for p = &line[0]; p < right; p++:
             if strchr(right, *p) != NULL:

--- a/examples/aoc2022/day05/part1.jou
+++ b/examples/aoc2022/day05/part1.jou
@@ -6,7 +6,7 @@ import "stdlib/list.jou"
 
 
 def reverse(list: List[byte]) -> None:
-    for i = 0; i < list.len/2; i++:
+    for i = 0; i < list.len // 2; i++:
         memswap(&list.ptr[i], &list.ptr[list.len - i - 1], sizeof(list.ptr[0]))
 
 
@@ -25,8 +25,8 @@ def main() -> int:
 
         for i = 1; i < strlen(line); i += 4:
             if line[i] != ' ':
-                assert i/4 < array_count(stacks)
-                stacks[i/4].append(line[i])
+                assert i // 4 < array_count(stacks)
+                stacks[i // 4].append(line[i])
 
     for i = 0; i < 9; i++:
         reverse(stacks[i])

--- a/examples/aoc2022/day05/part2.jou
+++ b/examples/aoc2022/day05/part2.jou
@@ -6,7 +6,7 @@ import "stdlib/list.jou"
 
 
 def reverse(ptr: byte*, len: int64) -> None:
-    for i = 0; i < len/2; i++:
+    for i = 0; i < len // 2; i++:
         memswap(&ptr[i], &ptr[len - i - 1], sizeof(ptr[0]))
 
 
@@ -25,8 +25,8 @@ def main() -> int:
 
         for i = 1; i < strlen(line); i += 4:
             if line[i] != ' ':
-                assert i/4 < array_count(stacks)
-                stacks[i/4].append(line[i])
+                assert i // 4 < array_count(stacks)
+                stacks[i // 4].append(line[i])
 
     for i = 0; i < 9; i++:
         reverse(stacks[i].ptr, stacks[i].len)

--- a/examples/aoc2023/day05/part2.jou
+++ b/examples/aoc2023/day05/part2.jou
@@ -82,8 +82,8 @@ class Input:
 
         words = split_by_ascii_whitespace(line)
         for i = 0; i+1 < words.len; i += 2:
-            assert i/2 < array_count(self.seed_ranges)
-            self.seed_ranges[i/2] = Range{
+            assert i // 2 < array_count(self.seed_ranges)
+            self.seed_ranges[i // 2] = Range{
                 start = atoll(words.ptr[i]),
                 end = atoll(words.ptr[i]) + atoll(words.ptr[i+1]),
             }

--- a/examples/aoc2023/day07/part2.jou
+++ b/examples/aoc2023/day07/part2.jou
@@ -108,7 +108,7 @@ class Hand:
                 # Duplicate each existing variation 13 times
                 nvariations *= 13
                 variations = realloc(variations, sizeof(variations[0]) * nvariations)
-                for isrc = nvariations/13 - 1; isrc >= 0; isrc--:
+                for isrc = nvariations//13 - 1; isrc >= 0; isrc--:
                     for idest = 13*isrc; idest < 13*(isrc+1); idest++:
                         variations[idest] = variations[isrc]
 

--- a/examples/aoc2023/day08/part2.jou
+++ b/examples/aoc2023/day08/part2.jou
@@ -44,7 +44,7 @@ def gcd(a: int64, b: int64) -> int64:
         memswap(&a, &b, sizeof(a))
 
 def lcm(a: int64, b: int64) -> int64:
-    return (a/gcd(a,b)) * b
+    return (a // gcd(a,b)) * b
 
 
 # We say that a number is a Z-count for a node, if doing that many steps
@@ -99,8 +99,8 @@ class ZCounts:
             if self.first_cycle.len % num_parts != 0 or self.cycle_offset % num_parts != 0:
                 continue
 
-            small_cycle_len = self.first_cycle.len / num_parts
-            small_offset = self.cycle_offset / num_parts
+            small_cycle_len = self.first_cycle.len // num_parts
+            small_offset = self.cycle_offset // num_parts
 
             can_split = True
             for i = 0; i < self.first_cycle.len - small_cycle_len; i++:

--- a/examples/aoc2023/day10/part1.jou
+++ b/examples/aoc2023/day10/part1.jou
@@ -67,7 +67,7 @@ def main() -> int:
         loop_length++
 
     assert loop_length % 2 == 0
-    printf("%d\n", loop_length / 2)  # Output: 4
+    printf("%d\n", loop_length // 2)  # Output: 4
 
     free(grid.data)
     return 0

--- a/examples/aoc2023/day10/part2.jou
+++ b/examples/aoc2023/day10/part2.jou
@@ -78,7 +78,7 @@ def polygon_area(corners: int[2]*, ncorners: int) -> int:
         c = corners[(i+1) % ncorners][0]
         d = corners[(i+1) % ncorners][1]
         double_area += a*d - b*c
-    return abs(double_area)/2
+    return abs(double_area) // 2
 
 
 def main() -> int:
@@ -95,8 +95,7 @@ def main() -> int:
 
     # take first step away from S
     dir = find_initial_direction(&grid, point)
-    point[0] += dir[0]
-    point[1] += dir[1]
+    point += dir
     loop_length = 1
 
     while grid.get(point) != 'S':
@@ -108,8 +107,7 @@ def main() -> int:
         else:
             dir = dirs[0]
         loop[loop_length++] = point
-        point[0] += dir[0]
-        point[1] += dir[1]
+        point += dir
 
     area_along_middle_of_path = polygon_area(loop, loop_length)
 
@@ -129,7 +127,7 @@ def main() -> int:
     #
     # Here n-m = 4 because the loop goes around a total of 360 degrees
     # towards the inside.
-    printf("%d\n", area_along_middle_of_path + 1 - loop_length/2)  # Output: 4
+    printf("%d\n", area_along_middle_of_path + 1 - loop_length//2)  # Output: 4
 
     free(grid.data)
     free(loop)

--- a/examples/aoc2023/day18/part2.jou
+++ b/examples/aoc2023/day18/part2.jou
@@ -67,7 +67,7 @@ def polygon_area(corners: List[int[2]]) -> int64:
         c: int64 = corners.ptr[(i+1) % corners.len][0]
         d: int64 = corners.ptr[(i+1) % corners.len][1]
         double_area += a*d - b*c
-    return llabs(double_area)/2
+    return llabs(double_area) // 2
 
 
 def main() -> int:
@@ -87,7 +87,7 @@ def main() -> int:
 
     assert path_len % 2 == 0
     points.pop()
-    printf("%lld\n", polygon_area(points) + 1 + path_len/2)  # Output: 952408144115
+    printf("%lld\n", polygon_area(points) + 1 + path_len//2)  # Output: 952408144115
 
     free(points.ptr)
     return 0

--- a/examples/aoc2023/day20/part2.jou
+++ b/examples/aoc2023/day20/part2.jou
@@ -165,7 +165,7 @@ def gcd(a: int64, b: int64) -> int64:
         memswap(&a, &b, sizeof(a))
 
 def lcm(a: int64, b: int64) -> int64:
-    return (a/gcd(a,b)) * b
+    return (a // gcd(a,b)) * b
 
 
 def main() -> int:

--- a/examples/aoc2023/day21/part2.jou
+++ b/examples/aoc2023/day21/part2.jou
@@ -62,7 +62,7 @@ class State:
         assert self.grid.width == self.grid.height
         side = self.grid.width
         assert side % 2 == 1
-        self.how_to_reach_anywhere = 2 * how_to_reach_anywhere_from_given_point(self.grid, [side/2,side/2])
+        self.how_to_reach_anywhere = 2 * how_to_reach_anywhere_from_given_point(self.grid, [side//2, side//2])
 
 
 def count_reachables_in_square(state: State*, entry_point_of_grid: int[2], steps_remaining_at_entry: int) -> int:
@@ -142,9 +142,9 @@ def count_reachables_in_square(state: State*, entry_point_of_grid: int[2], steps
 #
 # In above/below/left/right directions, this is
 #
-#   side*radius - side/2
+#   side*radius - side//2
 #
-# where side/2 is actually (side-1)/2 because it uses Jou's floor division.
+# where side//2 is actually (side-1)/2 because it uses Jou's floor division.
 # For example, for H we enter through the middle of its vertical left side.
 # Compared to its top left or bottom left corner, this saves (side-1)/2 steps up or down.
 def count_reachables_in_ring(state: State*, step_count: int, radius: int) -> int64:
@@ -154,12 +154,12 @@ def count_reachables_in_ring(state: State*, step_count: int, radius: int) -> int
 
     if radius == 0:
         # just the middle
-        return count_reachables_in_square(state, [side/2,side/2], step_count)
+        return count_reachables_in_square(state, [side//2,side//2], step_count)
 
     assert radius >= 1
 
     steps_remaining_diagonally = step_count - (side + 1 + side*(radius-2))
-    steps_remaining_above_or_below = step_count - (side*radius - side/2)
+    steps_remaining_above_or_below = step_count - (side*radius - side//2)
 
     # Above with radius=4, there's three A's.
     result = 0 as int64
@@ -167,10 +167,10 @@ def count_reachables_in_ring(state: State*, step_count: int, radius: int) -> int
     result += (radius-1) * count_reachables_in_square(state, [0,side-1], steps_remaining_diagonally)
     result += (radius-1) * count_reachables_in_square(state, [side-1,0], steps_remaining_diagonally)
     result += (radius-1) * count_reachables_in_square(state, [side-1,side-1], steps_remaining_diagonally)
-    result += count_reachables_in_square(state, [0, side/2], steps_remaining_above_or_below)
-    result += count_reachables_in_square(state, [side-1, side/2], steps_remaining_above_or_below)
-    result += count_reachables_in_square(state, [side/2, 0], steps_remaining_above_or_below)
-    result += count_reachables_in_square(state, [side/2, side-1], steps_remaining_above_or_below)
+    result += count_reachables_in_square(state, [0, side//2], steps_remaining_above_or_below)
+    result += count_reachables_in_square(state, [side-1, side//2], steps_remaining_above_or_below)
+    result += count_reachables_in_square(state, [side//2, 0], steps_remaining_above_or_below)
+    result += count_reachables_in_square(state, [side//2, side-1], steps_remaining_above_or_below)
     return result
 
 
@@ -215,14 +215,14 @@ def main() -> int:
 
     assert state.grid.count('S') == 1
     S_place = state.grid.find_first('S')
-    assert S_place[0] == side/2
-    assert S_place[1] == side/2
+    assert S_place[0] == side//2
+    assert S_place[1] == side//2
     state.grid.set(S_place, '.')
 
     # The square should have '.' at boundary, and in middle row and column (now that S is gone)
     for x = 0; x < side; x++:
         for y = 0; y < side; y++:
-            if x == 0 or x == side/2 or x == side-1 or y == 0 or y == side/2 or y == side-1:
+            if x == 0 or x == side//2 or x == side-1 or y == 0 or y == side//2 or y == side-1:
                 assert state.grid.get([x, y]) == '.'
 
     state.fill_cached_values()

--- a/examples/aoc2023/day24/bigint.jou
+++ b/examples/aoc2023/day24/bigint.jou
@@ -61,8 +61,8 @@ class BigInt:
     #   self > other  -->  1
     @public
     def compare(self: BigInt, other: BigInt) -> int:
-        self_sign_bit = self.data[sizeof(self.data) - 1] / 128
-        other_sign_bit = other.data[sizeof(other.data) - 1] / 128
+        self_sign_bit = self.data[sizeof(self.data) - 1] // 128
+        other_sign_bit = other.data[sizeof(other.data) - 1] // 128
 
         if self_sign_bit != other_sign_bit:
             return other_sign_bit - self_sign_bit
@@ -116,14 +116,14 @@ class BigInt:
                 gonna_add = bigint(0)
                 gonna_add.data[i+k] = temp as byte
                 if i+k+1 < sizeof(gonna_add.data):
-                    gonna_add.data[i+k+1] = (temp / 256) as byte
+                    gonna_add.data[i+k+1] = (temp // 256) as byte
                 result = result.add(gonna_add)
 
         if result.sign() != result_sign:
             result = result.neg()
         return result
 
-    # x / 256^n for x >= 0
+    # x // 256^n for x >= 0
     def shift_smaller(self: BigInt, n: int) -> BigInt:
         assert self.sign() >= 0
         assert n >= 0
@@ -147,7 +147,7 @@ class BigInt:
         memset(&self.data, 0, n)
         return self
 
-    # [x/y, x%y]
+    # [x//y, x%y]
     def divmod(self: BigInt, bottom: BigInt) -> BigInt[2]:
         assert not bottom.is_zero()
 
@@ -169,7 +169,7 @@ class BigInt:
                     d++
                 else:
                     d *= 2
-            d /= 2
+            d //= 2
             while bigger_bottom.mul(bigint(d+1)).compare(remainder) <= 0:
                 d++
 
@@ -195,19 +195,19 @@ class BigInt:
         #        for y = -100; y <= 100; y++:
         #            if y != 0:
         #                result = bigint(x).divmod(bigint(y))
-        #                assert x == (x/y)*y + (x%y)
+        #                assert x == (x//y)*y + (x%y)
         #                assert x == result[0].to_int64()*y + result[1].to_int64()
-        #                assert result[0].to_int64() == x / y
+        #                assert result[0].to_int64() == x // y
         #                assert result[1].to_int64() == x % y
 
-    # self / y
+    # self // y
     @public
     def div(self: BigInt, other: BigInt) -> BigInt:
         pair = self.divmod(other)
         return pair[0]
 
     # assert x % y == 0
-    # x / y
+    # x // y
     @public
     def div_exact(self: BigInt, other: BigInt) -> BigInt:
         pair = self.divmod(other)

--- a/examples/aoc2023/day24/part2.jou
+++ b/examples/aoc2023/day24/part2.jou
@@ -211,7 +211,7 @@ def get_paired_index(N: int, small: int, big: int) -> int:
 # t_1*t_2 becomes t_(N+1), t_1*t_3 becomes t_(N+2) and so on.
 # Even with that, the resulting equations contain enough info to be solved.
 def create_equations(moving_points: MovingPoint*, N: int, neqs: int*) -> Equation*:
-    nvariables = N + N*(N-1)/2  # N normal variables, (n choose 2) paired variables
+    nvariables = N + N*(N-1)//2  # N normal variables, (n choose 2) paired variables
 
     eqs: Equation* = calloc(sizeof(eqs[0]), 3*N*N*N + 1)  # more than big enough
     assert eqs != NULL

--- a/examples/aoc2024/day05/part1.jou
+++ b/examples/aoc2024/day05/part1.jou
@@ -97,7 +97,7 @@ def main() -> int:
             while job[n] != -1:
                 n++
             assert n % 2 == 1
-            midsum += job[(n - 1) / 2]
+            midsum += job[(n - 1) // 2]
 
     printf("%lld\n", midsum)  # Output: 143
 

--- a/examples/aoc2024/day05/part2.jou
+++ b/examples/aoc2024/day05/part2.jou
@@ -113,7 +113,7 @@ def main() -> int:
             while job[n] != -1:
                 n++
             assert n % 2 == 1
-            midsum += job[(n - 1) / 2]
+            midsum += job[(n - 1) // 2]
 
     printf("%lld\n", midsum)  # Output: 123
 

--- a/examples/aoc2024/day07/part2.jou
+++ b/examples/aoc2024/day07/part2.jou
@@ -9,7 +9,7 @@ def length_of_a_number(x: int64) -> int:
     assert x > 0
     result = 0
     while x != 0:
-        x /= 10
+        x //= 10
         result++
     return result
 

--- a/examples/aoc2024/day08/part2.jou
+++ b/examples/aoc2024/day08/part2.jou
@@ -26,18 +26,16 @@ def add_antinodes(antennas: Grid, antinodes: Grid*, frequency: byte) -> None:
     for i = 0; places[i][0] != -1; i++:
         for k = 0; places[k][0] != -1; k++:
             if i != k:
-                dx = places[k][0] - places[i][0]
-                dy = places[k][1] - places[i][1]
+                direction = places[k] - places[i]
 
-                # Pick shortest (dx,dy) vector in the correct direction
-                unnecessary_multipliers = gcd(abs(dx), abs(dy))
-                dx /= unnecessary_multipliers
-                dy /= unnecessary_multipliers
+                # Pick shortest vector in the correct direction
+                unnecessary_multipliers = gcd(abs(direction[0]), abs(direction[1]))
+                direction //= unnecessary_multipliers
 
-                # Walk in dx,dy direction.
+                # Walk in the direction.
                 pos = places[i]
                 while True:
-                    pos = [pos[0] + dx, pos[1] + dy]
+                    pos += direction
                     if not antinodes.is_in_bounds(pos):
                         break
                     antinodes.set(pos, '#')

--- a/examples/aoc2024/day09/part1.jou
+++ b/examples/aoc2024/day09/part1.jou
@@ -18,7 +18,7 @@ def parse_disk_map(disk_map_string: byte*) -> int*:
 
         if i % 2 == 0:
             # It is a file
-            file_id = i/2
+            file_id = i//2
             size = disk_map_string[i] - '0'
             while size --> 0:
                 *p++ = file_id

--- a/examples/aoc2024/day09/part2.jou
+++ b/examples/aoc2024/day09/part2.jou
@@ -18,7 +18,7 @@ def parse_disk_map(disk_map_string: byte*) -> int*:
 
         if i % 2 == 0:
             # It is a file
-            file_id = i/2
+            file_id = i//2
             size = disk_map_string[i] - '0'
             while size --> 0:
                 *p++ = file_id

--- a/examples/aoc2024/day11/part1.jou
+++ b/examples/aoc2024/day11/part1.jou
@@ -11,7 +11,7 @@ import "stdlib/str.jou"
 def count_digits(n: int64) -> int:
     result = 0
     while n > 0:
-        n /= 10
+        n //= 10
         result++
     return result
 
@@ -22,10 +22,10 @@ def split_digits(n: int64) -> int64[2]:
     assert length % 2 == 0
 
     power_of_10 = 1
-    for i = 0; i < length/2; i++:
+    for i = 0; i < length//2; i++:
         power_of_10 *= 10
 
-    return [n / power_of_10, n % power_of_10]
+    return [n // power_of_10, n % power_of_10]
 
 
 def blink(stones: List[int64]*) -> None:

--- a/examples/aoc2024/day11/part2.jou
+++ b/examples/aoc2024/day11/part2.jou
@@ -10,7 +10,7 @@ import "stdlib/str.jou"
 def count_digits(n: int64) -> int:
     result = 0
     while n > 0:
-        n /= 10
+        n //= 10
         result++
     return result
 
@@ -21,10 +21,10 @@ def split_digits(n: int64) -> int64[2]:
     assert length % 2 == 0
 
     power_of_10 = 1 as int64
-    for i = 0; i < length/2; i++:
+    for i = 0; i < length//2; i++:
         power_of_10 *= 10
 
-    return [n / power_of_10, n % power_of_10]
+    return [n // power_of_10, n % power_of_10]
 
 
 # Usage: cache[a][b] == analyze_stone(a, b)

--- a/examples/aoc2024/day13/part2.jou
+++ b/examples/aoc2024/day13/part2.jou
@@ -21,7 +21,7 @@ def gcd(a: int64, b: int64) -> int64:
 # Returns the shortest vector in the same direction as the given vector.
 def shortest_vector(v: int64[2]) -> int64[2]:
     unwanted_scaling = gcd(llabs(v[0]), llabs(v[1]))
-    return [v[0] / unwanted_scaling, v[1] / unwanted_scaling]
+    return v // unwanted_scaling
 
 
 # Determines if two vectors go in the same direction.
@@ -59,13 +59,13 @@ def solve_linear_unique_2x2_system(a: int64, b: int64, c: int64, d: int64, e: in
     while a != 0 and d != 0:
         if a > d:
             # Subtract second equation from first n times
-            n = a/d
+            n = a // d
             a -= n*d
             b -= n*e
             c -= n*f
         else:
             # Subtract first equation from second n times
-            n = d/a
+            n = d // a
             d -= n*a
             e -= n*b
             f -= n*c
@@ -83,8 +83,8 @@ def solve_linear_unique_2x2_system(a: int64, b: int64, c: int64, d: int64, e: in
     assert b != 0
     assert d != 0
 
-    y = c / b
-    x = (f - e*y) / d
+    y = c // b
+    x = (f - e*y) // d
 
     if a*x + b*y == c and d*x + e*y == f:
         # Solution happens to consist of integers
@@ -120,11 +120,11 @@ def optimize_1d(a: int64, b: int64, prize: int64) -> int64[2]:
     # Start by pressing the better button as much as we can without going
     # beyond the prize. Use the other button to move the rest of the way.
     if a_is_better:
-        a_presses = prize / a
-        b_presses = (prize - a*a_presses) / b
+        a_presses = prize // a
+        b_presses = (prize - a*a_presses) // b
     else:
-        b_presses = prize / b
-        a_presses = (prize - b*b_presses) / a
+        b_presses = prize // b
+        a_presses = (prize - b*b_presses) // a
 
     while a_presses >= 0 and b_presses >= 0:
         if a*a_presses + b*b_presses == prize:
@@ -137,10 +137,10 @@ def optimize_1d(a: int64, b: int64, prize: int64) -> int64[2]:
         # This seems to never happen with the inputs given in AoC.
         if a_is_better:
             a_presses--
-            b_presses = (prize - a*a_presses) / b
+            b_presses = (prize - a*a_presses) // b
         else:
             b_presses--
-            a_presses = (prize - b*b_presses) / a
+            a_presses = (prize - b*b_presses) // a
 
     # No solution
     return [-1, -1]

--- a/examples/aoc2024/day14/part1.jou
+++ b/examples/aoc2024/day14/part1.jou
@@ -20,8 +20,8 @@ def determine_quadrant(x: int, y: int) -> Quadrant:
     assert width % 2 == 1
     assert height % 2 == 1
 
-    mid_x = (width - 1) / 2
-    mid_y = (height - 1) / 2
+    mid_x = (width - 1) // 2
+    mid_y = (height - 1) // 2
 
     if x < mid_x:
         if y < mid_y:

--- a/examples/aoc2024/day14/part2.jou
+++ b/examples/aoc2024/day14/part2.jou
@@ -13,9 +13,7 @@ class Robot:
     velocity: int[2]
 
     def move(self) -> None:
-        self.position[0] += self.velocity[0]
-        self.position[1] += self.velocity[1]
-
+        self.position += self.velocity
         self.position[0] %= width
         self.position[1] %= height
 

--- a/examples/aoc2024/day22/part1.jou
+++ b/examples/aoc2024/day22/part1.jou
@@ -5,7 +5,7 @@ import "stdlib/str.jou"
 
 def next_num(n: int64) -> int64:
     n = (n ^ (n * 64)) % 16777216
-    n = (n ^ (n / 32)) % 16777216
+    n = (n ^ (n // 32)) % 16777216
     n = (n ^ (n * 2048)) % 16777216
     return n
 

--- a/examples/aoc2024/day22/part2.jou
+++ b/examples/aoc2024/day22/part2.jou
@@ -6,7 +6,7 @@ import "stdlib/mem.jou"
 
 def next_num(n: int64) -> int64:
     n = (n ^ (n * 64)) % 16777216
-    n = (n ^ (n / 32)) % 16777216
+    n = (n ^ (n // 32)) % 16777216
     n = (n ^ (n * 2048)) % 16777216
     return n
 

--- a/examples/aoc2024/day24/part2.jou
+++ b/examples/aoc2024/day24/part2.jou
@@ -157,7 +157,7 @@ def count_errors(orig_gates: Gate*, ngates: int, mark_sus: bool) -> int:
 
     # With real input, there are 45 adders, but the first adder is simpler than others.
     # It only has two gates: InputXor for output, InputAnd for overflow/carry.
-    num_adders = ngates/5 + 1
+    num_adders = ngates//5 + 1
     assert counts[GateType.InputXor as int] == num_adders
     assert counts[GateType.InputAnd as int] == num_adders
     assert counts[GateType.OutputXor as int] == num_adders - 1
@@ -329,7 +329,7 @@ def main() -> int:
             bad_outputs[bad_outputs_len++] = orig_gates.ptr[i].output
 
     # Output: 4 gates were in the wrong place (2 swaps)
-    printf("%d gates were in the wrong place (%d swaps)\n", bad_outputs_len, bad_outputs_len / 2)
+    printf("%d gates were in the wrong place (%d swaps)\n", bad_outputs_len, bad_outputs_len // 2)
 
     # Output: ia1,ia2,ix2,ix3
     sort_strings(bad_outputs, bad_outputs_len)

--- a/examples/aoc2025/day02/part1.jou
+++ b/examples/aoc2025/day02/part1.jou
@@ -5,7 +5,7 @@ import "stdlib/io.jou"
 def count_digits(n: int64) -> int:
     result = 0
     while n != 0:
-        n /= 10
+        n //= 10
         result++
     return result
 
@@ -30,8 +30,8 @@ def main() -> int:
         for n = start; n <= end; n++:
             ndigits = count_digits(n)
             if ndigits % 2 == 0:
-                power_of_10 = my_pow(10, ndigits / 2)
-                if n / power_of_10 == n % power_of_10:
+                power_of_10 = my_pow(10, ndigits // 2)
+                if n // power_of_10 == n % power_of_10:
                     result += n
 
         if fgetc(f) != ',':

--- a/examples/aoc2025/day02/part2.jou
+++ b/examples/aoc2025/day02/part2.jou
@@ -5,7 +5,7 @@ import "stdlib/io.jou"
 def count_digits(n: int64) -> int:
     result = 0
     while n != 0:
-        n /= 10
+        n //= 10
         result++
     return result
 
@@ -15,7 +15,7 @@ def dividing_produces_constant_sequence_until_zero(n: int64, pow10: int64) -> bo
     while n != 0:
         if n % pow10 != value:
             return False
-        n /= pow10
+        n //= pow10
     return True
 
 

--- a/examples/aoc2025/day09/part2.jou
+++ b/examples/aoc2025/day09/part2.jou
@@ -6,7 +6,7 @@ import "stdlib/mem.jou"
 
 
 def midpoint(a: int[2], b: int[2]) -> int[2]:
-    return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2]
+    return (a + b) // 2
 
 
 def main() -> int:


### PR DESCRIPTION
Jou comes with my solutions to all advent of code problems from the past few years. This PR changes them to use `//` for integer divisions instead of `/`.

I basically made this PR by enabling the commented-out warning about `/` integer division in the compiler:

https://github.com/Akuli/jou/blob/2c4b06c88c30b383e0739f0739ff6cf921c324e7/compiler/typecheck/step3_function_and_method_bodies.jou#L530-L532

Part of #1379 