### PR TITLE
Add more special error messages for Windows C API types

### DIFF
--- a/compiler/typecheck/common.jou
+++ b/compiler/typecheck/common.jou
@@ -63,12 +63,18 @@ def fail_with_type_not_found(location: Location, name: byte*) -> noreturn:
             suggest = "int64"
         case "u8" | "uint8_t" | "char":
             suggest = "byte"
-        case "u16" | "uint16_t":
+        case "u16" | "uint16_t" | "WCHAR":
             suggest = "uint16"
         case "u32" | "uint32_t" | "uint" | "DWORD":
             suggest = "uint32"
         case "u64" | "uint64_t":
             suggest = "uint64"
+        case "LPSTR" | "LPCSTR":
+            suggest = "byte*"
+        case "LPWSTR" | "LPCWSTR":
+            suggest = "uint16*"
+        case "LPVOID" | "LPCVOID":
+            suggest = "void*"
         case _:
             suggest = NULL
 


### PR DESCRIPTION
Example:

```python
def main() -> int:
    s: LPSTR = "hello"
    return 0
```

Before: `compiler error in file "a.jou", line 2: there is no type named 'LPSTR'`

After: `compiler error in file "a.jou", line 2: there is no type named 'LPSTR', use 'byte*' instead`

This PR adds:
- `WCHAR` (compiler suggests `uint16`)
- `LPSTR` and `LPCSTR` (compiler suggests `byte*`)
- `LPWSTR` and `LPCWSTR` (compiler suggests `uint16*`)
- `LPVOID` and `LPCVOID` (compiler suggests `void*`)

I will add more similar types as I do more Windows programming. These are the ones I ran into today.