### PR TITLE
Add Windows string conversion (WTF-8) functions to stdlib/utf8.jou

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: sudo apt install -y codespell || (sudo apt update && sudo apt install -y codespell)
-      - run: codespell --enable-colors -L ot,bu,hel,fom,olt,fo,nd $(git ls-files)
+      - run: codespell --enable-colors -L ot,bu,hel,fom,olt,fo,nd,worl $(git ls-files)
 
   # For consistency, Jou code in markdown files should use ```python, not ```python3
   python-in-markdown:

--- a/stdlib/utf8.jou
+++ b/stdlib/utf8.jou
@@ -149,13 +149,13 @@ def utf8_encode_char(u: uint32) -> byte[5]:
 # Usage:
 #
 #   # With heap memory
-#   s = windows_to_utf8(some_windows_string, NULL, 0)
+#   s = string_from_windows(some_windows_string, NULL, 0)
 #   printf("Got %s\n", s)
 #   free(s)
 #
 #   # With stack memory
 #   s: byte[100]
-#   if windows_to_utf8(some_windows_string, s, sizeof(s)) != NULL:
+#   if string_from_windows(some_windows_string, s, sizeof(s)) != NULL:
 #       # It fits into 100 bytes
 #       printf("Got %s\n", s)
 #
@@ -169,7 +169,7 @@ def utf8_encode_char(u: uint32) -> byte[5]:
 #
 # The windows string can be any 16-bit sequence terminated by zero. If it is
 # not valid UTF-16, this function outputs invalid UTF-8 that can be converted
-# back to the same invalid UTF-16 with utf8_to_windows(). For details of how
+# back to the same invalid UTF-16 with string_to_windows(). For details of how
 # this is achieved, look up WTF-8 (Wobbly Transformation Format).
 #
 # For example, if you use this function for handling file names on Windows,
@@ -177,7 +177,7 @@ def utf8_encode_char(u: uint32) -> byte[5]:
 # (converted) file names are not necessarily valid UTF-8, but it doesn't matter
 # if you only pass them around and perhaps concatenate them.
 @public
-def windows_to_utf8(windows_string: uint16*, buf: byte*, buf_size: intnative) -> byte*:
+def string_from_windows(windows_string: uint16*, buf: byte*, buf_size: intnative) -> byte*:
     assert (buf == NULL and buf_size == 0) or (buf != NULL and buf_size > 0)
 
     list = List[byte]{}  # used only if buf is NULL
@@ -247,33 +247,33 @@ def windows_to_utf8(windows_string: uint16*, buf: byte*, buf_size: intnative) ->
 # Usage:
 #
 #   # With heap memory
-#   wstring = utf8_to_windows(some_string, NULL, 0)
+#   wstring = string_to_windows(some_string, NULL, 0)
 #   SomeWindowsFunctionW(..., wstring, ...)
 #   free(windows_string)
 #
 #   # With stack memory
 #   wstring: uint16[100]
-#   if utf8_to_windows(some_string, wstring, sizeof(wstring)) != NULL:
+#   if string_to_windows(some_string, wstring, sizeof(wstring)) != NULL:
 #       # It fits into 100 units (200 bytes)
 #       SomeWindowsFunctionW(..., wstring, ...)
 #
-# The parameters and return value work similarly to windows_to_utf8(), with one
-# caveat: The buffer size is given in bytes, not in 16-bit units. For arrays,
-# this means you should use sizeof(), not array_count(). This way, if you
-# accidentally pass in the wrong kind of size (16-bit units instead of bytes),
+# The parameters and return value work similarly to string_from_windows(), with
+# one caveat: The buffer size is given in bytes, not in 16-bit units. For
+# arrays, this means you should use sizeof(), not array_count(). This way, if
+# you accidentally pass in the wrong kind of size (16-bit units instead of bytes),
 # there will be no stack overflow, although the second half of the buffer will
 # never be used.
 #
 # This function succeeds if the UTF-8 string is valid UTF-8, or a string in the
