### PR TITLE
Add a warning for `integer / integer` division

### DIFF
--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -527,7 +527,20 @@ def check_binop(
         snprintf(msg, sizeof(msg), "wrong types: cannot %s %s and %s", do_what, ltype.name, rtype.name)
         fail(location, msg)
 
-    if op == AstExpressionKind.Div and (got_integers or got_integer_array_and_integer):
+    if (
+        op == AstExpressionKind.Div
+        and (got_integers or got_integer_array_and_integer)
+        # Hack: stdlib/toml.jou cannot use the new syntax yet because it's
+        # needed to build joutest.
+        #
+        # To fully solve this and similar problems, we could have a separate
+        # copy of stdlib that only the bootstrap compiler uses. But for now
+        # that seems unnecessary.
+        and not ends_with(location.path, "/stdlib/toml.jou")
+        and not (WINDOWS and ends_with(location.path, "\\stdlib\\toml.jou"))
+        and not (WINDOWS and ends_with(location.path, "/stdlib\\toml.jou"))
+        and not (WINDOWS and ends_with(location.path, "\\stdlib/toml.jou"))
+    ):
         show_warning(location, "please use '//' for integer division, '/' will soon produce a double")
 
     if op == AstExpressionKind.BitShiftLeft or op == AstExpressionKind.BitShiftRight:

--- a/compiler/typecheck/step3_function_and_method_bodies.jou
+++ b/compiler/typecheck/step3_function_and_method_bodies.jou
@@ -527,9 +527,8 @@ def check_binop(
         snprintf(msg, sizeof(msg), "wrong types: cannot %s %s and %s", do_what, ltype.name, rtype.name)
         fail(location, msg)
 
-    # TODO: enable this warning
-    #if op == AstExpressionKind.Div and (got_integers or got_integer_array_and_integer):
-    #    show_warning(location, "please use '//' for integer division, '/' will soon produce a double")
+    if op == AstExpressionKind.Div and (got_integers or got_integer_array_and_integer):
+        show_warning(location, "please use '//' for integer division, '/' will soon produce a double")
 
     if op == AstExpressionKind.BitShiftLeft or op == AstExpressionKind.BitShiftRight:
         # Special-cased, because right side type does not affect the type of result.

--- a/stdlib/toml.jou
+++ b/stdlib/toml.jou
@@ -516,7 +516,7 @@ class TOMLParser:
 
                 old = unsigned_result
                 new = (old*base + v) as uint64
-                if new // base != old or new > max_abs:
+                if new/base != old or new > max_abs:
                     self.error = "integer doesn't fit to int64"
                     return False
                 unsigned_result = new

--- a/stdlib/toml.jou
+++ b/stdlib/toml.jou
@@ -516,7 +516,7 @@ class TOMLParser:
 
                 old = unsigned_result
                 new = (old*base + v) as uint64
-                if new/base != old or new > max_abs:
+                if new // base != old or new > max_abs:
                     self.error = "integer doesn't fit to int64"
                     return False
                 unsigned_result = new

--- a/tests/should_succeed/add_sub_mul_div_mod.jou
+++ b/tests/should_succeed/add_sub_mul_div_mod.jou
@@ -80,10 +80,14 @@ def main() -> int:
     printf("%d\n", x)
 
     # TODO: Dividing integers with "/" will soon produce a double
-    printf("%d / %d = %d\n", 7, 2, 7/2)         # Output: 7 / 2 = 3
-    printf("%d / %d = %d\n", -7, 2, (-7)/2)     # Output: -7 / 2 = -4
-    printf("%d / %d = %d\n", 7, -2, 7/(-2))     # Output: 7 / -2 = -4
-    printf("%d / %d = %d\n", -7, -2, (-7)/(-2)) # Output: -7 / -2 = 3
+    # Output: 7 / 2 = 3
+    # Output: -7 / 2 = -4
+    # Output: 7 / -2 = -4
+    # Output: -7 / -2 = 3
+    printf("%d / %d = %d\n", 7, 2, 7/2)         # Warning: please use '//' for integer division, '/' will soon produce a double
+    printf("%d / %d = %d\n", -7, 2, (-7)/2)     # Warning: please use '//' for integer division, '/' will soon produce a double
+    printf("%d / %d = %d\n", 7, -2, 7/(-2))     # Warning: please use '//' for integer division, '/' will soon produce a double
+    printf("%d / %d = %d\n", -7, -2, (-7)/(-2)) # Warning: please use '//' for integer division, '/' will soon produce a double
 
     # Signed 32-bit floor division
     printf("%d // %d = %d\n", 7, 2, 7//2)         # Output: 7 // 2 = 3
@@ -105,7 +109,11 @@ def main() -> int:
     printf("%d\n", x)
 
     # Output: 8 3 2 1
-    y = side_effect(8) / side_effect(3) / side_effect(2)
+    y = (
+        side_effect(8)
+        / side_effect(3)    # Warning: please use '//' for integer division, '/' will soon produce a double
+        / side_effect(2)    # Warning: please use '//' for integer division, '/' will soon produce a double
+    )
     printf("%d\n", y)
 
     # Output: 222222
@@ -143,7 +151,7 @@ def main() -> int:
     printf("%d\n", x)  # Output: 9
     x *= 3
     printf("%d\n", x)  # Output: 27
-    x /= 2
+    x //= 2
     printf("%d\n", x)  # Output: 13
     x %= 4
     printf("%d\n", x)  # Output: 1

--- a/tests/should_succeed/array_math.jou
+++ b/tests/should_succeed/array_math.jou
@@ -70,6 +70,8 @@ def test_div() -> None:
     floor_divided = [-2, 2, 8] // 3
     printf("%d %d %d\n", floor_divided[0], floor_divided[1], floor_divided[2])  # Output: -1 0 2
 
+    to_be_changed_soon = [-2, 2, 8] / 3  # Warning: please use '//' for integer division, '/' will soon produce a double
+
     array = [-2, 2, 8] / 3.0  # TODO: remove ".0" when possible
     printf("%f %f %f\n", array[0], array[1], array[2])  # Output: -0.666667 0.666667 2.666667
 

--- a/tests/should_succeed/compiler_unit_tests.jou
+++ b/tests/should_succeed/compiler_unit_tests.jou
@@ -5,7 +5,8 @@ import "stdlib/io.jou"
 import "stdlib/str.jou"
 import "stdlib/mem.jou"
 import "../../compiler/hash.jou"
-import "../../compiler/paths.jou"
+# TODO: this is very hacky... need to update the bootstrap compiler
+import "../../compiler/paths.jou"  # Output: compiler warning for file "compiler/paths.jou", line 360: please use '//' for integer division, '/' will soon produce a double
 
 if not WINDOWS:
     # Make sure we link with LLVM

--- a/tests/should_succeed/integer_type_inference.jou
+++ b/tests/should_succeed/integer_type_inference.jou
@@ -24,7 +24,7 @@ def main() -> int:
     b *= 2
     b += 5
     b -= 4
-    b /= 3
+    b /= 3  # Warning: please use '//' for integer division, '/' will soon produce a double
     printf("%d\n", b)  # Output: 67
 
     # Type inference inside an array

--- a/tests/should_succeed/random_test.jou
+++ b/tests/should_succeed/random_test.jou
@@ -26,6 +26,6 @@ def main() -> int:
     m = 0
     for i = 0; i < 10000; i++:
         m = max(m, rand())
-    printf("%d%d\n", RAND_MAX - RAND_MAX/100 < m, m <= RAND_MAX)  # Output: 11
+    printf("%d%d\n", 0.99*RAND_MAX < m, m <= RAND_MAX)  # Output: 11
 
     return 0

--- a/tests/should_succeed/sizeof.jou
+++ b/tests/should_succeed/sizeof.jou
@@ -36,7 +36,7 @@ def main() -> int:
     printf("%d\n", sizeof(arr))  # Output: 800
 
     # The "array length trick" that was used before array_count() existed
-    printf("%d\n", sizeof(arr) / sizeof(arr[0]))  # Output: 100
+    printf("%d\n", sizeof(arr) // sizeof(arr[0]))  # Output: 100
     printf("%d\n", array_count(arr))  # Output: 100
 
     # Evaluating a sizeof has no side effects.

--- a/tests/should_succeed/time_test.jou
+++ b/tests/should_succeed/time_test.jou
@@ -8,7 +8,7 @@ def test_time() -> None:
     # the current year. This test will break after a few years, but I want to
     # set a maximum in tests so I know I'm not e.g. getting milliseconds.
     seconds_in_year = 31557600
-    year = 1970 + time(NULL) / seconds_in_year
+    year = 1970 + (time(NULL) // seconds_in_year)
     if year < 2025:
         printf("year too small\n")
     elif year > 2030:


### PR DESCRIPTION
Example:

```python3
import "stdlib/io.jou"

def main() -> int:
    x = 1/2
    printf("%d\n", x)
    return 0
```

Output before this PR:

```
0
```

Output after this PR:

```
compiler warning for file "a.jou", line 4: please use '//' for integer division, '/' will soon produce a double
0
```

Once this warning has been out for a while (maybe one week?), I can change Jou so that `1/2` produces `0.5` instead of `0`.

Part of #1379 