### PR TITLE
Add `is_ascii_string()` function to stdlib/ascii.jou

### DIFF
--- a/stdlib/ascii.jou
+++ b/stdlib/ascii.jou
@@ -2,6 +2,14 @@ import "stdlib/str.jou"
 import "stdlib/mem.jou"
 import "stdlib/list.jou"
 
+# Test if a string is ASCII only.
+@public
+def is_ascii(s: byte*) -> bool:
+    for p = s; *p != '\0'; p++:
+        if *p >= 128:
+            return False
+    return True
+
 # Check for '0', '1', ..., '9'.
 @public
 def is_ascii_digit(b: byte) -> bool:

--- a/stdlib/ascii.jou
+++ b/stdlib/ascii.jou
@@ -4,7 +4,7 @@ import "stdlib/list.jou"
 
 # Test if a string is ASCII only.
 @public
-def is_ascii(s: byte*) -> bool:
+def is_ascii_string(s: byte*) -> bool:
     for p = s; *p != '\0'; p++:
         if *p >= 128:
             return False

--- a/tests/should_succeed/ascii_test.jou
+++ b/tests/should_succeed/ascii_test.jou
@@ -6,6 +6,11 @@ import "stdlib/str.jou"
 import "stdlib/list.jou"
 
 def main() -> int:
+    assert is_ascii("hello")
+    assert is_ascii("hello world test!!! @$!")
+    assert is_ascii("")
+    assert not is_ascii("örkkimörkki")
+
     assert is_ascii_digit('0')
     assert is_ascii_digit('7')
     assert is_ascii_digit('9')

--- a/tests/should_succeed/ascii_test.jou
+++ b/tests/should_succeed/ascii_test.jou
@@ -6,10 +6,10 @@ import "stdlib/str.jou"
 import "stdlib/list.jou"
 
 def main() -> int:
-    assert is_ascii("hello")
-    assert is_ascii("hello world test!!! @$!")
-    assert is_ascii("")
-    assert not is_ascii("örkkimörkki")
+    assert is_ascii_string("hello")
+    assert is_ascii_string("hello world test!!! @$!")
+    assert is_ascii_string("")
+    assert not is_ascii_string("örkkimörkki")
 
     assert is_ascii_digit('0')
     assert is_ascii_digit('7')


### PR DESCRIPTION
Reverts Akuli/jou#1268 and changes function name

I now have a use case for the `is_ascii_string()` function. In Windows API, there are two versions of many functions:
- `SomeFunctionA()` works with ASCII strings (and some other characters, but not anything nice like UTF-8)
- `SomeFunctionW()` works with all characters but expects input in a funny format that needs converting.

For ASCII strings, it's possible to avoid the conversion, which could be slightly faster, or at least simpler to debug and understand.