-# format that windows_to_utf8() outputs (WTF-8). NULL is returned if the input
-# string is invalid. So unlike with windows_to_utf8(), return value NULL
-# doesn't necessarily mean that the string didn't fit.
+# format that string_from_windows() outputs (WTF-8). NULL is returned if the
+# input string is invalid. So unlike with string_from_windows(), return value
+# NULL doesn't necessarily mean that the string didn't fit.
 #
 # If you want to compute a big enough buffer size beforehand, use
 # strlen(utf8_string)+1 or more 16-bit units. That's 2*(strlen(utf8_string)+1)
 # or more bytes.
 @public
-def utf8_to_windows(utf8_string: byte*, buf: uint16*, buf_size: intnative) -> uint16*:
+def string_to_windows(utf8_string: byte*, buf: uint16*, buf_size: intnative) -> uint16*:
     buf_size //= 2  # convert from bytes to 16-bit units
     assert (buf == NULL and buf_size == 0) or (buf != NULL and buf_size > 0)
 
@@ -316,7 +316,7 @@ def utf8_to_windows(utf8_string: byte*, buf: uint16*, buf_size: intnative) -> ui
         # security problems, because there are multiple ways to represent
         # the same string.
         if codepoint != -1:
-            # See windows_to_utf8()
+            # See string_from_windows()
             if codepoint <= 0x7f:
                 if num_bytes != 1:
                     codepoint = -1  # invalid WTF-8: overlong encoding
@@ -330,7 +330,6 @@ def utf8_to_windows(utf8_string: byte*, buf: uint16*, buf_size: intnative) -> ui
                 if num_bytes != 4:
                     codepoint = -1  # invalid WTF-8: overlong encoding
             else:
-                # TODO: Make sure this case gets tested
                 codepoint = -1  # invalid WTF-8: codepoint is too big to be anything valid
 
         if codepoint == -1:

--- a/stdlib/utf8.jou
+++ b/stdlib/utf8.jou
@@ -8,6 +8,8 @@
 
 import "stdlib/assert.jou"
 import "stdlib/intnative.jou"
+import "stdlib/list.jou"
+import "stdlib/mem.jou"
 
 
 # Check if b is a continuation byte. A UTF-8 multibyte (that is, non-ASCII)
@@ -140,3 +142,228 @@ def utf8_encode_char(u: uint32) -> byte[5]:
             assert False
 
     return result
+
+
+# Convert a string coming from Windows into a UTF-8 string.
+#
+# Usage:
+#
+#   # With heap memory
+#   s = windows_to_utf8(some_windows_string, NULL, 0)
+#   printf("Got %s\n", s)
+#   free(s)
+#
+#   # With stack memory
+#   s: byte[100]
+#   if windows_to_utf8(some_windows_string, s, sizeof(s)) != NULL:
+#       # It fits into 100 bytes
+#       printf("Got %s\n", s)
+#
+# So, if buf is not NULL, the result goes there, and otherwise this function
+# calls malloc().
+#
+# The return value is the UTF-8 string: either buf or a pointer from malloc().
+# Return value NULL means that the result didn't fit into buf, and in that
+# case, buf contains as much of the result as fits into it followed by a zero
+# byte to terminate it, just like with snprintf().
+#
+# The windows string can be any 16-bit sequence terminated by zero. If it is
+# not valid UTF-16, this function outputs invalid UTF-8 that can be converted
+# back to the same invalid UTF-16 with utf8_to_windows(). For details of how
+# this is achieved, look up WTF-8 (Wobbly Transformation Format).
+#
+# For example, if you use this function for handling file names on Windows,
+# then file name handling becomes very similar to other operating systems:
+# (converted) file names are not necessarily valid UTF-8, but it doesn't matter
+# if you only pass them around and perhaps concatenate them.
+@public
+def windows_to_utf8(windows_string: uint16*, buf: byte*, buf_size: intnative) -> byte*:
+    assert (buf == NULL and buf_size == 0) or (buf != NULL and buf_size > 0)
+
+    list = List[byte]{}  # used only if buf is NULL
+    index: intnative = 0  # used only if buf is not NULL
+
+    while True:
+        # Note: This does not read beyond the ending zero value of the windows string.
+        if windows_string[0] >> 10 == 0b110110 and windows_string[1] >> 10 == 0b110111:
+            # It is a valid UTF-16 surrogate pair
+            first_10_bits = *windows_string++ & 0b11_1111_1111
+            second_10_bits = *windows_string++ & 0b11_1111_1111
+            codepoint: int = ((first_10_bits as int) << 10) | second_10_bits
+            codepoint += 0x10000  # UTF-16 is weird
+        else:
+            # Anything else goes out as is in UTF-8 format. This includes
+            # invalid surrogate pairs.
+            codepoint = *windows_string++
+
+        output: byte[4]
+        output_len = 0
+
+        # Just like utf8_encode_char() but allows UTF-16 surrogates (0xD800 to 0xDFFF)
+        if codepoint <= 0x7f:
+            # Fits in 7 bits (ASCII character)
+            output[0] = codepoint as byte
+            output_len = 1
+        elif codepoint <= 0x7ff:
+            # Fits in 11 bits: emit 5-bit part and 6-bit part
+            output[0] = (0b1100_0000 | (codepoint >> 6)) as byte
+            output[1] = (0b1000_0000 | (codepoint & 0b0011_1111)) as byte
+            output_len = 2
+        elif codepoint <= 0xffff:
+            # Fits in 16 bits: emit 4-bit part and two 6-bit parts
+            output[0] = (0b1110_0000 | (codepoint >> 12)) as byte
+            output[1] = (0b1000_0000 | ((codepoint >> 6) & 0b0011_1111)) as byte
+            output[2] = (0b1000_0000 | (codepoint & 0b0011_1111)) as byte
+            output_len = 3
+        else:
+            # It came from a surrogate pair so it can be at most:
+            #
+            #   0b11111_11111_11111_11111 + 0x10000 = 0x10ffff
+            #
+            # So it fits in 21 bits. Emit 3-bit part and three 6-bit parts.
+            output[0] = (0b1111_0000 | (codepoint >> 18)) as byte
+            output[1] = (0b1000_0000 | ((codepoint >> 12) & 0b0011_1111)) as byte
+            output[2] = (0b1000_0000 | ((codepoint >> 6) & 0b0011_1111)) as byte
+            output[3] = (0b1000_0000 | (codepoint & 0b0011_1111)) as byte
+            output_len = 4
+
+        if buf == NULL:
+            list.extend_from_ptr(output, output_len)
+        else:
+            for i = 0; i < output_len; i++:
+                if index == buf_size:
+                    # does not fit :(
+                    buf[buf_size - 1] = '\0'
+                    return NULL
+                buf[index++] = output[i]
+
+        if codepoint == 0:
+            # We successfully consumed zero byte from input and added it to output.
+            return list.ptr if buf == NULL else buf
+
+
+# Convert a UTF-8 string into a string suitable for passing to Windows.
+#
+# Usage:
+#
+#   # With heap memory
+#   wstring = utf8_to_windows(some_string, NULL, 0)
+#   SomeWindowsFunctionW(..., wstring, ...)
+#   free(windows_string)
+#
+#   # With stack memory
+#   wstring: uint16[100]
+#   if utf8_to_windows(some_string, wstring, sizeof(wstring)) != NULL:
+#       # It fits into 100 units (200 bytes)
+#       SomeWindowsFunctionW(..., wstring, ...)
+#
+# The parameters and return value work similarly to windows_to_utf8(), with one
+# caveat: The buffer size is given in bytes, not in 16-bit units. For arrays,
+# this means you should use sizeof(), not array_count(). This way, if you
+# accidentally pass in the wrong kind of size (16-bit units instead of bytes),
+# there will be no stack overflow, although the second half of the buffer will
+# never be used.
+#
+# This function succeeds if the UTF-8 string is valid UTF-8, or a string in the
+# format that windows_to_utf8() outputs (WTF-8). NULL is returned if the input
+# string is invalid. So unlike with windows_to_utf8(), return value NULL
+# doesn't necessarily mean that the string didn't fit.
+#
+# If you want to compute a big enough buffer size beforehand, use
+# strlen(utf8_string)+1 or more 16-bit units. That's 2*(strlen(utf8_string)+1)
+# or more bytes.
+@public
+def utf8_to_windows(utf8_string: byte*, buf: uint16*, buf_size: intnative) -> uint16*:
+    buf_size //= 2  # convert from bytes to 16-bit units
+    assert (buf == NULL and buf_size == 0) or (buf != NULL and buf_size > 0)
+
+    list = List[uint16]{}  # used only if buf is NULL
+    index: intnative = 0  # used only if buf is not NULL
+
+    while True:
+        # Just like utf8_decode_char() but allows UTF-16 surrogates (0xD800 to 0xDFFF)
+        start_byte = *utf8_string++
+        codepoint: int
+
+        if start_byte & 0b1000_0000 == 0:  # 0xxx xxxx = plain old ASCII
+            num_bytes = 1
+            codepoint = start_byte
+        elif start_byte & 0b1110_0000 == 0b1100_0000:  # 110x xxxx = start of two-byte character
+            num_bytes = 2
+            codepoint = start_byte & 0b0001_1111
+        elif start_byte & 0b1111_0000 == 0b1110_0000:  # 1110 xxxx = start of 3-byte character
+            num_bytes = 3
+            codepoint = start_byte & 0b0000_1111
+        elif start_byte & 0b1111_1000 == 0b1111_0000:  # 1111 0xxx = start of 4-byte character
+            num_bytes = 4
+            codepoint = start_byte & 0b0000_0111
+        else:
+            num_bytes = 0
+            codepoint = -1  # invalid WTF-8: bad start byte
+
+        for i = 1; i < num_bytes; i++:
+            b = *utf8_string++
+            if not is_utf8_continuation(b):
+                # invalid WTF-8: bad continuation byte
+                codepoint = -1
+                break
+            codepoint <<= 6
+            codepoint |= b & 0b0011_1111  # get the 6 data bits from continuation byte
+
+        # Detect overlong encodings
+        #
+        # It is important to reject overlong encodings! Otherwise we have
+        # security problems, because there are multiple ways to represent
+        # the same string.
+        if codepoint != -1:
+            # See windows_to_utf8()
+            if codepoint <= 0x7f:
+                if num_bytes != 1:
+                    codepoint = -1  # invalid WTF-8: overlong encoding
+            elif codepoint <= 0x7ff:
+                if num_bytes != 2:
+                    codepoint = -1  # invalid WTF-8: overlong encoding
+            elif codepoint <= 0xffff:
+                if num_bytes != 3:
+                    codepoint = -1  # invalid WTF-8: overlong encoding
+            elif codepoint <= 0x10ffff:
+                if num_bytes != 4:
+                    codepoint = -1  # invalid WTF-8: overlong encoding
+            else:
+                # TODO: Make sure this case gets tested
+                codepoint = -1  # invalid WTF-8: codepoint is too big to be anything valid
+
+        if codepoint == -1:
+            # error
+            if buf == NULL:
+                free(list.ptr)
+            elif index < buf_size:
+                buf[index] = 0
+            else:
+                buf[buf_size - 1] = 0
+            return NULL
+
+        output: uint16[2]
+        if codepoint <= 0xffff:
+            output[0] = codepoint as uint16
+            output_len = 1
+        else:
+            # Split it into a surrogate pair
+            codepoint -= 0x10000  # UTF-16 is weird
+            output[0] = ((codepoint >> 10) | (0b110110 << 10)) as uint16
+            output[1] = ((codepoint & 0b11111_11111) | (0b110111 << 10)) as uint16
+            output_len = 2
+
+        if buf == NULL:
+            list.extend_from_ptr(output, output_len)
+        else:
+            for i = 0; i < output_len; i++:
+                if index == buf_size:
+                    # does not fit :(
+                    buf[buf_size - 1] = 0
+                    return NULL
+                buf[index++] = output[i]
+
+        if codepoint == 0:
+            # We successfully consumed zero byte from input and added it to output.
+            return list.ptr if buf == NULL else buf

--- a/tests/should_succeed/utf8_test.jou
+++ b/tests/should_succeed/utf8_test.jou
@@ -32,6 +32,8 @@ def test_successful_decode() -> None:
 
 
 def check_fail(s: byte*) -> None:
+    assert string_to_windows(s, NULL, 0) == NULL
+
     ptr = s
     printf("should fail --> %d\n", utf8_decode_char(&ptr))
     assert ptr == s
@@ -133,9 +135,18 @@ def test_surrogates() -> None:
     #           = 1101 111111 111111
     surrogate3: byte[3] = [0b1110_1101, 0b10_111111, 0b10_111111]
 
-    check_fail(surrogate1)  # Output: should fail --> -1
-    check_fail(surrogate2)  # Output: should fail --> -1
-    check_fail(surrogate3)  # Output: should fail --> -1
+    # We don't use check_fail() because it calls string_to_windows() which by
+    # design allows some bad surrogates.
+    ptr1 = &surrogate1[0]
+    ptr2 = &surrogate2[0]
+    ptr3 = &surrogate3[0]
+
+    # Output: surrogates -1 -1 -1
+    printf("surrogates %d %d %d\n", utf8_decode_char(&ptr1), utf8_decode_char(&ptr2), utf8_decode_char(&ptr3))
+
+    assert ptr1 == &surrogate1[0]
+    assert ptr2 == &surrogate2[0]
+    assert ptr3 == &surrogate3[0]
 
 
 def test_decoding_random_data() -> None:
@@ -192,15 +203,23 @@ def hexdump(ptr: byte*, len: int) -> None:
         putchar(ptr[i] if is_ascii_printable(ptr[i]) else '.')
     putchar('\n')
 
+def hexdump16(ptr: uint16*, len: int) -> None:
+    for i = 0; i < len; i++:
+        printf("%04x ", ptr[i])
+    putchar(' ')
+    for i = 0; i < len; i++:
+        putchar(ptr[i] if ptr[i] < 256 and is_ascii_printable(ptr[i] as byte) else '.')
+    putchar('\n')
 
-def test_windows_to_utf8_basic() -> None:
-    puts("windows_to_utf8")  # Output: windows_to_utf8
+
+def test_string_from_windows_basic() -> None:
+    puts("string_from_windows")  # Output: string_from_windows
 
     wstring: uint16[6] = ['h', 'e', 'l', 'l', 246, 0]
     out: byte[10]
 
     out = "jjjjjjjjj"
-    assert windows_to_utf8(wstring, out, sizeof(out)) == &out[0]
+    assert string_from_windows(wstring, out, sizeof(out)) == &out[0]
     puts(out)  # Output: hellö
     puts(&out[7])  # Output: jj
     # Here "c3 b6" is the ö character in UTF-8:
@@ -209,13 +228,13 @@ def test_windows_to_utf8_basic() -> None:
     # When buffer runs out, c3 part may be written without the b6 part.
     # Perhaps not ideal, but just like snprintf().
     out = "jjjjjjjjj"
-    assert windows_to_utf8(wstring, out, 6) == NULL
+    assert string_from_windows(wstring, out, 6) == NULL
     hexdump(out, sizeof(out))  # Output: 68 65 6c 6c c3 00 6a 6a 6a 00  hell..jjj.
 
     # Smiley 😀 (U+1F600)
     wide_smile: uint16[3] = [0xd83d, 0xde00, 0]
     out = "jjjjjjjjj"
-    assert windows_to_utf8(wide_smile, out, sizeof(out)) == &out[0]
+    assert string_from_windows(wide_smile, out, sizeof(out)) == &out[0]
     hexdump(out, sizeof(out))  # Output: f0 9f 98 80 00 6a 6a 6a 6a 00  .....jjjj.
     ptr = &out[0]
     printf("smiley = %d\n", utf8_decode_char(&ptr))  # Output: smiley = 128512
@@ -234,7 +253,7 @@ def test_windows_to_utf8_basic() -> None:
     #        = e    d    a    0    b    d
     #
     # Converting succeeds, but the result is not valid UTF-8.
-    assert windows_to_utf8(left_smile, out, sizeof(out)) == &out[0]
+    assert string_from_windows(left_smile, out, sizeof(out)) == &out[0]
     hexdump(out, sizeof(out))  # Output: ed a0 bd 00 6a 6a 6a 6a 6a 00  ....jjjjj.
     ptr = &out[0]
     printf("%d\n", utf8_decode_char(&ptr))  # Output: -1
@@ -242,27 +261,94 @@ def test_windows_to_utf8_basic() -> None:
     # Left and right smiley halves mixed in with text
     mixed_smile: uint16[9] = ['a', 'a', 0xd83d, 'b', 'b', 0xde00, 'c', 'c', 0]
     out = "jjjjjjjjj"
-    assert windows_to_utf8(mixed_smile, out, sizeof(out)) == NULL  # doesn't fit
+    assert string_from_windows(mixed_smile, out, sizeof(out)) == NULL  # doesn't fit
     hexdump(out, sizeof(out))  # Output: 61 61 ed a0 bd 62 62 ed b8 00  aa...bb...
     big_out: byte[15] = "jjjjjjjjjjjjjj"
-    assert windows_to_utf8(mixed_smile, big_out, sizeof(big_out)) == &big_out[0]
+    assert string_from_windows(mixed_smile, big_out, sizeof(big_out)) == &big_out[0]
     hexdump(big_out, sizeof(big_out))  # Output: 61 61 ed a0 bd 62 62 ed b8 80 63 63 00 6a 00  aa...bb...cc.j.
 
     # Dynamic memory allocating
-    s = windows_to_utf8(wstring, NULL, 0)
+    s = string_from_windows(wstring, NULL, 0)
     assert s != NULL
     puts(s)  # Output: hellö
     free(s)
 
-    s = windows_to_utf8(wide_smile, NULL, 0)
+    s = string_from_windows(wide_smile, NULL, 0)
     assert s != NULL
     printf("%zd\n", strlen(s))  # Output: 4
     free(s)
 
-    s = windows_to_utf8(left_smile, NULL, 0)
+    s = string_from_windows(left_smile, NULL, 0)
     assert s != NULL
     printf("%zd\n", strlen(s))  # Output: 3
     free(s)
+
+
+def test_string_to_windows_basic() -> None:
+    puts("string_to_windows")  # Output: string_to_windows
+
+    # We don't need to test a lot here because:
+    #   - existing tests call string_to_windows() with invalid inputs
+    #   - round-trip test below call string_to_windows() with valid inputs
+    #
+    # The only thing we really need to test is truncating when the output
+    # doesn't fit.
+
+    out: uint16[10]
+
+    memset(out, 0xab, sizeof(out))
+    assert string_to_windows("hello", out, sizeof(out)) != NULL
+    hexdump16(out, 10)  # Output: 0068 0065 006c 006c 006f 0000 abab abab abab abab  hello.....
+
+    memset(out, 0xab, sizeof(out))
+    assert string_to_windows("hello wor", out, sizeof(out)) != NULL
+    hexdump16(out, 10)  # Output: 0068 0065 006c 006c 006f 0020 0077 006f 0072 0000  hello wor.
+
+    memset(out, 0xab, sizeof(out))
+    assert string_to_windows("hello worl", out, sizeof(out)) == NULL
+    hexdump16(out, 10)  # Output: 0068 0065 006c 006c 006f 0020 0077 006f 0072 0000  hello wor.
+
+    memset(out, 0xab, sizeof(out))
+    assert string_to_windows("hello 😀 😀", out, sizeof(out)) == NULL
+    hexdump16(out, 10)  # Output: 0068 0065 006c 006c 006f 0020 d83d de00 0020 0000  hello .. .
+
+    memset(out, 0xab, sizeof(out))
+    assert string_to_windows("hello 😀😀", out, sizeof(out)) == NULL
+    # First half of smiley makes it to the output, second half does not
+    hexdump16(out, 10)  # Output: 0068 0065 006c 006c 006f 0020 d83d de00 d83d 0000  hello ....
+
+
+def test_windows_string_roundtrip() -> None:
+    # Check many random strings
+    repeat = 10000
+    while repeat --> 0:
+        windows_len = rand() % 10
+
+        w1: uint16[11]
+        memset(w1, 0, sizeof(w1))
+        for i = 0; i < windows_len; i++:
+            while w1[i] == 0:
+                w1[i] = rand() as uint16
+
+        s1 = string_from_windows(w1, NULL, 0)
+        assert s1 != NULL
+        assert strlen(s1) <= 4*windows_len
+
+        s2: byte[41]
+        assert string_from_windows(w1, s2, sizeof(s2)) == &s2[0]
+        assert strcmp(s1, s2) == 0
+
+        w2 = string_to_windows(s1, NULL, 0)
+        w3: uint16[11]
+        assert string_to_windows(s1, w3, sizeof(w3)) != NULL
+
+        assert memcmp(w1, w2, 2*(windows_len + 1)) == 0
+        assert memcmp(w1, w3, 2*(windows_len + 1)) == 0
+
+        free(s1)
+        free(w2)
+
+    puts("ok")  # Output: ok
 
 
 def main() -> int:
@@ -276,5 +362,7 @@ def main() -> int:
     test_surrogates()
     test_decoding_random_data()
     test_encode_char()
-    test_windows_to_utf8_basic()
+    test_string_from_windows_basic()
+    test_string_to_windows_basic()
+    test_windows_string_roundtrip()
     return 0

--- a/tests/should_succeed/utf8_test.jou
+++ b/tests/should_succeed/utf8_test.jou
@@ -1,4 +1,6 @@
 import "stdlib/assert.jou"
+import "stdlib/mem.jou"
+import "stdlib/ascii.jou"
 import "stdlib/io.jou"
 import "stdlib/random.jou"
 import "stdlib/str.jou"
@@ -182,6 +184,87 @@ def test_encode_char() -> None:
     printf("%d,%d,%d,%d,%d\n", s[0], s[1], s[2], s[3], s[4])  # Output: 0,0,0,0,0
 
 
+def hexdump(ptr: byte*, len: int) -> None:
+    for i = 0; i < len; i++:
+        printf("%02x ", ptr[i])
+    putchar(' ')
+    for i = 0; i < len; i++:
+        putchar(ptr[i] if is_ascii_printable(ptr[i]) else '.')
+    putchar('\n')
+
+
+def test_windows_to_utf8_basic() -> None:
+    puts("windows_to_utf8")  # Output: windows_to_utf8
+
+    wstring: uint16[6] = ['h', 'e', 'l', 'l', 246, 0]
+    out: byte[10]
+
+    out = "jjjjjjjjj"
+    assert windows_to_utf8(wstring, out, sizeof(out)) == &out[0]
+    puts(out)  # Output: hellö
+    puts(&out[7])  # Output: jj
+    # Here "c3 b6" is the ö character in UTF-8:
+    hexdump(out, sizeof(out))  # Output: 68 65 6c 6c c3 b6 00 6a 6a 00  hell...jj.
+
+    # When buffer runs out, c3 part may be written without the b6 part.
+    # Perhaps not ideal, but just like snprintf().
+    out = "jjjjjjjjj"
+    assert windows_to_utf8(wstring, out, 6) == NULL
+    hexdump(out, sizeof(out))  # Output: 68 65 6c 6c c3 00 6a 6a 6a 00  hell..jjj.
+
+    # Smiley 😀 (U+1F600)
+    wide_smile: uint16[3] = [0xd83d, 0xde00, 0]
+    out = "jjjjjjjjj"
+    assert windows_to_utf8(wide_smile, out, sizeof(out)) == &out[0]
+    hexdump(out, sizeof(out))  # Output: f0 9f 98 80 00 6a 6a 6a 6a 00  .....jjjj.
+    ptr = &out[0]
+    printf("smiley = %d\n", utf8_decode_char(&ptr))  # Output: smiley = 128512
+
+    # Left half of smiley
+    left_smile: uint16[2] = [0xd83d, 0]
+    out = "jjjjjjjjj"
+    # 0xd83d = 1101 1000 0011 1101
+    #        = 1101 100000 111101
+    #          ^^^^ ^^^^^^ ^^^^^^
+    #
+    # In WTF-8 this becomes:
+    #          11101101 10100000 10111101
+    #              ^^^^   ^^^^^^   ^^^^^^
+    #        = 1110 1101 1010 0000 1011 1101
+    #        = e    d    a    0    b    d
+    #
+    # Converting succeeds, but the result is not valid UTF-8.
+    assert windows_to_utf8(left_smile, out, sizeof(out)) == &out[0]
+    hexdump(out, sizeof(out))  # Output: ed a0 bd 00 6a 6a 6a 6a 6a 00  ....jjjjj.
+    ptr = &out[0]
+    printf("%d\n", utf8_decode_char(&ptr))  # Output: -1
+
+    # Left and right smiley halves mixed in with text
+    mixed_smile: uint16[9] = ['a', 'a', 0xd83d, 'b', 'b', 0xde00, 'c', 'c', 0]
+    out = "jjjjjjjjj"
+    assert windows_to_utf8(mixed_smile, out, sizeof(out)) == NULL  # doesn't fit
+    hexdump(out, sizeof(out))  # Output: 61 61 ed a0 bd 62 62 ed b8 00  aa...bb...
+    big_out: byte[15] = "jjjjjjjjjjjjjj"
+    assert windows_to_utf8(mixed_smile, big_out, sizeof(big_out)) == &big_out[0]
+    hexdump(big_out, sizeof(big_out))  # Output: 61 61 ed a0 bd 62 62 ed b8 80 63 63 00 6a 00  aa...bb...cc.j.
+
+    # Dynamic memory allocating
+    s = windows_to_utf8(wstring, NULL, 0)
+    assert s != NULL
+    puts(s)  # Output: hellö
+    free(s)
+
+    s = windows_to_utf8(wide_smile, NULL, 0)
+    assert s != NULL
+    printf("%zd\n", strlen(s))  # Output: 4
+    free(s)
+
+    s = windows_to_utf8(left_smile, NULL, 0)
+    assert s != NULL
+    printf("%zd\n", strlen(s))  # Output: 3
+    free(s)
+
+
 def main() -> int:
     test_char_count()
     test_successful_decode()
@@ -193,4 +276,5 @@ def main() -> int:
     test_surrogates()
     test_decoding_random_data()
     test_encode_char()
+    test_windows_to_utf8_basic()
     return 0


### PR DESCRIPTION
In Windows, there are two variants of each function that deals with strings:
- `SomeFunctionNameA()`: ASCII + some other characters depending on computer's language
- `SomeFunctionNameW()`: UTF-16, or sometimes invalid UTF-16

So you have two choices, and neither of them is UTF-8, which is what Jou and basically every modern and sane system uses.

So far Jou has been using the `A` functions, which is bad. For example, if there's a file with a funny name, you cannot open it with `fopen()` in Jou, and it shows up with the wrong name if you list the contents of the directory with Jou.

To fix all that, this PR adds two new functions to stdlib/utf8.jou, ~~and changes the rest of stdlib to use them internally:~~
- `string_from_windows(windows_string: uint16*, buf: byte*, buf_size: intnative) -> byte*`
- `string_to_windows(utf8_string: byte*, buf: uint16*, buf_size: intnative) -> uint16*`

These functions allow us to feed 16-bit strings to the `W` functions. They use [WTF-8](https://wtf-8.codeberg.page/#the-wtf-8-encoding) (Wobbly Transformation Format) to handle invalid UTF-16, which can occur in file names and such.

This PR doesn't use the new functions anywhere yet. I will update existing things to use them in separate PRs.